### PR TITLE
Fix PSP103 VACASK benchmark issues

### DIFF
--- a/benchmarks/vacask/c6288/cedarsim/runme.jl
+++ b/benchmarks/vacask/c6288/cedarsim/runme.jl
@@ -35,12 +35,12 @@ else
 end
 
 # Load and parse the SPICE netlist from file
+# Use parse_spice_file_to_mna to preserve file path context for .include resolution
 const spice_file = joinpath(@__DIR__, "runme.sp")
-const spice_code = read(spice_file, String)
 
-# Parse SPICE to code, then evaluate to get the builder function
-const circuit_code = parse_spice_to_mna(spice_code; circuit_name=:c6288_circuit,
-                                         imported_hdl_modules=[PSP103VA_module])
+# Parse SPICE file to code, then evaluate to get the builder function
+const circuit_code = parse_spice_file_to_mna(spice_file; circuit_name=:c6288_circuit,
+                                              imported_hdl_modules=[PSP103VA_module])
 eval(circuit_code)
 
 """

--- a/src/CedarSim.jl
+++ b/src/CedarSim.jl
@@ -34,7 +34,7 @@ export @dyn, @requires, @provides, @isckt_or
 export solve
 
 # Phase 4: MNA SPICE codegen exports
-export make_mna_circuit, parse_spice_to_mna, solve_spice_mna
+export make_mna_circuit, parse_spice_to_mna, parse_spice_file_to_mna, solve_spice_mna
 export @mna_sp_str
 
 # PDK/VA precompilation exports

--- a/src/spc/interface.jl
+++ b/src/spc/interface.jl
@@ -203,6 +203,24 @@ function parse_spice_to_mna(spice_code::String; circuit_name::Symbol=:circuit,
 end
 
 """
+    parse_spice_file_to_mna(filepath::AbstractString; circuit_name=:circuit, imported_hdl_modules=Module[])
+
+Parse a SPICE netlist file and generate an MNA builder function.
+This variant preserves the file path context for resolving relative includes.
+
+# Example
+```julia
+circuit_code = parse_spice_file_to_mna("circuit.sp"; circuit_name=:my_circuit)
+eval(circuit_code)
+```
+"""
+function parse_spice_file_to_mna(filepath::AbstractString; circuit_name::Symbol=:circuit,
+                                  imported_hdl_modules::Vector{Module}=Module[])
+    ast = SpectreNetlistParser.parsefile(filepath; start_lang=:spice, implicit_title=true)
+    return make_mna_circuit(ast; circuit_name, imported_hdl_modules)
+end
+
+"""
     solve_spice_mna(spice_code::String; temp=27.0)
 
 Parse SPICE code, build MNA circuit, and solve DC operating point.


### PR DESCRIPTION
This commit fixes multiple issues preventing PSP103-based circuits from running in the VACASK benchmarks:

1. Branch current handling in vasim.jl: Initialize _I_branch_XXX variables to 0.0 for named branches without voltage contributions (noise branches)

2. VoltageSource scope in SPICE codegen: Add necessary MNA imports to generated circuit code

3. Singular matrix issue: Implement hierarchical instance naming for internal nodes and current variables to prevent name collisions across multiple VA device instances. Added _mna_prefix_ parameter to subcircuit builders for proper hierarchical path tracking.

4. GMIN stamping: Added global GMIN (1e-12) to all voltage nodes in assemble_G to prevent floating node singularities

5. Include resolution: Added parse_spice_file_to_mna for file-based parsing that preserves path context for .include statements

6. GlobalStatement support: Added handling for .global statements in sema

The ring oscillator benchmark now runs successfully (builds, assembles, and attempts transient simulation). The c6288 multiplier benchmark loads but requires optimization for the large circuit size.