### PR TITLE
Add VA system function support: $temperature, $simparam, $param_given

### DIFF
--- a/src/mna/solve.jl
+++ b/src/mna/solve.jl
@@ -60,6 +60,13 @@ Base.@kwdef struct MNASpec{T<:Real}
     temp::Float64 = 27.0
     mode::Symbol = :tran
     time::T = 0.0
+    # Common simulator parameters (for $simparam access)
+    gmin::Float64 = 1e-12      # Minimum conductance
+    tnom::Float64 = 27.0       # Nominal temperature (Celsius)
+    abstol::Float64 = 1e-12    # Absolute tolerance
+    reltol::Float64 = 1e-3     # Relative tolerance
+    vntol::Float64 = 1e-6      # Voltage tolerance
+    iabstol::Float64 = 1e-12   # Current absolute tolerance
 end
 
 export MNASpec
@@ -69,14 +76,18 @@ export MNASpec
 
 Create new spec with different temperature.
 """
-with_temp(spec::MNASpec, temp::Real) = MNASpec(temp=Float64(temp), mode=spec.mode, time=spec.time)
+with_temp(spec::MNASpec, temp::Real) = MNASpec(temp=Float64(temp), mode=spec.mode, time=spec.time,
+    gmin=spec.gmin, tnom=spec.tnom, abstol=spec.abstol, reltol=spec.reltol,
+    vntol=spec.vntol, iabstol=spec.iabstol)
 
 """
     with_mode(spec::MNASpec, mode::Symbol) -> MNASpec
 
 Create new spec with different mode.
 """
-with_mode(spec::MNASpec, mode::Symbol) = MNASpec(temp=spec.temp, mode=mode, time=spec.time)
+with_mode(spec::MNASpec, mode::Symbol) = MNASpec(temp=spec.temp, mode=mode, time=spec.time,
+    gmin=spec.gmin, tnom=spec.tnom, abstol=spec.abstol, reltol=spec.reltol,
+    vntol=spec.vntol, iabstol=spec.iabstol)
 
 """
     with_time(spec::MNASpec, t::Real) -> MNASpec
@@ -84,7 +95,9 @@ with_mode(spec::MNASpec, mode::Symbol) = MNASpec(temp=spec.temp, mode=mode, time
 Create new spec with different time.
 Note: time type is preserved to support ForwardDiff Dual numbers.
 """
-with_time(spec::MNASpec, t::T) where {T<:Real} = MNASpec(temp=spec.temp, mode=spec.mode, time=t)
+with_time(spec::MNASpec, t::T) where {T<:Real} = MNASpec(temp=spec.temp, mode=spec.mode, time=t,
+    gmin=spec.gmin, tnom=spec.tnom, abstol=spec.abstol, reltol=spec.reltol,
+    vntol=spec.vntol, iabstol=spec.iabstol)
 
 export with_temp, with_mode, with_time
 

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -1061,9 +1061,12 @@ function make_mna_device(vm::VANode{VerilogModule})
     # Build struct and constructor directly without @kwdef to avoid macro hygiene issues
     # that rename field symbols in baremodule contexts
 
-    # 1. Build plain struct definition
+    # Filter out alias parameters from struct fields (aliases don't need storage)
+    real_params = filter(p -> !haskey(aliases, p), parameter_names)
+
+    # 1. Build plain struct definition (only real parameters, not aliases)
     struct_body = Expr(:block)
-    for paramsym in parameter_names
+    for paramsym in real_params
         push!(struct_body.args, Expr(:(::), paramsym, :(CedarSim.DefaultOr{Float64})))
     end
     struct_def = Expr(:struct, false,
@@ -1071,21 +1074,48 @@ function make_mna_device(vm::VANode{VerilogModule})
         struct_body)
 
     # 2. Build keyword constructor that mimics @kwdef
-    # Constructor: TypeName(; param1=mkdefault(default1), ...) = TypeName(vaconvert(...), ...)
-    if !isempty(parameter_names)
+    # Constructor accepts both real params and aliases
+    # Aliases forward their value to the target parameter
+    if !isempty(real_params) || !isempty(aliases)
         # Build keyword parameter list with defaults
         kw_params = Expr(:parameters)
         call_args = Any[]
-        for paramsym in parameter_names
+
+        # Add real parameters
+        for paramsym in real_params
             # Each parameter: paramsym = mkdefault(default_value)
             # Use the actual default value from the VA parameter declaration
             default_val = get(param_defaults, paramsym, 0.0)
             push!(kw_params.args, Expr(:kw, paramsym, :(CedarSim.mkdefault($default_val))))
-            # In call, convert using vaconvert
-            push!(call_args, Expr(:call, :(VerilogAEnvironment.vaconvert),
-                :(CedarSim.notdefault(fieldtype($symname, $(QuoteNode(paramsym))))),
-                paramsym))
         end
+
+        # Add alias parameters (they default to nothing, meaning "use target's value")
+        for (alias_sym, _) in aliases
+            push!(kw_params.args, Expr(:kw, alias_sym, :nothing))
+        end
+
+        # Build call args: for each real param, check if an alias was provided
+        for paramsym in real_params
+            # Find aliases that target this parameter
+            targeting_aliases = [a for (a, t) in aliases if t == paramsym]
+            if isempty(targeting_aliases)
+                # No aliases, just use the parameter directly
+                push!(call_args, Expr(:call, :(VerilogAEnvironment.vaconvert),
+                    :(CedarSim.notdefault(fieldtype($symname, $(QuoteNode(paramsym))))),
+                    paramsym))
+            else
+                # Has aliases - use alias value if provided, otherwise use parameter
+                # Build: something(alias1, alias2, ..., paramsym) where something picks first non-nothing
+                alias_expr = paramsym
+                for alias_sym in reverse(targeting_aliases)
+                    alias_expr = :($alias_sym !== nothing ? $alias_sym : $alias_expr)
+                end
+                push!(call_args, Expr(:call, :(VerilogAEnvironment.vaconvert),
+                    :(CedarSim.notdefault(fieldtype($symname, $(QuoteNode(paramsym))))),
+                    alias_expr))
+            end
+        end
+
         # Build constructor function
         constructor = Expr(:function,
             Expr(:call, symname, kw_params),
@@ -1094,9 +1124,36 @@ function make_mna_device(vm::VANode{VerilogModule})
         constructor = nothing
     end
 
+    # 3. Build getproperty override to support alias access
+    # Base.getproperty(dev::TypeName, s::Symbol) = s == :alias ? getfield(dev, :target) : getfield(dev, s)
+    getproperty_override = nothing
+    if !isempty(aliases)
+        # Build the if-elseif chain for aliases
+        alias_checks = nothing
+        for (alias_sym, target_sym) in aliases
+            check = :(s == $(QuoteNode(alias_sym)))
+            result = :(getfield(dev, $(QuoteNode(target_sym))))
+            if alias_checks === nothing
+                alias_checks = Expr(:if, check, result)
+            else
+                # Add as elseif
+                push!(alias_checks.args, Expr(:elseif, check, result))
+            end
+        end
+        # Add final else clause
+        push!(alias_checks.args, :(getfield(dev, s)))
+
+        getproperty_override = :(function Base.getproperty(dev::$symname, s::Symbol)
+            $alias_checks
+        end)
+    end
+
     result_args = Any[struct_def]
     if constructor !== nothing
         push!(result_args, constructor)
+    end
+    if getproperty_override !== nothing
+        push!(result_args, getproperty_override)
     end
     push!(result_args, stamp_method)
 
@@ -1655,7 +1712,8 @@ function make_mna_module(va::VANode)
 
     Expr(:toplevel, :(baremodule $s
         using Base: AbstractVector, Real, Symbol, Float64, Int, isempty, max, zeros, zero
-        using Base: hasproperty, getproperty, error
+        using Base: hasproperty, getproperty, getfield, error, !==
+        import Base  # For getproperty override in aliasparam
         import ..CedarSim
         using ..CedarSim.VerilogAEnvironment
         using ..CedarSim.MNA: va_ddt, stamp_current_contribution!, MNAContext, MNASpec

--- a/test/mna/vadistiller.jl
+++ b/test/mna/vadistiller.jl
@@ -19,6 +19,7 @@ using CedarSim.MNA: va_ddt, stamp_current_contribution!, evaluate_contribution
 using CedarSim.MNA: VoltageSource, Resistor, Capacitor, CurrentSource
 using ForwardDiff: Dual, value, partials
 using OrdinaryDiffEq
+using VerilogAParser
 
 const deftol = 1e-6
 isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
@@ -319,29 +320,140 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
     end
 
     #==========================================================================#
-    # Feature Tests: Parser/Codegen Extensions Needed
-    # These are marked as broken - don't even try to parse them
+    # Feature Tests: VA System Functions
     #==========================================================================#
 
-    @testset "Feature: Parser Extensions Needed" begin
+    @testset "Feature: VA System Functions" begin
 
         @testset "\$temperature access" begin
-            # VADistiller models use $temperature for temp-dependent parameters
-            # Currently broken: $temperature not implemented in MNAScope
-            @test_broken false
+            # Test temperature-dependent resistor using $temperature
+            va_code = raw"""
+            module VATempResistor(p, n);
+                parameter real R0 = 1000.0;
+                parameter real TC = 0.004;
+                inout p, n;
+                electrical p, n;
+                analog begin
+                    I(p,n) <+ V(p,n) / (R0 * (1.0 + TC * ($temperature() - 300.0)));
+                end
+            endmodule
+            """
+            va = VerilogAParser.parse(IOBuffer(va_code))
+            Core.eval(@__MODULE__, CedarSim.make_mna_module(va))
+
+            # Test at default temp (27C = 300.15K)
+            function temp_resistor_circuit(params, spec; x=Float64[])
+                ctx = MNAContext()
+                vcc = get_node!(ctx, :vcc)
+
+                stamp!(VoltageSource(5.0; name=:V1), ctx, vcc, 0)
+                stamp!(VATempResistor(R0=1000.0, TC=0.004), ctx, vcc, 0; x=x, spec=spec)
+
+                return ctx
+            end
+
+            # At 27°C (300.15K), resistance should be ~R0
+            spec = MNASpec(temp=27.0)
+            sol = solve_dc(temp_resistor_circuit, (;), spec)
+            # R = 1000 * (1 + 0.004 * (300.15 - 300)) = 1000 * 1.0006 ≈ 1000.6
+            # I = 5V / 1000.6 ≈ 0.005
+            @test isapprox(current(sol, :I_V1), -0.005; atol=1e-4)
+
+            # At 100°C (373.15K), resistance should be higher
+            spec_hot = MNASpec(temp=100.0)
+            sol_hot = solve_dc(temp_resistor_circuit, (;), spec_hot)
+            # R = 1000 * (1 + 0.004 * (373.15 - 300)) = 1000 * 1.293 ≈ 1292.6
+            # I = 5V / 1292.6 ≈ 0.00387
+            @test isapprox(current(sol_hot, :I_V1), -0.00387; atol=1e-4)
         end
 
         @testset "\$simparam access" begin
-            # VADistiller models use $simparam("gmin", 1e-12) etc.
-            # Currently broken: $simparam not implemented
-            @test_broken false
+            # Test $simparam with default value
+            va_code = raw"""
+            module VAGminResistor(p, n);
+                parameter real R = 1000.0;
+                inout p, n;
+                electrical p, n;
+                analog begin
+                    I(p,n) <+ V(p,n) / R + V(p,n) * $simparam("gmin", 1e-12);
+                end
+            endmodule
+            """
+            va = VerilogAParser.parse(IOBuffer(va_code))
+            Core.eval(@__MODULE__, CedarSim.make_mna_module(va))
+
+            function gmin_circuit(params, spec; x=Float64[])
+                ctx = MNAContext()
+                vcc = get_node!(ctx, :vcc)
+
+                stamp!(VoltageSource(5.0; name=:V1), ctx, vcc, 0)
+                stamp!(VAGminResistor(R=1000.0), ctx, vcc, 0; x=x, spec=spec)
+
+                return ctx
+            end
+
+            # With default gmin=1e-12
+            spec = MNASpec()
+            sol = solve_dc(gmin_circuit, (;), spec)
+            # I ≈ 5/1000 + 5*1e-12 ≈ 0.005
+            @test isapprox(current(sol, :I_V1), -0.005; atol=1e-6)
+
+            # With custom gmin=1e-3 (very high for testing)
+            spec_gmin = MNASpec(gmin=1e-3)
+            sol_gmin = solve_dc(gmin_circuit, (;), spec_gmin)
+            # I = 5/1000 + 5*1e-3 = 0.005 + 0.005 = 0.01
+            @test isapprox(current(sol_gmin, :I_V1), -0.01; atol=1e-6)
         end
 
         @testset "\$param_given check" begin
-            # VADistiller models use $param_given(param) for optional params
-            # Currently broken: $param_given not implemented
-            @test_broken false
+            # Test $param_given to check if parameter was explicitly set
+            # Uses ternary expression since if/else with contributions needs more work
+            va_code = raw"""
+            module VAOptionalParam(p, n);
+                parameter real R = 1000.0;
+                parameter real Ralt = 500.0;
+                inout p, n;
+                electrical p, n;
+                analog begin
+                    I(p,n) <+ V(p,n) / ($param_given(R) ? R : Ralt);
+                end
+            endmodule
+            """
+            va = VerilogAParser.parse(IOBuffer(va_code))
+            Core.eval(@__MODULE__, CedarSim.make_mna_module(va))
+
+            # With explicit R=2000 (R is "given")
+            sol_explicit = solve_dc((p,s; x=Float64[]) -> begin
+                ctx = MNAContext()
+                vcc = get_node!(ctx, :vcc)
+                stamp!(VoltageSource(5.0; name=:V1), ctx, vcc, 0)
+                stamp!(VAOptionalParam(R=2000.0, Ralt=500.0), ctx, vcc, 0; x=x, spec=s)
+                return ctx
+            end, (;), MNASpec())
+            # $param_given(R) is true, so uses R=2000
+            # I = 5V / 2000Ω = 0.0025A
+            @test isapprox(current(sol_explicit, :I_V1), -0.0025; atol=1e-6)
+
+            # With only Ralt given (R is NOT "given")
+            sol_default = solve_dc((p,s; x=Float64[]) -> begin
+                ctx = MNAContext()
+                vcc = get_node!(ctx, :vcc)
+                stamp!(VoltageSource(5.0; name=:V1), ctx, vcc, 0)
+                stamp!(VAOptionalParam(Ralt=500.0), ctx, vcc, 0; x=x, spec=s)
+                return ctx
+            end, (;), MNASpec())
+            # $param_given(R) is false, so uses Ralt=500
+            # I = 5V / 500Ω = 0.01A
+            @test isapprox(current(sol_default, :I_V1), -0.01; atol=1e-6)
         end
+
+    end
+
+    #==========================================================================#
+    # Feature Tests: Parser Extensions Still Needed
+    #==========================================================================#
+
+    @testset "Feature: Parser Extensions Needed" begin
 
         @testset "aliasparam declaration" begin
             # VADistiller uses aliasparam tref = tnom; etc.
@@ -352,6 +464,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
         @testset "Real variable with initialization" begin
             # VADistiller uses `real G = 0.0;` at module scope
             # Currently broken: parser error at inline initialization
+            # Note: This requires VerilogAParser changes
             @test_broken false
         end
 
@@ -377,10 +490,13 @@ end
 # ✅ 3-terminal MOSFET - I(d,s) <+ Kp/2*(Vgs-Vth)^2 with Newton iteration
 # ✅ 4-terminal NMOS - same as above with bulk terminal
 #
+# WORKING VA SYSTEM FUNCTIONS:
+# ✅ $temperature() - simulator temperature access (returns Kelvin)
+# ✅ $simparam("name", default) - simulator parameter queries (gmin, tnom, etc.)
+# ✅ $param_given(param) - check if parameter was specified
+# ✅ $vt() - thermal voltage (kT/q)
+#
 # MISSING PARSER FEATURES (needed for full VADistiller models):
-# ❌ $temperature - simulator temperature access
-# ❌ $simparam() - simulator parameter queries (gmin, tnom, abstol, etc.)
-# ❌ $param_given() - check if parameter was specified
 # ❌ $mfactor - device multiplicity
 # ❌ $limit() - voltage limiting for Newton convergence
 # ❌ aliasparam - parameter aliases


### PR DESCRIPTION
- Add $temperature() support in MNAScope (returns Kelvin)
- Add $simparam("name", default) for simulator parameter access
- Add $param_given(param) to check if parameter was explicitly set
- Add spec parameter to stamp! method signature for VA devices
- Extend MNASpec with common simparams: gmin, tnom, abstol, reltol, vntol, iabstol
- Update with_temp, with_mode, with_time to preserve new spec fields
- Add comprehensive tests for all three VA system functions
- Update vadistiller.jl summary to reflect new working features