### PR TITLE
Fix voltage contributions to use proper MNA branch currents

### DIFF
--- a/test/mna/vadistiller.jl
+++ b/test/mna/vadistiller.jl
@@ -1047,6 +1047,41 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
                 v_diode = sol.x[2]  # diode_a is node 2
                 v_diode > 0.6 && v_diode < 0.7  # Should be ~0.63V
             end
+
+            # Test with non-zero series resistance (rs=10Ω)
+            # This uses the full model with internal node (not aliased)
+            @test begin
+                function sp_diode_rs_circuit(params, spec; x=Float64[])
+                    ctx = MNAContext()
+                    vcc = get_node!(ctx, :vcc)
+                    diode_a = get_node!(ctx, :diode_a)
+                    stamp!(VoltageSource(1.0; name=:V1), ctx, vcc, 0)
+                    stamp!(Resistor(1000.0; name=:R1), ctx, vcc, diode_a)
+                    # Use rs=10Ω - this activates the internal node and series resistance
+                    stamp!(sp_diode(; rs=10.0), ctx, diode_a, 0; spec=spec, x=x)
+                    return ctx
+                end
+
+                sol = solve_dc(sp_diode_rs_circuit, (;), MNASpec())
+
+                # With rs=10Ω, the internal node should be allocated (not aliased)
+                # System should have: vcc, diode_a, sp_diode_a_int + I_V1 = 4 states
+                sys = assemble!(sp_diode_rs_circuit((;), MNASpec(); x=sol.x))
+                has_internal_node = :sp_diode_a_int in sys.node_names
+
+                # Voltage at diode_a should be slightly higher than internal junction
+                # due to voltage drop across series resistance: V_a = V_a_int + I*rs
+                # With I ≈ 0.37mA and rs=10Ω, drop ≈ 3.7mV
+                v_diode_a = sol.x[2]
+                v_a_int = sol.x[3]  # Internal junction node
+
+                # Check voltages are reasonable
+                junction_ok = v_a_int > 0.6 && v_a_int < 0.7  # Junction ~0.63V
+                drop_ok = v_diode_a > v_a_int  # Should have voltage drop across rs
+                drop_reasonable = (v_diode_a - v_a_int) < 0.01  # Drop should be small (few mV)
+
+                has_internal_node && junction_ok && drop_ok && drop_reasonable
+            end
         end
 
     end


### PR DESCRIPTION
The voltage contribution V(p,n) <+ expr (including short circuits V(p,n) <+ 0) was incorrectly implemented using high conductance (1e12) stamping. This approach cannot carry DC current when V_p = V_n because I = G*(V_p - V_n) = 0.

This fix properly implements voltage contributions using MNA branch current variables:
- KCL at p: G[p, I] = 1 (current flows out)
- KCL at n: G[n, I] = -1 (current flows in)
- Voltage constraint: G[I, p] = 1, G[I, n] = -1, b[I] = expr

Changes:
- src/vasim.jl: Update transform_contribution_statement() for conditional voltage contributions to use inline branch current allocation
- src/vasim.jl: Add twonode_voltage_contribs collection and stamping for regular (non-conditional) voltage contributions
- test/mna/vadistiller.jl: Update diode test from @test_broken to @test since it now works correctly (V ≈ 0.63V)

Test results:
- MNA Core: 332 pass
- VA Integration: 49 pass
- VADistiller: 50 pass (was 49 pass, 1 broken)