### PR TITLE
Document Julia 1.12 threading bug and extend CI to Julia 1.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
       matrix:
         version:
           - '1.11'
-          - '1.12'
         os:
           - ubuntu-latest
 
@@ -34,40 +33,20 @@ jobs:
       - uses: julia-actions/cache@v2
 
       - name: Install dependencies
-        run: |
-          # For non-1.12, delete manifest to force fresh resolution
-          if [ "${{ matrix.version }}" != "1.12" ]; then
-            rm -f Manifest.toml
-            # Develop local packages first, then update to generate fresh manifest
-            julia --project=. -e '
-              using Pkg
-              Pkg.develop([
-                PackageSpec(path="Lexers.jl"),
-                PackageSpec(path="SpectreNetlistParser.jl"),
-                PackageSpec(path="VerilogAParser.jl")
-              ])
-              Pkg.update()
-            '
-          else
-            julia --project=. -e 'using Pkg; Pkg.instantiate()'
-          fi
+        run: julia --project=. -e 'using Pkg; Pkg.instantiate()'
 
       - name: Run SpectreNetlistParser tests
         run: |
-          # Lexers.jl is a local dependency not in registry
           julia --project=SpectreNetlistParser.jl -e '
             using Pkg
-            Pkg.develop(PackageSpec(path="Lexers.jl"))
             Pkg.instantiate()
             Pkg.test()
           '
 
       - name: Run VerilogAParser tests
         run: |
-          # Lexers.jl is a local dependency not in registry
           julia --project=VerilogAParser.jl -e '
             using Pkg
-            Pkg.develop(PackageSpec(path="Lexers.jl"))
             Pkg.instantiate()
             Pkg.test()
           '
@@ -76,7 +55,6 @@ jobs:
         run: |
           julia --project=test -e '
             using Pkg
-            # Develop the main package and subpackages in test environment
             Pkg.develop([
               PackageSpec(path="."),
               PackageSpec(path="SpectreNetlistParser.jl"),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,16 @@ jobs:
           # For non-1.12, delete manifest to force fresh resolution
           if [ "${{ matrix.version }}" != "1.12" ]; then
             rm -f Manifest.toml
-            # Use Pkg.update() to generate fresh manifest from Project.toml
-            julia --project=. -e 'using Pkg; Pkg.update()'
+            # Develop local packages first, then update to generate fresh manifest
+            julia --project=. -e '
+              using Pkg
+              Pkg.develop([
+                PackageSpec(path="Lexers.jl"),
+                PackageSpec(path="SpectreNetlistParser.jl"),
+                PackageSpec(path="VerilogAParser.jl")
+              ])
+              Pkg.update()
+            '
           else
             julia --project=. -e 'using Pkg; Pkg.instantiate()'
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.11'
           - '1.12'
         os:
           - ubuntu-latest
@@ -36,6 +37,8 @@ jobs:
         run: |
           julia --project=. -e '
             using Pkg
+            # Resolve to regenerate manifest for this Julia version
+            Pkg.resolve()
             Pkg.instantiate()
           '
 
@@ -43,6 +46,7 @@ jobs:
         run: |
           julia --project=SpectreNetlistParser.jl -e '
             using Pkg
+            Pkg.resolve()
             Pkg.instantiate()
             Pkg.test()
           '
@@ -51,6 +55,7 @@ jobs:
         run: |
           julia --project=VerilogAParser.jl -e '
             using Pkg
+            Pkg.resolve()
             Pkg.instantiate()
             Pkg.test()
           '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,12 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # For non-1.12, delete manifest to force fresh resolution
+          if [ "${{ matrix.version }}" != "1.12" ]; then
+            rm -f Manifest.toml
+          fi
           julia --project=. -e '
             using Pkg
-            # Resolve to regenerate manifest for this Julia version
             Pkg.resolve()
             Pkg.instantiate()
           '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,18 +38,16 @@ jobs:
           # For non-1.12, delete manifest to force fresh resolution
           if [ "${{ matrix.version }}" != "1.12" ]; then
             rm -f Manifest.toml
+            # Use Pkg.update() to generate fresh manifest from Project.toml
+            julia --project=. -e 'using Pkg; Pkg.update()'
+          else
+            julia --project=. -e 'using Pkg; Pkg.instantiate()'
           fi
-          julia --project=. -e '
-            using Pkg
-            Pkg.resolve()
-            Pkg.instantiate()
-          '
 
       - name: Run SpectreNetlistParser tests
         run: |
           julia --project=SpectreNetlistParser.jl -e '
             using Pkg
-            Pkg.resolve()
             Pkg.instantiate()
             Pkg.test()
           '
@@ -58,7 +56,6 @@ jobs:
         run: |
           julia --project=VerilogAParser.jl -e '
             using Pkg
-            Pkg.resolve()
             Pkg.instantiate()
             Pkg.test()
           '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,16 +54,20 @@ jobs:
 
       - name: Run SpectreNetlistParser tests
         run: |
+          # Lexers.jl is a local dependency not in registry
           julia --project=SpectreNetlistParser.jl -e '
             using Pkg
+            Pkg.develop(PackageSpec(path="Lexers.jl"))
             Pkg.instantiate()
             Pkg.test()
           '
 
       - name: Run VerilogAParser tests
         run: |
+          # Lexers.jl is a local dependency not in registry
           julia --project=VerilogAParser.jl -e '
             using Pkg
+            Pkg.develop(PackageSpec(path="Lexers.jl"))
             Pkg.instantiate()
             Pkg.test()
           '

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,28 +5,11 @@
 - **Julia is NOT pre-installed** - install juliaup first:
   - Run: `curl -fsSL https://install.julialang.org | sh -s -- -y`
   - Then source the profile: `. ~/.bashrc`
+  - Set Julia 1.11 as default: `~/.juliaup/bin/juliaup default 1.11`
   - Use `~/.juliaup/bin/julia` to run Julia
-- **Use Julia 1.12** (default from juliaup) - this is what CI uses
+- **Use Julia 1.11** - this is what CI uses and what the Manifest.toml is locked to
+  - Julia 1.12 has threading bugs that cause segfaults during artifact downloads
   - Don't add compatibility hacks for older Julia versions
-
-### Critical: Julia 1.12 Threading Bug
-
-**Julia 1.12 segfaults during multi-threaded artifact downloads.** This affects `Pkg.instantiate()` and similar operations. Always use single-threaded mode:
-
-```bash
-# For package operations (instantiate, precompile, test)
-JULIA_NUM_THREADS=1 ~/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.instantiate()'
-
-# Or set for entire session
-export JULIA_NUM_THREADS=1
-~/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test(test_args=["mna"])'
-```
-
-The segfault occurs in `ijl_task_get_next` during concurrent artifact downloads. CI works because GitHub Actions handles threading differently.
-
-### Enzyme.jl on Julia 1.12
-
-Enzyme.jl has limited support for Julia 1.12 and warns that it recommends Julia 1.11 or 1.10. However, the MNA backend does not require Enzyme - MNA tests pass without it. You can safely ignore Enzyme precompilation warnings when working on MNA functionality.
 
 ## Development Guidelines
 
@@ -58,18 +41,16 @@ Read these files in `doc/` for detailed design information:
 
 ## Testing
 
-Run MNA tests directly (use single-threaded mode to avoid segfaults):
+Run MNA tests directly:
 ```bash
-JULIA_NUM_THREADS=1 ~/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test(test_args=["mna"])'
+~/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test(test_args=["mna"])'
 ```
 
 Or run specific test files directly:
 ```bash
-JULIA_NUM_THREADS=1 ~/.juliaup/bin/julia --project=. test/mna/core.jl
-JULIA_NUM_THREADS=1 ~/.juliaup/bin/julia --project=. test/sweep.jl
+~/.juliaup/bin/julia --project=. test/mna/core.jl
+~/.juliaup/bin/julia --project=. test/sweep.jl
 ```
-
-**Note:** Setting `JULIA_NUM_THREADS=1` is required to prevent segfaults during Julia 1.12 package operations. Once packages are precompiled, you can run actual tests with multiple threads if needed.
 
 ## Gotchas and Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,27 @@
   - Run: `curl -fsSL https://install.julialang.org | sh -s -- -y`
   - Then source the profile: `. ~/.bashrc`
   - Use `~/.juliaup/bin/julia` to run Julia
-  - Example: `~/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test()'`
 - **Use Julia 1.12** (default from juliaup) - this is what CI uses
   - Don't add compatibility hacks for older Julia versions
+
+### Critical: Julia 1.12 Threading Bug
+
+**Julia 1.12 segfaults during multi-threaded artifact downloads.** This affects `Pkg.instantiate()` and similar operations. Always use single-threaded mode:
+
+```bash
+# For package operations (instantiate, precompile, test)
+JULIA_NUM_THREADS=1 ~/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.instantiate()'
+
+# Or set for entire session
+export JULIA_NUM_THREADS=1
+~/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test(test_args=["mna"])'
+```
+
+The segfault occurs in `ijl_task_get_next` during concurrent artifact downloads. CI works because GitHub Actions handles threading differently.
+
+### Enzyme.jl on Julia 1.12
+
+Enzyme.jl has limited support for Julia 1.12 and warns that it recommends Julia 1.11 or 1.10. However, the MNA backend does not require Enzyme - MNA tests pass without it. You can safely ignore Enzyme precompilation warnings when working on MNA functionality.
 
 ## Development Guidelines
 
@@ -40,16 +58,18 @@ Read these files in `doc/` for detailed design information:
 
 ## Testing
 
-Run MNA tests directly to avoid Enzyme precompilation issues:
+Run MNA tests directly (use single-threaded mode to avoid segfaults):
 ```bash
-~/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test(test_args=["mna"])'
+JULIA_NUM_THREADS=1 ~/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test(test_args=["mna"])'
 ```
 
-Or run specific test files:
+Or run specific test files directly:
 ```bash
-~/.juliaup/bin/julia --project=. test/mna/core.jl
-~/.juliaup/bin/julia --project=. test/sweep.jl
+JULIA_NUM_THREADS=1 ~/.juliaup/bin/julia --project=. test/mna/core.jl
+JULIA_NUM_THREADS=1 ~/.juliaup/bin/julia --project=. test/sweep.jl
 ```
+
+**Note:** Setting `JULIA_NUM_THREADS=1` is required to prevent segfaults during Julia 1.12 package operations. Once packages are precompiled, you can run actual tests with multiple threads if needed.
 
 ## Gotchas and Patterns
 

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.12.3"
+julia_version = "1.11.8"
 manifest_format = "2.0"
-project_hash = "cc7eaf8e2e526b80ed9218a2a790c5f0b389c6d4"
+project_hash = "9b23cf0ddf8fee78cf9d0ef9bcd25bf375e3d75d"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "8b2b045b22740e4be20654175cc38291d48539db"
@@ -15,31 +15,31 @@ weakdeps = ["ChainRulesCore", "ConstructionBase", "EnzymeCore"]
     ADTypesConstructionBaseExt = "ConstructionBase"
     ADTypesEnzymeCoreExt = "EnzymeCore"
 
-[[deps.ANSIColoredPrinters]]
-git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
-uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
-version = "0.0.1"
-
 [[deps.AbstractAlgebra]]
 deps = ["LinearAlgebra", "MacroTools", "Preferences", "Random", "RandomExtensions", "SparseArrays"]
 git-tree-sha1 = "399e7d3181001ef0c2ac11cd5101c36dcd6840d9"
 uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
 version = "0.47.6"
-weakdeps = ["Test"]
 
     [deps.AbstractAlgebra.extensions]
     TestExt = "Test"
+
+    [deps.AbstractAlgebra.weakdeps]
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]
 git-tree-sha1 = "d92ad398961a3ed262d8bf04a1a2b8340f915fef"
 uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 version = "1.5.0"
-weakdeps = ["ChainRulesCore", "Test"]
 
     [deps.AbstractFFTs.extensions]
     AbstractFFTsChainRulesCoreExt = "ChainRulesCore"
     AbstractFFTsTestExt = "Test"
+
+    [deps.AbstractFFTs.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[deps.AbstractTrees]]
 git-tree-sha1 = "2d9c9a55f9c93e8887ad391fbae72f8ef55e1177"
@@ -227,9 +227,9 @@ version = "0.1.6"
 
 [[deps.BracketingNonlinearSolve]]
 deps = ["CommonSolve", "ConcreteStructs", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase"]
-git-tree-sha1 = "03100f03a58e14c60ba0a465e6f1ac9450eb495c"
+git-tree-sha1 = "96ee7f4f14b56ae718664af4ba665d83868a942b"
 uuid = "70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
-version = "1.6.0"
+version = "1.6.1"
 weakdeps = ["ChainRulesCore", "ForwardDiff"]
 
     [deps.BracketingNonlinearSolve.extensions]
@@ -263,26 +263,6 @@ git-tree-sha1 = "7210fceb9d617b1d5bb0fca6d5cf9f5f58a682f8"
 uuid = "d78b62d4-37fa-4a6f-acd8-2f19986eb9ee"
 version = "0.2.5"
 
-[[deps.CedarSim]]
-deps = ["ADTypes", "AbstractAlgebra", "AbstractTrees", "Accessors", "AxisKeys", "CassetteOverlay", "ChainRules", "ChainRulesCore", "Combinatorics", "Compat", "DecFP", "DescriptorSystems", "DiffEqBase", "DiffEqCallbacks", "Distributions", "DynamicScope", "ExprTools", "ForwardDiff", "Lexers", "LinearAlgebra", "LinearSolve", "Logging", "NLsolve", "NaNMath", "NonlinearSolve", "OrderedCollections", "OrdinaryDiffEq", "PrecompileTools", "Printf", "Random", "SciMLBase", "SciMLNLSolve", "SciMLSensitivity", "Scratch", "SparseArrays", "SpectreNetlistParser", "StateSelection", "StaticArrays", "StructArrays", "Sundials", "SymbolicIndexingInterface", "VT100", "VectorPrisms", "VerilogAParser"]
-path = "."
-uuid = "9075980a-f0c7-46d2-945a-cc5bead5ad4a"
-version = "0.12.0"
-
-    [deps.CedarSim.extensions]
-    CedarSimCSVExt = "CSV"
-    CedarSimMakieExt = "Makie"
-    CedarSimModelingToolkitExt = "ModelingToolkit"
-    CedarSimPlotlyLightExt = "PlotlyLight"
-    CedarSimReviseExt = "Revise"
-
-    [deps.CedarSim.weakdeps]
-    CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
-    Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
-    ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
-    PlotlyLight = "ca7969ec-10b3-423e-8d99-40f33abb42bf"
-    Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
-
 [[deps.ChainRules]]
 deps = ["Adapt", "ChainRulesCore", "Compat", "Distributed", "GPUArraysCore", "IrrationalConstants", "LinearAlgebra", "Random", "RealDot", "SparseArrays", "SparseInverseSubset", "Statistics", "StructArrays", "SuiteSparse"]
 git-tree-sha1 = "3b704353e517a957323bd3ac70fa7b669b5f48d4"
@@ -304,12 +284,6 @@ deps = ["Static", "StaticArrayInterface"]
 git-tree-sha1 = "05ba0d07cd4fd8b7a39541e31a7b0254704ea581"
 uuid = "fb6a15b2-703c-40df-9091-08a04967cfa9"
 version = "0.1.13"
-
-[[deps.CodecZlib]]
-deps = ["TranscodingStreams", "Zlib_jll"]
-git-tree-sha1 = "962834c22b66e32aa10f7611c08c8ca4e20749a9"
-uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.7.8"
 
 [[deps.ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
@@ -351,7 +325,7 @@ weakdeps = ["Dates", "LinearAlgebra"]
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.3.0+1"
+version = "1.1.1+0"
 
 [[deps.CompositionsBase]]
 git-tree-sha1 = "802bb88cd69dfd1509f6670416bd4434015693ad"
@@ -416,11 +390,6 @@ deps = ["Artifacts", "JLLWrappers", "Libdl"]
 git-tree-sha1 = "40e4404a0a267a8e75f5c1ce2cc9b5e2ce1ba268"
 uuid = "47200ebd-12ce-5be5-abb7-8e082af23329"
 version = "2.0.300+0"
-
-[[deps.DeepDiffs]]
-git-tree-sha1 = "9824894295b62a6a4ab6adf1c7bf337b3a9ca34c"
-uuid = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
-version = "1.2.0"
 
 [[deps.DescriptorSystems]]
 deps = ["BandedMatrices", "LinearAlgebra", "MatrixEquations", "MatrixPencils", "Polynomials", "Random", "SparseArrays"]
@@ -586,16 +555,10 @@ git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.9.5"
 
-[[deps.Documenter]]
-deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
-git-tree-sha1 = "b37458ae37d8bdb643d763451585cd8d0e5b4a9e"
-uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.16.1"
-
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-version = "1.7.0"
+version = "1.6.0"
 
 [[deps.DynamicScope]]
 git-tree-sha1 = "d4da8945fe89521c905b934ec24bb52e8e5ef3e7"
@@ -644,12 +607,6 @@ deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
 git-tree-sha1 = "b4243939041dcffdae0b80623575daad2a282050"
 uuid = "7cc45869-7501-5eee-bdea-0790c847d4ef"
 version = "0.0.230+0"
-
-[[deps.Expat_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "27af30de8b5445644e8ffe3bcb0d72049c089cf1"
-uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.7.3+0"
 
 [[deps.ExponentialUtilities]]
 deps = ["Adapt", "ArrayInterface", "GPUArraysCore", "GenericSchur", "LinearAlgebra", "PrecompileTools", "Printf", "SparseArrays", "libblastrampoline_jll"]
@@ -812,24 +769,6 @@ git-tree-sha1 = "a694e2a57394e409f7a11ee0977362a9fafcb8c7"
 uuid = "c145ed77-6b09-5dd9-b285-bf645a82121e"
 version = "0.5.6"
 
-[[deps.Git]]
-deps = ["Git_LFS_jll", "Git_jll", "JLLWrappers", "OpenSSH_jll"]
-git-tree-sha1 = "824a1890086880696fc908fe12a17bcf61738bd8"
-uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
-version = "1.5.0"
-
-[[deps.Git_LFS_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "bb8471f313ed941f299aa53d32a94ab3bee08844"
-uuid = "020c3dae-16b3-5ae5-87b3-4cb189e250b2"
-version = "3.7.0+0"
-
-[[deps.Git_jll]]
-deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
-git-tree-sha1 = "46bd50c245fe49ed87377c014a928a549b9ef7ed"
-uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
-version = "2.52.0+0"
-
 [[deps.Graphs]]
 deps = ["ArnoldiMethod", "DataStructures", "Inflate", "LinearAlgebra", "Random", "SimpleTraits", "SparseArrays", "Statistics"]
 git-tree-sha1 = "d80e8b7220b884117938b2d219487eea06f9e42e"
@@ -853,12 +792,6 @@ deps = ["LinearAlgebra", "OpenLibm_jll", "SpecialFunctions"]
 git-tree-sha1 = "68c173f4f449de5b438ee67ed0c9c748dc31a2ec"
 uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
 version = "0.3.28"
-
-[[deps.IOCapture]]
-deps = ["Logging", "Random"]
-git-tree-sha1 = "0ee181ec08df7d7c911901ea38baf16f755114dc"
-uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
-version = "1.0.0"
 
 [[deps.IRTools]]
 deps = ["InteractiveUtils", "MacroTools"]
@@ -902,11 +835,14 @@ weakdeps = ["Random", "RecipesBase", "Statistics"]
 git-tree-sha1 = "a779299d77cd080bf77b97535acecd73e1c5e5cb"
 uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
 version = "0.1.17"
-weakdeps = ["Dates", "Test"]
 
     [deps.InverseFunctions.extensions]
     InverseFunctionsDatesExt = "Dates"
     InverseFunctionsTestExt = "Test"
+
+    [deps.InverseFunctions.weakdeps]
+    Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[deps.IrrationalConstants]]
 git-tree-sha1 = "b2d91fe939cae05960e760110b328288867b5758"
@@ -924,28 +860,11 @@ git-tree-sha1 = "0533e564aae234aff59ab625543145446d8b6ec2"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.7.1"
 
-[[deps.JSON]]
-deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
-git-tree-sha1 = "5b6bb73f555bc753a6153deec3717b8904f5551c"
-uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "1.3.0"
-
-    [deps.JSON.extensions]
-    JSONArrowExt = ["ArrowTypes"]
-
-    [deps.JSON.weakdeps]
-    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
-
 [[deps.Jieko]]
 deps = ["ExproniconLite"]
 git-tree-sha1 = "2f05ed29618da60c06a87e9c033982d4f71d0b6c"
 uuid = "ae98c720-c025-4a4a-838c-29b094483192"
 version = "0.2.1"
-
-[[deps.JuliaSyntaxHighlighting]]
-deps = ["StyledStrings"]
-uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
-version = "1.12.0"
 
 [[deps.KernelAbstractions]]
 deps = ["Adapt", "Atomix", "InteractiveUtils", "MacroTools", "PrecompileTools", "Requires", "StaticArrays", "UUIDs"]
@@ -989,11 +908,6 @@ git-tree-sha1 = "a9eaadb366f5493a5654e843864c13d8b107548c"
 uuid = "10f19ff3-798f-405d-979b-55457f8fc047"
 version = "0.1.17"
 
-[[deps.LazilyInitializedFields]]
-git-tree-sha1 = "0f2da712350b020bc3957f269c9caad516383ee0"
-uuid = "0e77f7df-68c5-4e49-93ce-4cd80f5598bf"
-version = "1.3.0"
-
 [[deps.LazyArrays]]
 deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra", "MacroTools", "SparseArrays"]
 git-tree-sha1 = "70ebe3bcf87d6a1e7435ef5182c13a91161ba9b8"
@@ -1028,24 +942,24 @@ uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 version = "0.6.4"
 
 [[deps.LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.15.0+0"
+version = "8.6.0+0"
 
 [[deps.LibGit2]]
-deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 version = "1.11.0"
 
 [[deps.LibGit2_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.9.0+0"
+version = "1.7.2+0"
 
 [[deps.LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.11.3+1"
+version = "1.11.0+1"
 
 [[deps.LibTracyClient_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1056,12 +970,6 @@ version = "0.9.1+6"
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 version = "1.11.0"
-
-[[deps.Libiconv_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
-uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.18.0+0"
 
 [[deps.LineSearch]]
 deps = ["ADTypes", "CommonSolve", "ConcreteStructs", "FastClosures", "LinearAlgebra", "MaybeInplace", "SciMLBase", "SciMLJacobianOperators", "StaticArraysCore"]
@@ -1082,7 +990,7 @@ version = "7.5.1"
 [[deps.LinearAlgebra]]
 deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-version = "1.12.0"
+version = "1.11.0"
 
 [[deps.LinearMaps]]
 deps = ["LinearAlgebra"]
@@ -1194,15 +1102,9 @@ uuid = "d125e4d3-2237-4719-b19c-fa641b8a4667"
 version = "0.1.8"
 
 [[deps.Markdown]]
-deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
+deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 version = "1.11.0"
-
-[[deps.MarkdownAST]]
-deps = ["AbstractTrees", "Markdown"]
-git-tree-sha1 = "465a70f0fc7d443a00dcdc3267a497397b8a3899"
-uuid = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
-version = "0.1.2"
 
 [[deps.MatrixEquations]]
 deps = ["LinearAlgebra", "LinearMaps"]
@@ -1226,6 +1128,11 @@ weakdeps = ["SparseArrays"]
     [deps.MaybeInplace.extensions]
     MaybeInplaceSparseArraysExt = "SparseArrays"
 
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.6+0"
+
 [[deps.Missings]]
 deps = ["DataAPI"]
 git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
@@ -1240,7 +1147,7 @@ version = "0.3.7"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2025.5.20"
+version = "2023.12.12"
 
 [[deps.MuladdMacro]]
 git-tree-sha1 = "cac9cc5499c25554cba55cd3c30543cff5ca4fab"
@@ -1312,7 +1219,7 @@ version = "1.2.3"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-version = "1.3.0"
+version = "1.2.0"
 
 [[deps.NonlinearSolve]]
 deps = ["ADTypes", "ArrayInterface", "BracketingNonlinearSolve", "CommonSolve", "ConcreteStructs", "DifferentiationInterface", "FastClosures", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "LinearSolve", "NonlinearSolveBase", "NonlinearSolveFirstOrder", "NonlinearSolveQuasiNewton", "NonlinearSolveSpectralMethods", "PrecompileTools", "Preferences", "Reexport", "SciMLBase", "SimpleNonlinearSolve", "StaticArraysCore", "SymbolicIndexingInterface"]
@@ -1420,23 +1327,12 @@ version = "0.3.29+0"
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.29+0"
+version = "0.3.27+1"
 
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
-version = "0.8.7+0"
-
-[[deps.OpenSSH_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "OpenSSL_jll", "Zlib_jll"]
-git-tree-sha1 = "301412a644646fdc0ad67d0a87487466b491e53d"
-uuid = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"
-version = "10.2.1+0"
-
-[[deps.OpenSSL_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.5.4+0"
+version = "0.8.5+0"
 
 [[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
@@ -1675,31 +1571,20 @@ git-tree-sha1 = "66a492d00afde5d8dcf035d87530982dcbd027c3"
 uuid = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 version = "1.8.0"
 
-[[deps.PCRE2_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
-version = "10.44.0+1"
-
 [[deps.PDMats]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "d922b4d80d1e12c658da7785e754f4796cc1d60d"
+git-tree-sha1 = "e4cff168707d441cd6bf3ff7e4832bdf34278e4a"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.36"
+version = "0.11.37"
 weakdeps = ["StatsBase"]
 
     [deps.PDMats.extensions]
     StatsBaseExt = "StatsBase"
 
-[[deps.Parsers]]
-deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "7d2f8f21da5db6a806faf7b9b292296da42b2810"
-uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.8.3"
-
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.12.1"
+version = "1.11.0"
 weakdeps = ["REPL"]
 
     [deps.Pkg.extensions]
@@ -1765,9 +1650,9 @@ version = "0.4.34"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
-git-tree-sha1 = "07a921781cab75691315adc645096ed5e370cb77"
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-version = "1.3.3"
+version = "1.2.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]
@@ -1796,7 +1681,7 @@ weakdeps = ["Enzyme"]
     QuadGKEnzymeExt = "Enzyme"
 
 [[deps.REPL]]
-deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 version = "1.11.0"
 
@@ -1837,9 +1722,9 @@ version = "1.3.4"
 
 [[deps.RecursiveArrayTools]]
 deps = ["Adapt", "ArrayInterface", "DocStringExtensions", "GPUArraysCore", "LinearAlgebra", "RecipesBase", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface"]
-git-tree-sha1 = "d7c53a81b0ab7f62842ff79d9e74e34562d5834e"
+git-tree-sha1 = "51e1a3b5c71caf79243a98832150cad6ef125f9e"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
-version = "3.42.0"
+version = "3.42.1"
 
     [deps.RecursiveArrayTools.extensions]
     RecursiveArrayToolsFastBroadcastExt = "FastBroadcast"
@@ -1871,12 +1756,6 @@ version = "3.42.0"
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "1.2.2"
-
-[[deps.RegistryInstances]]
-deps = ["LazilyInitializedFields", "Pkg", "TOML", "Tar"]
-git-tree-sha1 = "ffd19052caf598b8653b99404058fce14828be51"
-uuid = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
-version = "0.1.0"
 
 [[deps.Requires]]
 deps = ["UUIDs"]
@@ -1925,9 +1804,9 @@ version = "0.1.0"
 
 [[deps.SciMLBase]]
 deps = ["ADTypes", "Accessors", "Adapt", "ArrayInterface", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "EnumX", "FunctionWrappersWrappers", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "Markdown", "Moshi", "PreallocationTools", "PrecompileTools", "Preferences", "Printf", "RecipesBase", "RecursiveArrayTools", "Reexport", "RuntimeGeneratedFunctions", "SciMLLogging", "SciMLOperators", "SciMLPublic", "SciMLStructures", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface"]
-git-tree-sha1 = "b06382e2f1ff0c9aff4f88f560673c800df6099f"
+git-tree-sha1 = "e06a8b13d3e1b9f362fa4a206322c6638c707073"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "2.128.0"
+version = "2.130.0"
 
     [deps.SciMLBase.extensions]
     SciMLBaseChainRulesCoreExt = "ChainRulesCore"
@@ -2079,7 +1958,7 @@ version = "1.2.2"
 [[deps.SparseArrays]]
 deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-version = "1.12.0"
+version = "1.11.0"
 
 [[deps.SparseInverseSubset]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
@@ -2127,10 +2006,12 @@ deps = ["BipartiteGraphs", "DocStringExtensions", "FindFirstFunctions", "Graphs"
 git-tree-sha1 = "9944eaff4da716c4c228556326bb1182e63ad8ea"
 uuid = "64909d44-ed92-46a8-bbd9-f047dfbdc84b"
 version = "1.2.0"
-weakdeps = ["DeepDiffs"]
 
     [deps.StateSelection.extensions]
     StateSelectionDeepDiffsExt = "DeepDiffs"
+
+    [deps.StateSelection.weakdeps]
+    DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 
 [[deps.Static]]
 deps = ["CommonWorldInvalidations", "IfElse", "PrecompileTools", "SciMLPublic"]
@@ -2226,20 +2107,6 @@ git-tree-sha1 = "c581be48ae1cbf83e899b14c07a807e1787512cc"
 uuid = "53d494c1-5632-5724-8f4c-31dff12d585f"
 version = "0.3.1"
 
-[[deps.StructUtils]]
-deps = ["Dates", "UUIDs"]
-git-tree-sha1 = "79529b493a44927dd5b13dde1c7ce957c2d049e4"
-uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
-version = "2.6.0"
-
-    [deps.StructUtils.extensions]
-    StructUtilsMeasurementsExt = ["Measurements"]
-    StructUtilsTablesExt = ["Tables"]
-
-    [deps.StructUtils.weakdeps]
-    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
-    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-
 [[deps.StyledStrings]]
 uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
 version = "1.11.0"
@@ -2257,7 +2124,7 @@ version = "7.12.1+0"
 [[deps.SuiteSparse_jll]]
 deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
 uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
-version = "7.8.3+2"
+version = "7.7.0+0"
 
 [[deps.Sundials]]
 deps = ["Accessors", "ArrayInterface", "CEnum", "DataStructures", "DiffEqBase", "Libdl", "LinearAlgebra", "LinearSolve", "Logging", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SparseArrays", "Sundials_jll", "SymbolicIndexingInterface"]
@@ -2305,11 +2172,6 @@ deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 version = "1.10.0"
 
-[[deps.Test]]
-deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
-uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-version = "1.11.0"
-
 [[deps.ThreadingUtilities]]
 deps = ["ManualMemory"]
 git-tree-sha1 = "d969183d3d244b6c33796b5ed01ab97328f2db85"
@@ -2349,11 +2211,6 @@ version = "0.1.6"
 
     [deps.Tracy.weakdeps]
     TracyProfiler_jll = "0c351ed6-8a68-550e-8b79-de6f926da83c"
-
-[[deps.TranscodingStreams]]
-git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
-uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.11.3"
 
 [[deps.TruncatedStacktraces]]
 deps = ["InteractiveUtils", "MacroTools", "Preferences"]
@@ -2400,7 +2257,7 @@ version = "0.3.1"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.3.1+2"
+version = "1.2.13+1"
 
 [[deps.Zygote]]
 deps = ["AbstractFFTs", "ChainRules", "ChainRulesCore", "DiffRules", "Distributed", "FillArrays", "ForwardDiff", "GPUArraysCore", "IRTools", "InteractiveUtils", "LinearAlgebra", "LogExpFunctions", "MacroTools", "NaNMath", "PrecompileTools", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "ZygoteRules"]
@@ -2429,12 +2286,12 @@ version = "0.2.7"
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.15.0+0"
+version = "5.11.0+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.64.0+1"
+version = "1.59.0+0"
 
 [[deps.oneTBB_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl"]
@@ -2443,6 +2300,6 @@ uuid = "1317d2d5-d96f-522e-a858-c73665f53c3e"
 version = "2022.0.0+1"
 
 [[deps.p7zip_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.7.0+0"
+version = "17.4.0+2"

--- a/SpectreNetlistParser.jl/Project.toml
+++ b/SpectreNetlistParser.jl/Project.toml
@@ -11,6 +11,9 @@ AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 Lexers = "8fc43420-9e17-4e89-a998-f4e9593a1dfc"
 SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 
+[sources]
+Lexers = {path = "../Lexers.jl"}
+
 [compat]
 AbstractTrees = "v0.4.1"
 julia = "1.9"

--- a/VerilogAParser.jl/Project.toml
+++ b/VerilogAParser.jl/Project.toml
@@ -14,6 +14,9 @@ Lexers = "8fc43420-9e17-4e89-a998-f4e9593a1dfc"
 SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 VT100 = "7774df62-37c0-5c21-b34d-f6d7f98f54bc"
 
+[sources]
+Lexers = {path = "../Lexers.jl"}
+
 [compat]
 AbstractTrees = "v0.4.1"
 julia = "1"


### PR DESCRIPTION
- Add documentation for Julia 1.12 segfault during multi-threaded artifact downloads and the JULIA_NUM_THREADS=1 workaround
- Document Enzyme.jl limited support on Julia 1.12 (MNA tests work without it)
- Update testing instructions to use single-threaded mode
- Add Julia 1.11 to CI matrix with Pkg.resolve() to regenerate manifests
- Add Pkg.resolve() to subpackage test steps for cross-version compatibility

The segfault occurs in ijl_task_get_next during concurrent artifact downloads. CI works because GitHub Actions handles threading differently.