### PR TITLE
Hook up missing MNA tests to runtests.jl

### DIFF
--- a/test/ddx.jl
+++ b/test/ddx.jl
@@ -34,8 +34,8 @@ endmodule
     # NLVCR(R=2) with d=vcc, g=vg, s=gnd
     #
     # Expected current:
-    # I(d,s) = 2*R*V(d,s)*V(g,s) = 2*2*5*3 = 60A
-    # V1 sources this current, so I_V1 = -60A
+    # I(d,s) = 2*R*V(d,s)*V(g,s) = 2*2*5*3 = 60A flows from vcc to gnd
+    # V1 sources this current (pushes out of positive terminal), so I_V1 = -60A
 
     # Builder accepts x keyword for Newton iteration
     function VRcircuit(params, spec; x=Float64[])
@@ -60,9 +60,9 @@ endmodule
 
     # Verify current:
     # I(d,s) = 2*R*V(d,s)*V(g,s) = 2*2*5*3 = 60A flows from d(vcc) to s(gnd)
-    # V1 supplies this current, so I_V1 = +60A (current into V1's positive terminal)
+    # V1 sources this current (pushing out of positive terminal), so I_V1 = -60A
     expected_I = 5.0 * 2.0 * 2.0 * 3.0
-    @test isapprox(current(sol, :I_V1), expected_I; atol=1e-6)
+    @test isapprox(current(sol, :I_V1), -expected_I; atol=1e-6)
 end
 
 end # module ddx_tests

--- a/test/mna/vadistiller.jl
+++ b/test/mna/vadistiller.jl
@@ -163,6 +163,9 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
         @testset "Diode with series resistance" begin
             # Diode with Rs for more realistic behavior
             # This tests internal nodes which require phase 6 features
+            # NOTE: VA definition commented out - internal nodes not yet supported
+            # Once internal node support is added, uncomment this:
+            #=
             va"""
             module VADDiodeRs(a, c);
                 parameter real Is = 1e-14;
@@ -176,25 +179,11 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
                 end
             endmodule
             """
+            =#
 
             # Forward bias test with internal node
             # This will fail until we add internal node support
-            @test_skip begin
-                function diode_rs_circuit(params, spec)
-                    ctx = MNAContext()
-                    anode = get_node!(ctx, :anode)
-                    a_int = get_node!(ctx, :a_int)
-
-                    stamp!(VoltageSource(0.7; name=:V1), ctx, anode, 0)
-                    stamp!(VADDiodeRs(Is=1e-14, N=1.0, Rs=10.0), ctx, anode, 0; internal_nodes=(:a_int => a_int,))
-
-                    return ctx
-                end
-                ctx = diode_rs_circuit((;), MNASpec())
-                sys = assemble!(ctx)
-                sol = solve_dc(sys)
-                true  # Just check it runs
-            end
+            @test_broken false  # Placeholder: internal nodes not yet supported
         end
 
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,14 @@ if PHASE0_MINIMAL
     # Phase 5: VA integration tests (s-dual contribution stamping)
     @testset "Phase 5: MNA VA Integration" begin
         @testset "mna/va.jl" include("mna/va.jl")
+        @testset "ddx.jl" include("ddx.jl")
+        @testset "varegress.jl" include("varegress.jl")
+    end
+
+    # Phase 6: Multi-terminal VA devices and MOSFET tests
+    @testset "Phase 6: MNA VA Multi-Terminal" begin
+        @testset "mna/va_mosfet.jl" include("mna/va_mosfet.jl")
+        @testset "mna/vadistiller.jl" include("mna/vadistiller.jl")
     end
 
     # Phase 4: Basic tests using MNA backend


### PR DESCRIPTION
Add recently-added test files that were fixed but not hooked up:
- Phase 5: ddx.jl, varegress.jl (VA integration tests)
- Phase 6: va_mosfet.jl, vadistiller.jl (multi-terminal VA tests)

Also fix:
- ddx.jl: correct sign convention in current test (V1 sources -60A)
- vadistiller.jl: comment out internal node VA code (not yet supported)