### PR TITLE
Add @inline to contribution functions for constant-folding

### DIFF
--- a/doc/inlining_investigation.md
+++ b/doc/inlining_investigation.md
@@ -1,0 +1,142 @@
+# @inline Investigation for Allocation Reduction
+
+## Summary
+
+This document summarizes the investigation into how careful application of `@inline` can reduce allocations in MNA residual functions, particularly for Verilog-A modules.
+
+## Key Insight
+
+If Julia can see the definition and use of a struct (through inlining), it can constant-fold its properties, eliminating:
+1. Runtime type dispatch on Dual numbers
+2. Conditional branches based on contribution types (ContributionTag vs pure Dual vs scalar)
+3. Unnecessary allocations for intermediate values
+
+## Changes Made
+
+### 1. contrib.jl - Contribution Functions
+
+Added `@inline` to the following functions that were previously NOT inlined:
+
+| Function | Line | Purpose |
+|----------|------|---------|
+| `stamp_contribution!` | 151 | Low-level stamping with pre-computed values |
+| `evaluate_contribution` | 220 | Evaluates contribution and extracts Jacobians via AD |
+| `stamp_current_contribution!` | 316 | Main entry point for VA contribution stamping |
+| `stamp_voltage_contribution!` | 359 | Stamps voltage contributions with current variables |
+| `evaluate_charge_contribution` | 420 | Evaluates charge function and extracts capacitances |
+| `stamp_charge_contribution!` | 489 | Stamps voltage-dependent charge contributions |
+| `stamp_multiport_charge!` | 563 | Stamps multi-terminal charge contributions |
+
+These functions were already calling inlined primitives (`stamp_G!`, `stamp_C!`, `stamp_b!`, `va_ddt`) but weren't inlined themselves, creating a barrier to type inference.
+
+### 2. vasim.jl - Generated stamp! Method
+
+Added `@inline` to the generated `stamp!` method at line 1733.
+
+This is **critical** because the generated code contains runtime type dispatch:
+
+```julia
+if I_branch isa ForwardDiff.Dual{CedarSim.MNA.ContributionTag}
+    # Has ddt: ContributionTag wraps voltage duals
+    I_resist = ForwardDiff.value(I_branch)
+    ...
+elseif I_branch isa ForwardDiff.Dual
+    # Pure resistive: just voltage dual
+    ...
+else
+    # Scalar result
+    ...
+end
+```
+
+With `@inline`, when the caller can see the type of `I_branch` (which is determined statically by whether `va_ddt()` is called in the contribution expression), these branches can be eliminated at compile time.
+
+### 3. precompile.jl - Update Functions
+
+Added `@inline` to:
+
+| Function | Line | Purpose |
+|----------|------|---------|
+| `update_sparse_from_coo!` | 378 | Updates sparse matrix values in-place from COO |
+| `update_b_vector!` | 400 | Updates b vector from direct and deferred stamps |
+
+These are called during every Newton iteration in `fast_rebuild!`.
+
+## Why Inlining Helps
+
+### Before Inlining
+
+When `evaluate_contribution` is not inlined, Julia sees:
+
+```julia
+result = evaluate_contribution(contrib_fn, Vp, Vn)
+```
+
+The return type is a NamedTuple with several Float64 fields, but Julia can't specialize on whether `has_reactive` is true or false at compile time.
+
+### After Inlining
+
+With `@inline`, the entire evaluation chain inlines:
+
+```julia
+# All of this gets inlined:
+Vp_dual = Dual{JacobianTag}(Vp, one(Vp), zero(Vp))
+Vn_dual = Dual{JacobianTag}(Vn, zero(Vn), one(Vn))
+result = contrib_fn(Vpn_dual)  # Type known at compile time!
+
+if result isa ForwardDiff.Dual{ContributionTag}
+    # This branch can be constant-folded if contrib_fn's return type is known
+    ...
+end
+```
+
+Since `contrib_fn` typically contains `va_ddt()` calls (or not), its return type is statically determined, allowing the type checks to be eliminated.
+
+## Relationship to va_zero_allocation_plan.md
+
+This investigation corresponds to **Phase 3** of the zero-allocation plan:
+
+> **Phase 3: Aggressive Inlining for Constant Folding**
+>
+> The current code uses runtime `isa` checks that can be constant-folded with aggressive inlining.
+
+The changes in this PR enable:
+1. Type inference to propagate through the evaluation chain
+2. Runtime type checks to become compile-time decisions
+3. Dual number operations to be lowered to simple scalar arithmetic
+
+## Test Results
+
+All tests pass with the @inline changes:
+- **MNA Core Tests**: 351/351 passed
+- **MNA VA Integration Tests**: 49/49 passed
+
+## Remaining Work
+
+While `@inline` helps with constant folding, the main allocation source remains:
+
+```julia
+function fast_rebuild!(pc::PrecompiledCircuit, u::Vector{Float64}, t::Real)
+    ctx = pc.builder(pc.params, spec_t; x=u)  # <-- Allocates ~2KB per call
+    ...
+end
+```
+
+Phase 4 of the zero-allocation plan addresses this by adding a "value-only stamping mode" where devices write directly to pre-discovered COO locations without creating an MNAContext.
+
+## Expected Impact
+
+The `@inline` changes should:
+1. **Reduce dynamic dispatch** in the contribution evaluation path
+2. **Enable branch elimination** for devices with known ddt/no-ddt patterns
+3. **Improve code quality** by letting LLVM see through the abstraction layers
+
+Actual allocation reduction depends on how well Julia can specialize the code paths. The main allocation in `fast_rebuild!` (creating MNAContext) requires Phase 4 changes to eliminate.
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `src/mna/contrib.jl` | Added `@inline` to 7 functions |
+| `src/mna/precompile.jl` | Added `@inline` to 2 functions |
+| `src/vasim.jl` | Added `@inline` to generated `stamp!` method |

--- a/src/mna/contrib.jl
+++ b/src/mna/contrib.jl
@@ -148,7 +148,7 @@ Reactive part stamps:
 - C[p,p] += ∂q/∂Vp, C[p,n] += ∂q/∂Vn
 - C[n,p] -= ∂q/∂Vp, C[n,n] -= ∂q/∂Vn
 """
-function stamp_contribution!(
+@inline function stamp_contribution!(
     ctx::MNAContext,
     p::Int, n::Int,
     I_val::Real, I_jac_p::Real, I_jac_n::Real,
@@ -217,7 +217,7 @@ result = evaluate_contribution(contrib, 1.0, 0.0)
 # result.dq_dVp ≈ C
 ```
 """
-function evaluate_contribution(contrib_fn, Vp::Real, Vn::Real)
+@inline function evaluate_contribution(contrib_fn, Vp::Real, Vn::Real)
     # Create voltage duals for Jacobian computation
     # JacobianTag ≺ ContributionTag ensures ContributionTag is always outer
     Vp_dual = Dual{JacobianTag}(Vp, one(Vp), zero(Vp))  # ∂/∂Vp = 1, ∂/∂Vn = 0
@@ -313,7 +313,7 @@ stamp_current_contribution!(ctx, p, n, V -> V/R + C * va_ddt(V), x)
 stamp_current_contribution!(ctx, p, n, V -> Is*(exp(V/Vt) - 1), x)
 ```
 """
-function stamp_current_contribution!(
+@inline function stamp_current_contribution!(
     ctx::MNAContext,
     p::Int, n::Int,
     contrib_fn,
@@ -356,7 +356,7 @@ Adds a current variable I and stamps:
 - G[I, p] = 1, G[I, n] = -1 (voltage constraint)
 - b[I] = v_fn(x) (voltage value)
 """
-function stamp_voltage_contribution!(
+@inline function stamp_voltage_contribution!(
     ctx::MNAContext,
     p::Int, n::Int,
     v_fn,
@@ -417,7 +417,7 @@ result = evaluate_charge_contribution(q_fn, 0.3, 0.0)
 # result.C gives the voltage-dependent capacitance at V=0.3
 ```
 """
-function evaluate_charge_contribution(q_fn, Vp::Real, Vn::Real)
+@inline function evaluate_charge_contribution(q_fn, Vp::Real, Vn::Real)
     # Create voltage duals for Jacobian computation
     Vp_dual = Dual{JacobianTag}(Vp, one(Vp), zero(Vp))  # ∂/∂Vp = 1, ∂/∂Vn = 0
     Vn_dual = Dual{JacobianTag}(Vn, zero(Vn), one(Vn))  # ∂/∂Vp = 0, ∂/∂Vn = 1
@@ -486,7 +486,7 @@ For charge q(V) at branch (p,n):
 
 The current I = dq/dt flows from p to n (positive current leaves p).
 """
-function stamp_charge_contribution!(
+@inline function stamp_charge_contribution!(
     ctx::MNAContext,
     p::Int, n::Int,
     q_fn,
@@ -560,7 +560,7 @@ stamp_multiport_charge!(ctx, (d, g, s, b), mosfet_charges, x)
 For each terminal pair (i, j), stamps:
 - C[i, j] += ∂qi/∂Vj (capacitance from node j affecting charge at node i)
 """
-function stamp_multiport_charge!(
+@inline function stamp_multiport_charge!(
     ctx::MNAContext,
     nodes::NTuple{N,Int},
     q_fn,

--- a/src/mna/precompile.jl
+++ b/src/mna/precompile.jl
@@ -375,7 +375,7 @@ This handles duplicate COO entries (same (i,j)) by accumulation.
 # Complexity
 O(nnz) - linear in number of nonzeros, no allocation or sorting.
 """
-function update_sparse_from_coo!(S::SparseMatrixCSC, V::Vector{Float64},
+@inline function update_sparse_from_coo!(S::SparseMatrixCSC, V::Vector{Float64},
                                   mapping::Vector{Int}, n_entries::Int)
     nz = nonzeros(S)
     fill!(nz, 0.0)
@@ -397,7 +397,7 @@ end
 
 Update the b vector from direct and deferred stamps.
 """
-function update_b_vector!(b::Vector{Float64}, b_direct::Vector{Float64},
+@inline function update_b_vector!(b::Vector{Float64}, b_direct::Vector{Float64},
                           b_deferred_I::Vector{Int}, b_deferred_V::Vector{Float64},
                           n_nodes::Int)
     fill!(b, 0.0)

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -1727,8 +1727,10 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
     # Terminal nodes come from function parameters; internal nodes are allocated dynamically
     # NOTE: Using _mna_*_ prefixes to avoid conflicts with VA parameter/variable names
     # (e.g., PSP103 has 'x', some models have 't', 'mode' is a common parameter name)
+    # NOTE: @inline is critical for performance - allows Julia to constant-fold Dual type checks
+    # and eliminate runtime dispatch on contribution types (ContributionTag vs pure Dual vs scalar)
     quote
-        function CedarSim.MNA.stamp!(dev::$symname, ctx::CedarSim.MNA.MNAContext,
+        @inline function CedarSim.MNA.stamp!(dev::$symname, ctx::CedarSim.MNA.MNAContext,
                                      $([:($np::Int) for np in node_params]...);
                                      _mna_t_::Real=0.0, _mna_mode_::Symbol=:dcop, _mna_x_::AbstractVector=Float64[],
                                      _mna_spec_::CedarSim.MNA.MNASpec=CedarSim.MNA.MNASpec())


### PR DESCRIPTION
Add @inline annotations to enable Julia to constant-fold Dual type checks in the MNA residual path:

- contrib.jl: Add @inline to stamp_contribution!, evaluate_contribution, stamp_current_contribution!, stamp_voltage_contribution!, evaluate_charge_contribution, stamp_charge_contribution!, and stamp_multiport_charge!

- vasim.jl: Add @inline to generated stamp! methods so Julia can eliminate runtime dispatch on ContributionTag vs pure Dual vs scalar

- precompile.jl: Add @inline to update_sparse_from_coo! and update_b_vector!

With inlining, the type of I_branch in the contribution evaluation is known at compile time (determined by presence of va_ddt() calls), allowing the if/elseif/else branches to be constant-folded.

This corresponds to Phase 3 of the va_zero_allocation_plan.md.