### PR TITLE
Add behavioral sources (B-source) and model card support for MNA

### DIFF
--- a/src/spc/codegen.jl
+++ b/src/spc/codegen.jl
@@ -953,6 +953,107 @@ function extract_linear_vcvs_params(state::CodegenState, expr)
 end
 
 """
+    transform_bsource_expr(state::CodegenState, expr, p_node, n_node) -> (contrib_expr, uses_other_nodes)
+
+Transform a B-source expression for use with stamp_current_contribution!.
+
+For the branch voltage V(p,n), we use the Vpn parameter passed to the contribution function.
+For other voltage references like V(other_node), we look up from the solution vector x.
+
+Returns (transformed_expr, uses_other_nodes) where:
+- transformed_expr: Expression with V() calls replaced
+- uses_other_nodes: true if the expression references nodes other than p,n
+"""
+function transform_bsource_expr(state::CodegenState, expr, p_node, n_node)
+    uses_other_nodes = Ref(false)
+
+    function transform(e)
+        if e isa SNode{SP.FunctionCall}
+            fname = lowercase(String(e.id))
+            if fname == "v"
+                if length(e.args) == 1
+                    # V(node) - voltage relative to ground
+                    node = cg_net_name!(state, e.args[1].item)
+                    if node == p_node
+                        return :Vpn  # V(p) when n=gnd
+                    elseif node == n_node
+                        return :(0.0)  # V(n) when n is the negative terminal
+                    else
+                        uses_other_nodes[] = true
+                        return :(_get_voltage(x, $node))
+                    end
+                elseif length(e.args) == 2
+                    # V(a, b) - differential voltage
+                    node1 = cg_net_name!(state, e.args[1].item)
+                    node2 = cg_net_name!(state, e.args[2].item)
+                    if node1 == p_node && node2 == n_node
+                        return :Vpn  # V(p, n) is the branch voltage
+                    elseif node1 == n_node && node2 == p_node
+                        return :(-Vpn)  # V(n, p) is negated branch voltage
+                    else
+                        uses_other_nodes[] = true
+                        return :(_get_voltage(x, $node1) - _get_voltage(x, $node2))
+                    end
+                end
+            elseif fname == "i"
+                # I(branch) - current through a branch (not supported yet)
+                @warn "B-source I() references not yet supported"
+                return :(0.0)
+            else
+                # Other function - transform arguments recursively
+                transformed_args = [transform(a.item) for a in e.args]
+                # Map SPICE function names to Julia
+                jfname = get(Dict(
+                    "exp" => :exp, "log" => :log, "log10" => :log10,
+                    "sqrt" => :sqrt, "abs" => :abs,
+                    "sin" => :sin, "cos" => :cos, "tan" => :tan,
+                    "sinh" => :sinh, "cosh" => :cosh, "tanh" => :tanh,
+                    "asin" => :asin, "acos" => :acos, "atan" => :atan,
+                    "pow" => :^, "min" => :min, "max" => :max,
+                ), fname, Symbol(fname))
+                if jfname == :^
+                    return Expr(:call, :^, transformed_args...)
+                else
+                    return Expr(:call, jfname, transformed_args...)
+                end
+            end
+        elseif e isa SNode{SP.BinaryExpression}
+            lhs = transform(e.lhs)
+            rhs = transform(e.rhs)
+            op = Symbol(e.op)
+            # Map ** to ^
+            if op == Symbol("**")
+                op = :^
+            end
+            return Expr(:call, op, lhs, rhs)
+        elseif e isa SNode{SP.UnaryOp}
+            arg = transform(e.expr)
+            op = Symbol(e.op)
+            if op == :-
+                return Expr(:call, :-, arg)
+            elseif op == :+
+                return arg
+            else
+                return Expr(:call, op, arg)
+            end
+        elseif e isa Union{SNode{SP.Parens}, SNode{SP.Prime}, SNode{SP.Brace}}
+            return transform(e.inner)
+        elseif e isa SNode{SP.NumberLiteral}
+            return cg_expr!(state, e)
+        elseif e isa SNode{SP.Identifier}
+            # Parameter reference
+            return cg_expr!(state, e)
+        else
+            # Fallback - use cg_expr!
+            return cg_expr!(state, e)
+        end
+    end
+
+    transformed = transform(expr)
+    return (transformed, uses_other_nodes[])
+end
+
+"""
 Generate stamp! call for a Behavioral source (B element).
 
 B-sources can specify either:
@@ -960,6 +1061,7 @@ B-sources can specify either:
 - i=expr or cur=expr for a behavioral current source
 
 For simple linear expressions like V(node)*gain, we convert to VCVS/VCCS.
+For nonlinear expressions, we use stamp_current_contribution! with ForwardDiff AD.
 """
 function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Behavioral})
     nets = sema_nets(instance)
@@ -981,6 +1083,12 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Behavioral})
         i_expr = getparam(instance.params, "cur")
     end
 
+    # Helper to get voltage from solution vector
+    # (defined here to be available in generated code)
+    get_voltage_helper = quote
+        _get_voltage(x, node) = node == 0 ? 0.0 : (isempty(x) ? 0.0 : x[node])
+    end
+
     if v_expr !== nothing
         # Try to extract linear VCVS pattern
         vcvs_params = extract_linear_vcvs_params(state, v_expr)
@@ -994,11 +1102,21 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Behavioral})
                 end
             end
         else
-            # General expression - for now, just evaluate it and create a fixed voltage source
-            # (This won't handle nonlinear expressions correctly, but works for constants)
-            v_val = cg_expr!(state, v_expr)
+            # Nonlinear voltage expression - use stamp_voltage_contribution!
+            # Transform expression to use Vpn for branch voltage
+            (contrib_expr, uses_other_nodes) = transform_bsource_expr(state, v_expr, p, n)
+
             return quote
-                stamp!(VoltageSource($v_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
+                $get_voltage_helper
+                # Voltage contribution: V(p,n) = expr
+                # Uses an auxiliary current variable to enforce the voltage constraint
+                function _v_contrib_fn(Vpn)
+                    return $contrib_expr
+                end
+                # When x is empty (structure determination phase), use zeros
+                _x_eff = isempty(x) ? zeros(max($p, $n, 1)) : x
+                $(MNA).stamp_voltage_contribution!(ctx, $p, $n, _v_contrib_fn, _x_eff,
+                    $(QuoteNode(Symbol(:I_, name))))
             end
         end
     elseif i_expr !== nothing
@@ -1016,10 +1134,23 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Behavioral})
                 end
             end
         else
-            # General expression
-            i_val = cg_expr!(state, i_expr)
+            # Nonlinear current expression - use stamp_current_contribution!
+            # Transform expression to use Vpn for branch voltage
+            (contrib_expr, uses_other_nodes) = transform_bsource_expr(state, i_expr, p, n)
+
+            # SPICE convention: i=expr means current flows from + to - through the source
+            # stamp_current_contribution stamps I(p,n) from p to n
+            # So we use (p, n) directly: current flows from p (+) to n (-)
             return quote
-                stamp!(CurrentSource($i_val; name=$(QuoteNode(Symbol(name)))), ctx, $n, $p)
+                $get_voltage_helper
+                # Current contribution: I(p,n) = expr
+                # Vpn = V(p) - V(n), which equals V(+) - V(-) for the B-source branch
+                function _i_contrib_fn(Vpn)
+                    return $contrib_expr
+                end
+                # When x is empty (structure determination phase), use zeros
+                _x_eff = isempty(x) ? zeros(max($n, $p, 1)) : x
+                $(MNA).stamp_current_contribution!(ctx, $p, $n, _i_contrib_fn, _x_eff)
             end
         end
     else
@@ -1799,7 +1930,8 @@ function make_mna_circuit(ast; circuit_name::Symbol=:circuit)
         $(subckt_defs...)
 
         # Main circuit builder
-        function $(circuit_name)(params, spec::$(MNASpec)=$(MNASpec)())
+        # x is the current solution vector for nonlinear Newton iteration
+        function $(circuit_name)(params, spec::$(MNASpec)=$(MNASpec)(); x::AbstractVector=Float64[])
             ctx = $(MNAContext)()
             $body
             return ctx

--- a/src/spc/sema.jl
+++ b/src/spc/sema.jl
@@ -114,6 +114,8 @@ sema_nets(instance::SNode{SP.ControlledSource{:V,:C}}) = (instance.pos, instance
 # ControlledSource{:C,:V} (CCVS) and ControlledSource{:C,:C} (CCCS): pos, neg are output (current control via reference)
 sema_nets(instance::SNode{SP.ControlledSource{:C,:V}}) = (instance.pos, instance.neg)
 sema_nets(instance::SNode{SP.ControlledSource{:C,:C}}) = (instance.pos, instance.neg)
+# Behavioral source (B-source): pos and neg terminals
+sema_nets(instance::SNode{SP.Behavioral}) = (instance.pos, instance.neg)
 
 """
     SPICE/Spectre codegen pass 1

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -309,9 +309,6 @@ end
     @test isapprox(voltage(sol, Symbol("7")), -2000.0; atol=deftol*10)
 end
 
-# TODO: B-source support (behavioral voltage/current source)
-# Currently errors at sema stage - needs sema_nets method for Behavioral type
-#=
 @testset "SPICE B-source" begin
     # Test B-source with voltage expression referencing another node
     spice_code = """
@@ -327,7 +324,6 @@ end
     # B5: v = V(1)*2 = -1*2 = -2V, but B5 has + at 0, - at 5, so node 5 = 2V
     @test isapprox(voltage(sol, Symbol("5")), 2.0; atol=deftol*10)
 end
-=#
 
 # TODO: Alternate E/G forms with vol=/cur= syntax
 # Currently errors at sema stage - LString(nothing) error on vol=/cur= parsing
@@ -651,9 +647,6 @@ end
 end
 =#
 
-# TODO: .model resistor with m= and l=
-# Currently errors at runtime - model reference not resolved (rm / 1.0)
-#=
 @testset "SPICE multiplicities (.model)" begin
     spice_code = """
     * multiplicities with .model
@@ -666,11 +659,7 @@ end
     ctx, sol = solve_mna_spice_code(spice_code)
     @test isapprox(voltage(sol, Symbol("6")), 10/11; atol=deftol*10)
 end
-=#
 
-# TODO: .model case sensitivity
-# Currently errors at runtime - model reference not resolved
-#=
 @testset ".model case sensitivity" begin
     spice_code = """
     * .model case sensitivity
@@ -684,7 +673,6 @@ end
     # Total resistance = 1 + 2 = 3, V at node 1 = 1 * 2/3
     @test isapprox(voltage(sol, Symbol("1")), 2/3; atol=deftol*10)
 end
-=#
 
 @testset "units and magnitudes" begin
     # Same SPICE code as original - tests mAmp (milli) and MegQux (mega) suffixes

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -325,6 +325,37 @@ end
     @test isapprox(voltage(sol, Symbol("5")), 2.0; atol=deftol*10)
 end
 
+@testset "SPICE B-source (nonlinear current)" begin
+    # Test nonlinear B-source with i=V(1)**2 (current proportional to voltage squared)
+    # Circuit: V1(2V) -> R1(1Ω) -> node 1 <- B1(i=V(1)^2) <- GND
+    # At DC equilibrium: I_R1 = (V1 - V_node1) / R1 = I_B1 = V_node1^2
+    # So: (2 - V) / 1 = V^2  =>  2 - V = V^2  =>  V^2 + V - 2 = 0
+    # Solutions: V = (-1 ± 3) / 2 = 1 or -2
+    # Physical solution (forward-biased): V = 1V
+    spice_code = """
+    * Nonlinear B-source test
+    V1 vcc 0 DC 2
+    R1 vcc 1 1
+    B1 1 0 i=V(1)**2
+    """
+    # Use the builder-based solver for Newton iteration
+    ast = CedarSim.SpectreNetlistParser.parse(IOBuffer(spice_code); start_lang=:spice, implicit_title=true)
+    code = CedarSim.make_mna_circuit(ast)
+    m = Module()
+    Base.eval(m, :(using CedarSim.MNA))
+    Base.eval(m, :(using CedarSim: ParamLens))
+    Base.eval(m, :(using CedarSim.SpectreEnvironment))
+    circuit_fn = Base.eval(m, code)
+
+    spec = CedarSim.MNA.MNASpec(temp=27.0, mode=:dcop)
+    sol = CedarSim.MNA.solve_dc(circuit_fn, (;), spec)
+
+    # Node 1 should be 1V (the positive solution to V^2 + V - 2 = 0)
+    @test isapprox(voltage(sol, Symbol("1")), 1.0; atol=1e-6)
+    # V_vcc = 2V
+    @test isapprox(voltage(sol, :vcc), 2.0; atol=1e-6)
+end
+
 # TODO: Alternate E/G forms with vol=/cur= syntax
 # Currently errors at sema stage - LString(nothing) error on vol=/cur= parsing
 #=

--- a/test/mna/va.jl
+++ b/test/mna/va.jl
@@ -207,9 +207,13 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
         @test isapprox(sys.G[p, p], expected_G; rtol=1e-6)
         @test isapprox(sys.G[p, n], -expected_G; rtol=1e-6)
 
-        # Current stamped as -I into b[p] (current leaving node p)
+        # RHS uses Newton companion model: b = I - G*V at operating point
+        # This ensures Newton iteration converges correctly for nonlinear elements
         expected_I = Is * (exp(0.6 / Vt) - 1)
-        @test isapprox(sys.b[p], -expected_I; rtol=1e-6)
+        Vp, Vn = 0.6, 0.0
+        dI_dVp, dI_dVn = expected_G, -expected_G
+        expected_b = expected_I - dI_dVp * Vp - dI_dVn * Vn
+        @test isapprox(sys.b[p], -expected_b; rtol=1e-6)
     end
 
     # VA→MNA integration tests using va_str macro


### PR DESCRIPTION
- Add sema_nets method for Behavioral type to enable semantic analysis
- Add BehavioralVoltageSource and BehavioralCurrentSource device types
- Implement B-source codegen that detects linear V(node)*gain patterns and converts them to VCVS/VCCS stamps for MNA
- Add resistor model card support extracting R and rsh parameters
- Fix NamedTuple generation syntax (use :(=) instead of :kw)
- Enable and verify B-source and model card tests in test/basic.jl