### PR TITLE
Add BJT, JFET1, MES1 model tests and fix internal node ground aliasing

### DIFF
--- a/VerilogAParser.jl/src/parse/forms.jl
+++ b/VerilogAParser.jl/src/parse/forms.jl
@@ -179,6 +179,13 @@ struct FunctionCall
 end
 allchildren(fc::FunctionCall) = (fc.id, fc.attrs, fc.lparen, fc.args..., fc.rparen)
 
+# Function call as a statement (for functions with inout/output parameters called for side effects)
+struct FunctionCallStatement
+    call::EXPR{FunctionCall}
+    semi::EXPRErr{Notation}
+end
+allchildren(fcs::FunctionCallStatement) = (fcs.call, fcs.semi)
+
 struct ContributionStatement
     lvalue::EXPR
     cassign::EXPRErr{Notation}

--- a/VerilogAParser.jl/test/errors/missing_assignment.out
+++ b/VerilogAParser.jl/test/errors/missing_assignment.out
@@ -1,7 +1,0 @@
-[31m[1m╭ ERROR [VAS14]:[22m[39m[31m Statements without assignments are illegal in Verilog-A.[39m
-[31m│[39m[90m   ╭───── missing_assignment.va:12[39m
-[31m│[90m12[0m [90m│[0m                 NumFingerDiff(nf, minSD, niIntD, nuEndD, nuIntS, nuEndS);
-[31m│[0m   [90m┊[0m                 [91m━━━━━━┳━━━━━━
-[31m│[0m   [90m┊[0m         [91mStatement without assignment[0m
-[31m│[39m[90m   │[39m
-[31m│[39m[90m   ╰───── [39m

--- a/VerilogAParser.jl/test/errors/pag.out
+++ b/VerilogAParser.jl/test/errors/pag.out
@@ -1,7 +1,9 @@
-[31m[1m╭ ERROR [VAS14]:[22m[39m[31m Statements without assignments are illegal in Verilog-A.[39m
-[31m│[39m[90m    ╭───── pag.va:12[39m
-[31m│[90m12[0m  [90m│[0m                 NumFingerDiff(nf, minSD, niIntD, nuEndD, nuIntS, nuEndS);
-[31m│[0m    [90m┊[0m                 [91m━━━━━━┳━━━━━━
-[31m│[0m    [90m┊[0m         [91mStatement without assignment[0m
+[31m[1m╭ ERROR [VAS26]:[22m[39m[31m begin/end blocks not allowed inside case statements.[39m
+[31m│[39m[90m    ╭───── pag.va:34[39m
+[31m│[90m34[0m  [90m│[0m             case(geo) begin
+[31m│[0m    [90m┊[0m             [33m━━┳━[0m      [91m━━┳━━
+[31m│[0m    [90m┊[0m               [91m✗ Unexpected `begin`
+[31m│[0m    [90m┊[0m [33m`case` statement starts here[0m
 [31m│[39m[90m    │[39m
 [31m│[39m[90m    ╰───── [39m
+[31m╯[39m

--- a/src/spc/cache.jl
+++ b/src/spc/cache.jl
@@ -22,6 +22,9 @@ function parse_and_cache_va!(cache::CedarParseCache, path::String)
     end
     abspath = isabspath(path) ? path : joinpath(dirname(pathof(cache.thismod)), "..", path)
     va = VerilogAParser.parsefile(abspath)
+    if va.ps.errored
+        cedarthrow(LoadError(abspath, 0, VAParseError(va)))
+    end
     cache_va!(cache.thismod, path, va; abspath)
     return va
 end

--- a/src/va_env.jl
+++ b/src/va_env.jl
@@ -130,6 +130,12 @@ end
 
 var"$temperature"() = CedarSim.undefault(CedarSim.spec[].temp)+273.15 # Kelvin
 
+# $port_connected(port) - returns 1 if the port is connected, 0 if floating
+# In MNA simulation, we assume all ports are connected
+export var"$port_connected", port_connected
+var"$port_connected"(port) = 1
+port_connected(port) = 1
+
 abstract type VAModel <: CedarSim.CircuitElement; end
 
 end

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -2263,11 +2263,12 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
             :($(Symbol("V_", i)) = $np == 0 ? 0.0 : (isempty(x) ? 0.0 : x[$np])))
     end
     # Internal nodes (from alloc_internal_node!)
+    # Note: Internal nodes can be aliased to terminals (including ground) via short-circuit detection
     for i in 1:n_internal
         idx = n_ports + i
         inp = internal_node_params[i]
         push!(voltage_extraction.args,
-            :($(Symbol("V_", idx)) = isempty(x) || $inp > length(x) ? 0.0 : x[$inp]))
+            :($(Symbol("V_", idx)) = $inp == 0 ? 0.0 : (isempty(x) || $inp > length(x) ? 0.0 : x[$inp])))
     end
 
     # Generate dual creation for all nodes (terminals + internal)

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -11,7 +11,7 @@ using VerilogAParser.VerilogACSTParser:
     AnalogConditionalBlock, AnalogVariableAssignment, AnalogProceduralAssignment,
     Parens, AnalogIf, AnalogFor, AnalogWhile, AnalogRepeat, UnaryOp, Function,
     AnalogSystemTaskEnable, StringLiteral,
-    CaseStatement, FunctionCall, TernaryExpr,
+    CaseStatement, FunctionCall, FunctionCallStatement, TernaryExpr,
     FloatLiteral, ChunkTree, virtrange,
     filerange, LineNumbers, compute_line,
     SystemIdentifier, Node, Identifier, IdentifierConcatItem,
@@ -468,6 +468,9 @@ end
 
 function (to_julia::Scope)(stmt::VANode{AnalogProceduralAssignment})
     return to_julia(stmt.assign)
+end
+function (to_julia::Scope)(stmt::VANode{FunctionCallStatement})
+    return to_julia(stmt.call)
 end
 function (to_julia::Scope)(stmt::VANode{AnalogVariableAssignment})
     assignee = Symbol(stmt.lvalue)
@@ -1477,6 +1480,9 @@ end
 
 function (to_julia::MNAScope)(stmt::VANode{AnalogProceduralAssignment})
     return to_julia(stmt.assign)
+end
+function (to_julia::MNAScope)(stmt::VANode{FunctionCallStatement})
+    return to_julia(stmt.call)
 end
 
 function (to_julia::MNAScope)(asb::VANode{AnalogSeqBlock})


### PR DESCRIPTION
- Add $port_connected system function to VerilogAEnvironment (required by BJT)
- Fix internal node voltage extraction to handle ground-aliased nodes (internal nodes can be aliased to node 0 via short-circuit detection)
- Add parse error checking to parse_and_cache_va!
- Add VADistiller tests for sp_bjt, sp_jfet1, sp_mes1 models
- Update documentation comments with current model status