### PR TITLE
Add VA variable initialization support (real x = 0.0;)

### DIFF
--- a/VerilogAParser.jl/src/parse/forms.jl
+++ b/VerilogAParser.jl/src/parse/forms.jl
@@ -60,6 +60,15 @@ allchildren(p::Identifier) = p.concat === nothing ? (p.id,) : (p.id, p.concat...
 
 const IdentifierListItem = ListItem{EXPR{Identifier}}
 
+# Variable declaration with optional initialization (real x = 0.0;)
+struct IntRealVarDecl
+    id::EXPR{Identifier}
+    eq::Maybe{EXPR{Notation}}
+    init::Maybe{EXPR}
+end
+allchildren(v::IntRealVarDecl) = v.eq === nothing ? (v.id,) : (v.id, v.eq, v.init)
+const IntRealDeclItem = ListItem{EXPR{IntRealVarDecl}}
+
 struct AttrSpec
     name::Union{EXPR{Identifier}, EXPR{Keyword}, EXPR{Error}, EXPR{MacroError}}
     eq::EXPRErr{Notation}
@@ -321,7 +330,7 @@ allchildren(fd::AnalogFunctionDeclaration) = (fd.akw, fd.fkw, fd.fty, fd.id, fd.
 
 struct IntRealDeclaration
     kw::EXPR{Keyword}
-    idents::EXPRList{IdentifierListItem}
+    idents::EXPRList{IntRealDeclItem}
 end
 allchildren(ird::IntRealDeclaration) = (ird.kw, ird.idents...)
 


### PR DESCRIPTION
Parser changes:
- Add IntRealVarDecl struct to hold variable identifier and optional initialization
- Extend IntRealDeclaration to use new IntRealDeclItem list
- Update parse_intreal_declaration to parse inline initialization (real x = 0.0;)

MNA codegen changes:
- Collect var_inits dictionary during pre-pass for initialization expressions
- Update local_var_decls generation to use initialization values
- Fix stamp method generation to preserve init values with Dual type compatibility

This enables parsing and simulating VADistiller models that use inline variable initialization like `real REStemp = 0;` at module scope.

Tests added for:
- Variable with zero initialization
- Variable with non-zero initialization (offset = 0.5)