### PR TITLE
Remove DAECompiler code from vasim.jl

### DIFF
--- a/ext/CedarSimReviseExt.jl
+++ b/ext/CedarSimReviseExt.jl
@@ -9,7 +9,7 @@ if isdefined(Revise, :is_same_file)
         if va.ps.errored
             throw(LoadError(file.file, 0, VAParseError(va)))
         end
-        ex = CedarSim.make_module(va)
+        ex = CedarSim.make_mna_module(va)
         Revise.process_source!(mod_exprs_sigs, ex, file, mod; kwargs...)
     end
     Revise.is_same_file(a::VAFile, b::String) = a.file == b

--- a/src/CedarSim.jl
+++ b/src/CedarSim.jl
@@ -108,7 +108,7 @@ using PrecompileTools
     """
     @compile_workload @time begin
         sa1 = VerilogAParser.parsefile(joinpath(@__DIR__, "../VerilogAParser.jl/test/inputs/resistor.va"))
-        code1 = CedarSim.make_module(sa1)
+        code1 = CedarSim.make_mna_module(sa1)
         sa2 = SpectreNetlistParser.parse(IOBuffer(spectre))
         code2 = CedarSim.make_spectre_circuit(sa2)
         sa3 = SpectreNetlistParser.parse(IOBuffer(spice); start_lang=:spice)

--- a/src/spc/sema.jl
+++ b/src/spc/sema.jl
@@ -797,7 +797,7 @@ end
 function sema_codegen_hdl(r::SemaResult)
     ret = Expr(:toplevel)
     for (_, (_, va)) in r.hdl_includes
-        push!(ret.args, CedarSim.make_module(va))
+        push!(ret.args, CedarSim.make_mna_module(va))
     end
     return ret
 end

--- a/src/spectre.jl
+++ b/src/spectre.jl
@@ -1412,7 +1412,7 @@ function source_body(n::SNode{<:SC.AbstractBlockASTNode},
             else
                 vamod = va.stmts[end]
                 name = Symbol(String(vamod.id))
-                kwargs[:ckts][name] = make_module(va)
+                kwargs[:ckts][name] = make_mna_module(va)
             end
         elseif isa(stmt, SNode{SC.Include})
             str = strip(unescape_string(String(stmt.filename)), '"') # verify??
@@ -1517,7 +1517,7 @@ function source_body(n::SNode{<:SP.AbstractBlockASTNode}, to_julia::SpcScope; in
                 macroname = Symbol("ckt_", lowercase(String(name)))
                 modname = Symbol(name, "_module")
                 kwargs[:ckts][name] = Expr(:toplevel,
-                    make_module(va),
+                    make_mna_module(va),
                     :(macro $macroname(🔍, nodes, args...)
                         dev = $modname.$name
                         esc(:(CedarSim.spicecall(CedarSim.ParsedModel($dev, (;)); $(args...))($nodes...)))

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -25,9 +25,6 @@ using ForwardDiff: Dual
 const VAT = VerilogAParser.VerilogATokenize
 
 const VANode = VerilogAParser.VerilogACSTParser.Node
-struct SimTag; end
-ForwardDiff.:(≺)(::Type{<:ForwardDiff.Tag}, ::Type{SimTag}) = true
-ForwardDiff.:(≺)(::Type{SimTag}, ::Type{<:ForwardDiff.Tag}) = false
 
 function eisa(e::VANode{S}, T::Type) where {S}
     S <: T
@@ -41,57 +38,7 @@ struct VAFunction
     inout_decls::Dict{Symbol, Symbol}
 end
 
-struct Scope
-    parameters::Set{Symbol}
-    node_order::Vector{Symbol}
-    ninternal_nodes::Int
-    branch_order::Vector{Pair{Symbol}}
-    used_branches::Set{Pair{Symbol}}
-    var_types::Dict{Symbol, Union{Type{Int}, Type{Float64}}}
-    all_functions::Dict{Symbol, VAFunction}
-    undefault_ids::Bool
-    ddx_order::Vector{Symbol}
-end
-Scope() = Scope(Set{Symbol}(), Vector{Symbol}(), 0, Vector{Pair{Symbol}}(), Set{Pair{Symbol}}(),
-    Dict{Symbol, Union{Type{Int}, Type{Float64}}}(), Dict{Symbol, VAFunction}(),
-    false, Vector{Symbol}())
-
-struct Pins
-    p::Any
-    n::Any
-end
-Base.reverse(p::Pins) = Pins(p.n, p.p)
-Base.getindex(p::Pins, i::Integer) = i == 1 ? p.p : i == 2 ? p.n : throw(BoundsError(p, i))
-
-struct BranchContribution
-    kind::BranchKind
-    pins::Pins
-    value::Any
-end
-
-function Base.LineNumberNode(n::VANode)
-    print_vr = (n.startof+n.expr.off):(n.startof+n.expr.off+n.expr.width-1)
-    tc = AbstractTrees.TreeCursor(ChunkTree(n.ps))
-    leaf = VerilogAParser.VerilogACSTParser.findleafbyvirtrange(Leaves(tc), first(print_vr))
-
-    # Compute line number
-    vr = virtrange(leaf)
-    fr = filerange(leaf)
-
-    startoff_file = first(fr) + (n.startof + n.expr.off - first(vr))
-
-    sf = n.ps.srcfiles[leaf.fidx]
-    lsf = sf.lineinfo
-
-    lno_first = compute_line(lsf, startoff_file)
-    LineNumberNode(lno_first, Symbol(sf.path))
-end
-
-
-function (::Scope)(cs::VANode{Literal})
-    Meta.parse(String(cs))
-end
-
+# Scale factor mapping for Verilog-A literals
 const sf_mapping = Dict(
     'T' => 1e12,
     'G' => 1e9,
@@ -104,79 +51,7 @@ const sf_mapping = Dict(
     'p' => 1e-12,
     'f' => 1e-15,
     'a' => 1e-18,
-);
-
-function (::Scope)(cs::VANode{FloatLiteral})
-    txt = String(cs)
-    sf = nothing
-    if is_scale_factor(txt[end])
-        sf = txt[end]
-        txt = txt[1:end-1]
-    end
-    ret = Base.parse(Float64, txt)
-    if sf !== nothing
-        ret *= sf_mapping[sf]
-    end
-    return ret
-end
-
-function (to_julia::Scope)(cs::VANode{ContributionStatement})
-    bpfc = cs.lvalue
-    kind = Symbol(bpfc.id)
-    # TODO: Look at disciplines
-    if kind == :I
-        kind = CURRENT
-    elseif kind == :V
-        kind = VOLTAGE
-    else
-        return :(error("Unknown branch contribution kind"))
-    end
-
-    refs = map(bpfc.references) do ref
-        Symbol(assemble_id_string(ref.item))
-    end
-
-    if length(refs) == 1
-        node = refs[1]
-        svar = Symbol("branch_state_", node, "_0")
-        eqvar = Symbol("branch_value_", node, "_0")
-        push!(to_julia.used_branches, node => Symbol("0"))
-        return quote
-            if $svar != $kind
-                $eqvar = 0.0
-                $svar = $kind
-            end
-            $eqvar += $(ForwardDiff.value)($(SimTag),$(to_julia(cs.assign_expr)))
-        end
-    elseif length(refs) == 2
-        (id1, id2) = refs
-
-        idx = findfirst(to_julia.branch_order) do branch
-            branch == (id1 => id2) || branch == (id2 => id1)
-        end
-        @assert idx !== nothing
-        branch = to_julia.branch_order[idx]
-        push!(to_julia.used_branches, branch)
-        reversed = branch == (id2 => id1)
-
-        s = gensym()
-
-        svar = Symbol("branch_state_", branch[1], "_", branch[2])
-        eqvar = Symbol("branch_value_", branch[1], "_", branch[2])
-        return @nolines quote
-            if $svar != $kind
-                $eqvar = 0.0
-                $svar = $kind
-            end
-            $s = $(to_julia(cs.assign_expr))
-            $eqvar += $(ForwardDiff.value)($(SimTag), $(reversed ? :(-$s) : s))
-        end
-    end
-end
-
-function (to_julia::Scope)(bpfc::VANode{BPFC})
-    Expr(:call, Symbol(bpfc.id), map(x->Symbol(x.item), bpfc.references)...)
-end
+)
 
 function assemble_id_string(id)
     if isa(id, Node{SystemIdentifier})
@@ -194,459 +69,7 @@ function assemble_id_string(id)
     end
 end
 
-function (scope::Scope)(ip::VANode{IdentifierPrimary})
-    id = Symbol(assemble_id_string(ip.id))
-    if scope.undefault_ids
-        id = Expr(:call, undefault, id)
-    end
-    id
-end
-
-function (scope::Scope)(ip::VANode{SystemIdentifier})
-    id = Symbol(ip)
-    # Is this really the right place for these? These are kind function calls
-    # without arguments in the spec.
-    if id == Symbol("\$temperature")
-        return Expr(:call, id)
-    else
-        error()
-    end
-end
-
-function (to_julia::Scope)(cs::VANode{BinaryExpression})
-    op = Symbol(cs.op)
-    #if op in (:(||), :(&&))
-    #    return Expr(op, to_julia(cs.lhs), to_julia(cs.rhs))
-    if op == :(||)
-        return Expr(:call, (|), to_julia(cs.lhs), to_julia(cs.rhs))
-    elseif op == :(&&)
-        return Expr(:call, (&), to_julia(cs.lhs), to_julia(cs.rhs))
-    else
-        return Expr(:call, op, to_julia(cs.lhs), to_julia(cs.rhs))
-    end
-end
-
-function (to_julia::Scope)(asb::VANode{AnalogSeqBlock})
-    if asb.decl !== nothing
-        block_var_types = copy(to_julia.var_types)
-
-        for decl in asb.decl.decls
-            item = decl.item
-            @case formof(item) begin
-                IntRealDeclaration => begin
-                    T = kw_to_T(item.kw.kw)
-                    for ident in item.idents
-                        # ident.item is IntRealVarDecl with id, eq, init fields
-                        vardecl = ident.item
-                        name = Symbol(assemble_id_string(vardecl.id))
-                        block_var_types[name] = T
-                    end
-                end
-            end
-        end
-
-        to_julia_block = Scope(to_julia.parameters,
-            to_julia.node_order, to_julia.ninternal_nodes, to_julia.branch_order,
-            to_julia.used_branches, block_var_types, to_julia.all_functions,
-            to_julia.undefault_ids, to_julia.ddx_order)
-    else
-        to_julia_block = to_julia
-    end
-    ret = Expr(:block)
-    last_lno = nothing
-    for stmt in asb.stmts
-        lno = LineNumberNode(stmt)
-        if lno != last_lno
-            push!(ret.args, lno)
-        end
-        push!(ret.args, to_julia_block(stmt))
-    end
-    ret
-end
-
-abstract type SemaError <: CedarException; end
-
-struct DuplicateDef <: SemaError
-    name::Symbol
-end
-
-struct NoArguments <: SemaError; end
-struct MissingTypeDecl <: SemaError
-    name::Symbol
-end
-
-
-function validate_parameters(type_decls, inout_decls)
-    isempty(inout_decls) && throw(NoArguments())
-    for key in keys(inout_decls)
-        haskey(type_decls, key) || throw(MissingTypeDecl(key))
-    end
-end
-
 kw_to_T(kw::Kind) = kw === REAL ? Float64 : Int
-
-(to_julia::Scope)(stmt::VANode{AnalogStatement}) = to_julia(stmt.stmt)
-
-function (to_julia::Scope)(stmt::VANode{AnalogConditionalBlock})
-    aif = stmt.aif
-    function if_body_to_julia(ifstmt)
-        if formof(ifstmt) == AnalogSeqBlock
-            return to_julia(ifstmt)
-        else
-            return Expr(:block, LineNumberNode(ifstmt), to_julia(ifstmt))
-        end
-    end
-
-    # Convert VA condition to boolean - in VA, integers are truthy (non-zero = true)
-    function va_condition_to_bool(cond_expr)
-        :(!(iszero($(to_julia(cond_expr)))))
-    end
-
-    ifex = ex = Expr(:if, va_condition_to_bool(aif.condition), if_body_to_julia(aif.stmt))
-    for case in stmt.elsecases
-        if formof(case.stmt) == AnalogIf
-            elif = case.stmt
-            newex = Expr(:elseif, va_condition_to_bool(elif.condition), if_body_to_julia(elif.stmt))
-            push!(ex.args, newex)
-            ex = newex
-        else
-            push!(ex.args, if_body_to_julia(case.stmt))
-        end
-    end
-    ifex
-end
-
-function (to_julia::Scope)(stmt::VANode{AnalogFor})
-    body = to_julia(stmt.stmt)
-    push!(body.args, to_julia(stmt.update_stmt))
-    # Convert condition to bool (VA integers are truthy)
-    cond_bool = :(!(iszero($(to_julia(stmt.cond_expr)))))
-    while_expr = Expr(:while, cond_bool, body)
-    Expr(:block, to_julia(stmt.init_stmt), while_expr)
-end
-
-function (to_julia::Scope)(stmt::VANode{AnalogWhile})
-    body = to_julia(stmt.stmt)
-    # Convert condition to bool (VA integers are truthy)
-    cond_bool = :(!(iszero($(to_julia(stmt.cond_expr)))))
-    Expr(:while, cond_bool, body)
-end
-
-function (to_julia::Scope)(stmt::VANode{AnalogRepeat})
-    body = to_julia(stmt.stmt)
-    Expr(:for, :(_ = 1:$(stmt.num_repeat)), body)
-end
-
-function (to_julia::Scope)(stmt::VANode{UnaryOp})
-    return Expr(:call, Symbol(stmt.op), to_julia(stmt.operand))
-end
-
-function (to_julia::Scope)(stmt::VANode{FunctionCall})
-    fname = Symbol(stmt.id)
-    if fname == Symbol("\$param_given")
-        id = Symbol(stmt.args[1].item)
-        return Expr(:call, !, Expr(:call, isdefault,
-            Expr(:call, getfield, Symbol("#self#"), QuoteNode(id))))
-    end
-
-    # TODO: Rather than hardcoding this, this should look at the list of
-    # defined disciplines
-    if fname == :V
-        function Vref(id)
-            id_idx = findfirst(==(id), to_julia.ddx_order)
-            if id_idx !== nothing
-                return Expr(:call, Dual{SimTag}, id,
-                        Expr(:(...), ntuple(i->i == id_idx ? 1.0 : 0.0, length(to_julia.ddx_order)))
-                )
-            else
-                return id
-            end
-        end
-
-        @assert length(stmt.args) in (1,2)
-        id1 = Symbol(stmt.args[1].item)
-        id2 = length(stmt.args) > 1 ? Symbol(stmt.args[2].item) : nothing
-
-        if id2 === nothing
-            push!(to_julia.used_branches, id1 => Symbol("0"))
-            return Vref(id1)
-        else
-            idx = findfirst(to_julia.branch_order) do branch
-                branch == (id1 => id2) || branch == (id2 => id1)
-            end
-            @assert idx !== nothing
-            branch = to_julia.branch_order[idx]
-            push!(to_julia.used_branches, branch)
-            return :($(Vref(id1)) - $(Vref(id2)))
-        end
-    elseif fname == :I
-        @assert length(stmt.args) == 2
-        id1 = Symbol(stmt.args[1].item)
-        id2 = Symbol(stmt.args[2].item)
-
-        idx = findfirst(to_julia.branch_order) do branch
-            branch == (id1 => id2) || branch == (id2 => id1)
-        end
-        @assert idx !== nothing
-
-        branch = to_julia.branch_order[idx]
-        reversed = branch == (id2 => id1)
-        push!(to_julia.used_branches, branch)
-
-        ex = :(error("TODO"))
-        reversed && (ex = :(-$ex))
-        return ex
-    elseif fname == :ddx
-        item = stmt.args[2].item
-        @assert formof(item) == FunctionCall
-        @assert Symbol(item.id) == :V
-        if length(item.args) == 1
-            probe = Symbol(item.args[1].item)
-            id_idx = findfirst(==(probe), to_julia.ddx_order)
-            return :(let x = $(to_julia(stmt.args[1].item))
-                $(isa)(x, $(Dual)) ? (@inbounds $(ForwardDiff.partials)($(SimTag), x, $id_idx)) : 0.0
-            end)
-        else
-            probe1 = Symbol(item.args[1].item)
-            id1_idx = findfirst(==(probe1), to_julia.ddx_order)
-            probe2 = Symbol(item.args[2].item)
-            id2_idx = findfirst(==(probe2), to_julia.ddx_order)
-            return :(let x = $(to_julia(stmt.args[1].item)),
-                        dx1 = $(isa)(x, $(Dual)) ? (@inbounds $(ForwardDiff.partials)($(SimTag), x, $id1_idx)) : 0.0,
-                        dx2 = $(isa)(x, $(Dual)) ? (@inbounds $(ForwardDiff.partials)($(SimTag), x, $id2_idx)) : 0.0
-                (dx1-dx2)/2
-            end)
-        end
-    elseif fname ∈ (:white_noise, :flicker_noise)
-        args = map(x->to_julia(x.item), stmt.args)
-        ϵ = Symbol(:ϵ, gensym(last(args)))
-        args[end] = QuoteNode(ϵ)
-        return Expr(:call, fname, :dscope, args...)
-    end
-
-    vaf = get(to_julia.all_functions, fname, nothing)
-    if vaf !== nothing
-        # Call to a Verilog-A defined function
-        args = map(x->to_julia(x.item), stmt.args)
-        in_args = Any[]
-        out_args = Any[]
-
-        if length(args) != length(vaf.arg_order)
-            # TODO: Fancy diagnostic
-            return Expr(:call, error, "Wrong number of arguments to function $fname ($args, $(vaf.arg_order)")
-        end
-
-        for (arg, vaarg) in zip(args, vaf.arg_order)
-            kind = vaf.inout_decls[vaarg]
-            if kind == :output || kind == :inout
-                isa(arg, Symbol) || return Expr(:call, error, "Output argument $vaarg to function $fname must be a symbol. Got $arg.")
-                push!(out_args, arg)
-            end
-            if kind == :input || kind == :inout
-                push!(in_args, arg)
-            end
-        end
-        ret = Expr(:call, fname, in_args...)
-        if length(out_args) != 0
-            s = gensym()
-            ret = @nolines quote
-                ($s, ($(out_args...),)) = $ret
-                $s
-            end
-        end
-        return ret
-    end
-
-    return Expr(:call, fname, map(x->to_julia(x.item), stmt.args)...)
-end
-
-function (to_julia::Scope)(stmt::VANode{AnalogProceduralAssignment})
-    return to_julia(stmt.assign)
-end
-function (to_julia::Scope)(stmt::VANode{FunctionCallStatement})
-    return to_julia(stmt.call)
-end
-function (to_julia::Scope)(stmt::VANode{AnalogVariableAssignment})
-    assignee = Symbol(stmt.lvalue)
-    varT = get(to_julia.var_types, assignee, nothing)
-    assignee === nothing && cedarerror("Undeclared variable: $assignee")
-
-    eq = stmt.eq.op
-
-    op = eq == VAT.EQ             ?  :(=) :
-         eq == VAT.STAR_STAR_EQ   ?  :(=) : # Extra handling below
-         eq == VAT.PLUS_EQ        ? :(+=) :
-         eq == VAT.MINUS_EQ       ? :(-=) :
-         eq == VAT.STAR_EQ        ? :(*=) :
-         eq == VAT.SLASH_EQ       ? :(/=) :
-         eq == VAT.PERCENT_EQ     ? :(%=) :
-         eq == VAT.AND_EQ         ? :(&=) :
-         eq == VAT.OR_EQ          ? :(|=) :
-         eq == VAT.XOR_EQ         ? :(^=) :
-         eq == VAT.LBITSHIFT_EQ   ? :(<<=) :
-         eq == VAT.RBITSHIFT_EQ   ? :(>>=) :
-         eq == VAT.LBITSHIFT_A_EQ ? :(=) : # Extra handling below
-         eq == VAT.RBITSHIFT_A_EQ ? :(>>>=) :
-         cedarerror("Unsupported assignment operator: $eq")
-
-    req = Expr(op, assignee, varT === nothing ? Expr(:call, error, "Unknown type for variable $assignee") :
-        Expr(:call, VerilogAEnvironment.vaconvert, varT, to_julia(stmt.rvalue)))
-
-    if eq == VAT.STAR_STAR_EQ
-        req = Expr(op, assignee, Expr(:call, var"**", req.args...))
-    elseif eq === VAT.LBITSHIFT_A_EQ
-        req = Expr(op, assignee, Expr(:call, var"<<<", req.args...))
-    end
-
-    return req
-end
-
-function (to_julia::Scope)(stmt::VANode{Parens})
-    return to_julia(stmt.inner)
-end
-
-function (to_julia::Scope)(cs::VANode{TernaryExpr})
-    # Convert condition to bool (VA integers are truthy)
-    cond_bool = :(!(iszero($(to_julia(cs.condition)))))
-    return Expr(:if, cond_bool, to_julia(cs.ifcase), to_julia(cs.elsecase))
-end
-
-
-function (to_julia::Scope)(fd::VANode{AnalogFunctionDeclaration})
-    type_decls = Dict{Symbol, Any}()
-    inout_decls = Dict{Symbol, Symbol}()
-    fname = Symbol(fd.id)
-    var_types = Dict{Symbol, Union{Type{Int}, Type{Float64}}}()
-    # 4.7.1
-    # The analog_function_type specifies the return value of the function;
-    # its use is optional. type can be a real or an integer; if unspecified,
-    # the default is real.
-    rt = fd.fty === nothing ? Real : kw_to_T(fd.fty.kw)
-    var_types[fname] = rt
-    arg_order = Symbol[]
-    for decl in fd.items
-        item = decl.item
-        @case formof(item) begin
-            InOutDeclaration => begin
-                kind = item.kw.kw === INPUT ?  :input :
-                       item.kw.kw === OUTPUT ? :output :
-                                               :inout
-                for name in item.portnames
-                    ns = Symbol(name.item)
-                    haskey(inout_decls, ns) && throw(DuplicateDef(name))
-                    # NB: Don't think this is technically forbidden by the standard
-                    ns == fname && throw(DuplicateDef(ns))
-                    inout_decls[ns] = kind
-                    push!(arg_order, ns)
-                end
-            end
-            IntRealDeclaration => begin
-                T = kw_to_T(item.kw.kw)
-                for ident in item.idents
-                    # ident.item is IntRealVarDecl with id, eq, init fields
-                    vardecl = ident.item
-                    ns = Symbol(assemble_id_string(vardecl.id))
-                    haskey(type_decls, ns) && throw(DuplicateDef(ns))
-                    ns == fname && throw(DuplicateDef(ns))
-                    var_types[ns] = T
-                end
-            end
-            _ => cedarerror("Unknown function declaration item")
-        end
-    end
-
-    to_julia_internal = Scope(to_julia.parameters, to_julia.node_order,
-        to_julia.ninternal_nodes, to_julia.branch_order, to_julia.used_branches, var_types,
-        to_julia.all_functions, to_julia.undefault_ids, to_julia.ddx_order)
-
-    validate_parameters(var_types, inout_decls)
-    out_args = [k for k in arg_order if inout_decls[k] in (:output, :inout)]
-    in_args = [k for k in arg_order if inout_decls[k] in (:input, :inout)]
-    rt_decl = length(out_args) == 0 ? fname : :(($fname, ($(out_args...),)))
-
-    to_julia.all_functions[fname] = VAFunction(arg_order, inout_decls)
-
-    localize_vars = Any[]
-    for var in keys(var_types)
-        var in arg_order && continue
-        push!(localize_vars, :(local $var))
-    end
-
-    return @nolines quote
-        @inline function $fname($(in_args...))
-            $(localize_vars...)
-            local $fname = $(VerilogAEnvironment.vaconvert)($rt, 0)
-            $(to_julia_internal(fd.stmt))
-            return $rt_decl
-        end
-    end
-end
-
-function (to_julia::Scope)(stmt::VANode{StringLiteral})
-    return String(stmt)[2:end-1]
-end
-
-const systemtaskenablemap = Dict{Symbol, Function}(
-    Symbol("\$ln")=>Base.log, Symbol("\$log10")=>log10, Symbol("\$exp")=>exp, Symbol("\$sqrt")=>sqrt,
-    Symbol("\$sin")=>sin, Symbol("\$cos")=>cos, Symbol("\$tan")=>tan,
-    Symbol("\$asin")=>asin, Symbol("\$acos")=>acos, Symbol("\$atan")=>atan, Symbol("\$atan2")=>atan,
-    Symbol("\$sinh")=>sinh, Symbol("\$cos")=>cosh, Symbol("\$tan")=>tanh,
-    Symbol("\$asinh")=>asinh, Symbol("\$acosh")=>acosh, Symbol("\$atanh")=>atanh,
-    Symbol("\$error")=>error)
-function (to_julia::Scope)(stmt::VANode{AnalogSystemTaskEnable})
-    if formof(stmt.task) == FunctionCall
-        fc = stmt.task
-        fname = Symbol(fc.id)
-        args = map(x->to_julia(x.item), fc.args)
-        if fname in keys(systemtaskenablemap)
-            return Expr(:call, systemtaskenablemap[fname], args...)
-        elseif fname == Symbol("\$strobe")
-            # TODO: Need to guard this with convergence conditions
-            return nothing # Expr(:call, println, args...)
-        elseif fname == Symbol("\$warning")
-            warn = GlobalRef(Base, Symbol("@warn"))
-            return nothing # Expr(:macrocall, warn, LineNumberNode(stmt), args..., :(maxlog=1))
-        else
-            cedarerror("Verilog task unimplmented: $fname")
-        end
-    else
-        error()
-    end
-end
-
-function (to_julia::Scope)(stmt::VANode{CaseStatement})
-    s = gensym()
-    first = true
-    expr = nothing
-    default_case = nothing
-    for case in stmt.cases
-        if isa(case.conds, Node)
-            # Default case
-            default_case = to_julia(case.item)
-        else
-            conds = map(cond->:($s == $(to_julia(cond.item))), case.conds)
-            cond = length(conds) == 1 ? conds[1] : Expr(:(||), conds...)
-            ex = Expr(first ? :if : :elseif, cond, to_julia(case.item))
-            if first
-                expr = ex
-                first = false
-            else
-                push!(expr.args, ex)
-            end
-        end
-    end
-    default_case !== nothing && (push!(expr.args, default_case))
-    Expr(:block, :($s = $(to_julia(stmt.switch))), expr)
-end
-
-function (to_julia::Scope)(stmt::VANode{Attributes})
-    res = Dict{Symbol, Any}()
-    for attr in stmt.specs
-        item = attr.item
-        res[Symbol(item.name)] = to_julia(item.val)
-    end
-    return res
-end
 
 function pins(vm::VANode{VerilogModule})
     plist = vm.port_list
@@ -722,14 +145,17 @@ function make_mna_device(vm::VANode{VerilogModule})
     struct_fields = Any[]
     parameter_names = Set{Symbol}()
     param_defaults = Dict{Symbol, Any}()  # Store parameter default expressions
-    to_julia_global = Scope()
-    find_ddx!(to_julia_global.ddx_order, vm)
 
-    to_julia_defaults = Scope(to_julia_global.parameters,
-        to_julia_global.node_order, to_julia_global.ninternal_nodes,
-        to_julia_global.branch_order, to_julia_global.used_branches,
-        to_julia_global.var_types, to_julia_global.all_functions,
-        true, to_julia_global.ddx_order)
+    # Find ddx order for derivatives
+    ddx_order = Vector{Symbol}()
+    find_ddx!(ddx_order, vm)
+
+    # Create scope for translating parameter defaults (undefault_ids=true)
+    to_julia_defaults = MNAScope(Set{Symbol}(), Vector{Symbol}(), 0,
+        Vector{Pair{Symbol}}(), Set{Pair{Symbol}}(),
+        Dict{Symbol, Union{Type{Int}, Type{Float64}}}(),
+        Dict{Symbol, VAFunction}(), true, ddx_order,
+        Dict{Symbol, Pair{Symbol,Symbol}}())
 
     internal_nodes = Vector{Symbol}()
     var_types = Dict{Symbol, Union{Type{Int}, Type{Float64}}}()
@@ -833,7 +259,7 @@ function make_mna_device(vm::VANode{VerilogModule})
         Set{Pair{Symbol}}(),
         var_types,
         Dict{Symbol, VAFunction}(), false,
-        to_julia_global.ddx_order,
+        ddx_order,
         named_branches)
 
     # Generate analog block code
@@ -1008,12 +434,31 @@ struct MNAScope
     named_branches::Dict{Symbol, Pair{Symbol,Symbol}}  # Maps branch name -> (pos, neg) nodes
 end
 
-# Forward basic translations to Scope
-(s::MNAScope)(x::VANode{Literal}) = Scope()(x)
-(s::MNAScope)(x::VANode{FloatLiteral}) = Scope()(x)
+# Literal parsing methods
+function (::MNAScope)(cs::VANode{Literal})
+    Meta.parse(String(cs))
+end
+
+function (::MNAScope)(cs::VANode{FloatLiteral})
+    txt = String(cs)
+    sf = nothing
+    if is_scale_factor(txt[end])
+        sf = txt[end]
+        txt = txt[1:end-1]
+    end
+    ret = Base.parse(Float64, txt)
+    if sf !== nothing
+        ret *= sf_mapping[sf]
+    end
+    return ret
+end
 
 function (scope::MNAScope)(ip::VANode{IdentifierPrimary})
-    Symbol(assemble_id_string(ip.id))
+    id = Symbol(assemble_id_string(ip.id))
+    if scope.undefault_ids
+        id = Expr(:call, undefault, id)
+    end
+    id
 end
 
 function (to_julia::MNAScope)(cs::VANode{BinaryExpression})


### PR DESCRIPTION
- Remove USE_DAECOMPILER conditional imports and DAECompiler.ddt extension
- Remove make_spice_device function that generated DAECompiler code
- Remove make_module function that wrapped make_spice_device
- Update all references to use make_mna_module instead of make_module
- Clean up comments and docstrings referencing DAECompiler

The MNA backend is now the sole VA code generator. All 351 core MNA tests and 49 VA tests continue to pass.