### PR TITLE
Add voltage-dependent capacitor detection and charge formulation

### DIFF
--- a/doc/voltage_dependent_capacitors.md
+++ b/doc/voltage_dependent_capacitors.md
@@ -1,0 +1,304 @@
+# Voltage-Dependent Capacitors: Charge Formulation Implementation
+
+## Problem Statement
+
+When `vasim.jl` encounters `ddt(Q(V))` where `Q(V)` is a nonlinear charge function (voltage-dependent capacitor), it currently stamps `∂Q/∂V = C(V)` into the C matrix. This creates a **state-dependent mass matrix** which SciML solvers don't handle well.
+
+### Current Behavior
+
+For a contribution like:
+```verilog
+I(p,n) <+ ddt(Q(V(p,n)));  // Q(V) is nonlinear in V
+```
+
+The s-dual approach evaluates:
+- `va_ddt(Q(V))` returns `Dual{ContributionTag}(0, Q(V))`
+- `partials(result, 1)` = `Q(V)` (the charge)
+- `∂Q/∂V = C(V)` is stamped into C matrix
+
+This yields the ODE system: `C(V) * dV/dt + G*V = b`
+
+When `C(V)` varies with state `V`, SciML's mass matrix ODE solvers struggle:
+- Rosenbrock methods (Rodas4, Rodas5P) only support constant mass matrices
+- `RadauIIA5` technically supports non-constant mass via `DiffEqArrayOperator`, but it's undocumented and unstable
+- The recommended approach is reformulating to constant mass matrix
+
+### Examples of Voltage-Dependent Capacitors
+
+1. **Junction capacitance** (diodes, MOSFETs):
+   ```
+   Q(V) = Cj0 * φ * (1 - (1 - V/φ)^(1-m))
+   C(V) = dQ/dV = Cj0 * (1 - V/φ)^(-m)
+   ```
+
+2. **MOS gate charge** (BSIM models):
+   ```
+   Qg = f(Vgs, Vds, Vbs)  // Complex nonlinear function
+   Cgg = ∂Qg/∂Vgs, Cgd = ∂Qg/∂Vds, etc.
+   ```
+
+3. **Varactor**:
+   ```
+   Q(V) = C0 * V + C1 * V^2 + C2 * V^3
+   C(V) = C0 + 2*C1*V + 3*C2*V^2
+   ```
+
+## Solution: Charge Formulation
+
+Reformulate using **charge as an explicit state variable**:
+
+### Original (state-dependent mass matrix):
+```
+C(V) * dV/dt = I_branch
+```
+
+### Reformulated (constant mass matrix):
+```
+dq/dt = I_branch     (differential equation, mass coefficient = 1)
+q - Q(V) = 0         (algebraic constraint)
+```
+
+This transforms the system from:
+```
+[C(V)  0] [V̇]   [f(V)]
+[0     0] [·] = [·   ]
+```
+
+To:
+```
+[M₀   0  0 ] [V̇]   [KCL equations (include dq/dt from capacitor)]
+[0    0  0 ] [·] = [other algebraic                             ]
+[0    0  0 ] [q̇]   [constraint row (algebraic)                  ]
+              +
+[G block     | 0 ] [V]   [b    ]
+[            | · ] [·] = [     ]
+[−∂Q/∂V      | 1 ] [q]   [Q(V₀)]  <- q = Q(V) constraint
+```
+
+Key insight: The charge constraint row `q - Q(V) = 0` is **algebraic** (no C entry).
+The dq/dt terms appear in the KCL equations via `C[p, q_idx] = 1` and `C[n, q_idx] = -1`.
+This correctly enforces the constraint exactly at each time step, not just at steady state.
+
+The mass matrix is now constant (zeros in the charge row, KCL rows have constant coupling to dq/dt).
+
+## Detection Strategy: Nested Duals (No AST Analysis)
+
+We detect voltage-dependent capacitance **at runtime using AD**, avoiding AST analysis. The key insight: if `∂²Q/∂V² ≠ 0`, then `C(V) = ∂Q/∂V` is voltage-dependent.
+
+### Dual Tag Hierarchy
+
+```
+Precedence (outer to inner):
+  ContributionTag  - separates resistive/reactive (s-dual for ddt)
+  JacobianTag      - ∂/∂V for Jacobian extraction
+  CapacitanceDerivTag - ∂²/∂V² to detect voltage dependence
+```
+
+### Detection Algorithm
+
+```julia
+function is_voltage_dependent_charge(contrib_fn, Vp::Real, Vn::Real)
+    # Triple-nested duals:
+    # 1. CapacitanceDerivTag (innermost) - for ∂²Q/∂V²
+    # 2. JacobianTag (middle) - for ∂Q/∂V
+    # 3. ContributionTag (outermost) - separates q from I via va_ddt
+
+    # IMPORTANT: Check at BOTH the operating point AND a perturbed point.
+    # Some functions have ∂²Q/∂V² = 0 at specific points (e.g., Q = V³ at V=0)
+    # but are still voltage-dependent. The perturbation catches these cases.
+
+    # Create voltage with all three dual layers
+    Vp_triple = create_triple_dual(Vp, ...)
+    result = contrib_fn(Vp_triple - Vn_triple)
+
+    # Check at operating point
+    if has_nonzero_second_derivative(result)
+        return true
+    end
+
+    # Check at perturbed point (ε = 1e-3) to catch edge cases
+    return check_at_point(contrib_fn, Vp + ε, Vn)
+end
+```
+
+This perturbation approach ensures **type-level detection** (analytically nonlinear functions)
+rather than value-level detection (which could miss edge cases at zeros of ∂²Q/∂V²).
+
+### Performance: Type Stability and Inlining
+
+To ensure the detection overhead optimizes away:
+
+1. **Type-stable dual creation**: All dual types are concrete and known at compile time
+2. **Inline detection functions**: Use `@inline` for hot paths
+3. **Branch on type, not value**: Detection result feeds into type-dispatched stamping
+4. **Const-prop friendly**: Simple boolean result enables dead code elimination
+
+```julia
+@inline function evaluate_and_detect(contrib_fn, Vp::Real, Vn::Real)
+    # Standard evaluation (always needed)
+    result = evaluate_contribution(contrib_fn, Vp, Vn)
+
+    # Detection only for reactive contributions
+    if result.has_reactive
+        is_vdep = is_voltage_dependent_charge(contrib_fn, Vp, Vn)
+        return (result..., is_voltage_dependent = is_vdep)
+    end
+    return (result..., is_voltage_dependent = false)
+end
+```
+
+For the common case (linear capacitors), the detection should compile away to a constant `false` after inlining since `∂²(C*V)/∂V² = 0` is known at compile time for literal `C`.
+
+## Implementation Plan
+
+### Phase 1: Detection Infrastructure (`src/mna/contrib.jl`)
+
+```julia
+# New tag for second derivatives
+struct CapacitanceDerivTag end
+
+# Tag ordering (all three must be ordered correctly)
+ForwardDiff.:≺(::Type{CapacitanceDerivTag}, ::Type{JacobianTag}) = true
+ForwardDiff.:≺(::Type{CapacitanceDerivTag}, ::Type{ContributionTag}) = true
+# ... other orderings ...
+
+# Detection function
+@inline function is_voltage_dependent_charge(contrib_fn, Vp::Real, Vn::Real)::Bool
+    # Implementation using triple-nested duals
+end
+```
+
+### Phase 2: Charge Variable Support (`src/mna/context.jl`)
+
+```julia
+mutable struct MNAContext
+    # ... existing fields ...
+
+    # Charge state variables
+    charge_names::Vector{Symbol}
+    n_charges::Int
+    charge_branches::Vector{Tuple{Int, Int}}  # (p, n) for each charge
+end
+
+function alloc_charge!(ctx::MNAContext, name::Symbol, p::Int, n::Int)::Int
+    push!(ctx.charge_names, name)
+    ctx.n_charges += 1
+    push!(ctx.charge_branches, (p, n))
+    return ctx.n_nodes + ctx.n_currents + ctx.n_charges
+end
+```
+
+### Phase 3: Charge-Based Stamping (`src/mna/contrib.jl`)
+
+```julia
+"""
+Stamp voltage-dependent capacitor using charge formulation.
+"""
+function stamp_charge_state!(
+    ctx::MNAContext,
+    p::Int, n::Int,
+    q_fn,  # V -> Q(V)
+    x::AbstractVector,
+    charge_name::Symbol
+)
+    q_idx = alloc_charge!(ctx, charge_name, p, n)
+
+    Vp = p == 0 ? 0.0 : x[p]
+    Vn = n == 0 ? 0.0 : x[n]
+    q_val = length(x) >= q_idx ? x[q_idx] : 0.0
+
+    result = evaluate_charge_contribution(q_fn, Vp, Vn)
+
+    # 1. dq/dt term: constant mass coefficient of 1
+    stamp_C!(ctx, q_idx, q_idx, 1.0)
+
+    # 2. KCL: I = dq/dt flows from p to n
+    stamp_C!(ctx, p, q_idx, 1.0)   # current leaves p
+    stamp_C!(ctx, n, q_idx, -1.0)  # current enters n
+
+    # 3. Constraint: q - Q(V) = 0
+    stamp_G!(ctx, q_idx, q_idx, 1.0)           # ∂/∂q = 1
+    stamp_G!(ctx, q_idx, p, -result.dq_dVp)    # ∂/∂Vp = -∂Q/∂Vp
+    stamp_G!(ctx, q_idx, n, -result.dq_dVn)    # ∂/∂Vn = -∂Q/∂Vn
+
+    # Newton companion for constraint
+    b_val = q_val - result.q - (1.0*q_val - result.dq_dVp*Vp - result.dq_dVn*Vn)
+    stamp_b!(ctx, q_idx, b_val)
+
+    return q_idx
+end
+```
+
+### Phase 4: Update vasim.jl Code Generation
+
+Modify `generate_mna_stamp_method_nterm` to:
+1. Call detection at runtime for contributions with `ddt()`
+2. Branch to charge formulation when voltage-dependent
+3. Use standard C-matrix stamping for constant capacitors
+
+The detection and branching should be type-stable so the JIT can optimize.
+
+### Phase 5: Solver Updates (`src/mna/solve.jl`)
+
+```julia
+function make_dae_problem(sys::MNASystem, tspan; kwargs...)
+    # Identify differential vs algebraic variables
+    n = system_size(sys)
+    differential_vars = [sys.C[i,i] != 0 for i in 1:n]
+
+    # Constraint rows (charge variables) have 0 in C diagonal initially
+    # but we set them to 1 in stamp_charge_state!, so they're differential
+
+    # Use DAEProblem with IDA or DFBDF
+    # ...
+end
+```
+
+### Phase 6: Testing
+
+New test file `test/mna/charge_formulation.jl`:
+
+```julia
+@testset "Detection" begin
+    # Linear: I = C * ddt(V) -> not voltage dependent
+    @test !is_voltage_dependent_charge(V -> 1e-12 * va_ddt(V), 1.0, 0.0)
+
+    # Quadratic: I = ddt(C * V^2) -> voltage dependent
+    @test is_voltage_dependent_charge(V -> va_ddt(1e-12 * V^2), 1.0, 0.0)
+
+    # Junction cap -> voltage dependent
+    Cj0, phi, m = 1e-12, 0.7, 0.5
+    jcap(V) = va_ddt(Cj0 * phi * (1 - (1 - V/phi)^(1-m)))
+    @test is_voltage_dependent_charge(jcap, 0.3, 0.0)
+end
+
+@testset "Charge formulation transient" begin
+    # Verify transient with nonlinear cap matches expected/reference
+end
+```
+
+## Key Design Decisions
+
+1. **Runtime detection via AD** (not AST analysis): More robust, handles arbitrary expressions, leverages existing dual infrastructure.
+
+2. **Type-stable detection**: Returns `Bool`, enabling compile-time optimization for common cases.
+
+3. **Charge as explicit state**: Yields constant mass matrix, enabling efficient Rosenbrock solvers.
+
+4. **Backward compatible**: Linear capacitors continue to use existing C-matrix stamping.
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/mna/contrib.jl` | Add `CapacitanceDerivTag`, `is_voltage_dependent_charge()`, `stamp_charge_state!()` |
+| `src/mna/context.jl` | Add charge variable fields and `alloc_charge!()` |
+| `src/vasim.jl` | Modify stamp generation to detect and handle voltage-dependent caps |
+| `src/mna/solve.jl` | Update DAE problem creation for charge variables |
+| `test/mna/charge_formulation.jl` | New test file |
+
+## References
+
+- `doc/Sciml charge formulation.md` - Background on SciML DAE support
+- `doc/mna_ad_stamping.md` - Existing s-dual approach for ddt()
+- `src/mna/contrib.jl` - Current contribution evaluation

--- a/src/mna/build.jl
+++ b/src/mna/build.jl
@@ -97,8 +97,8 @@ function assemble_G(ctx::MNAContext; gmin::Float64=0.0)
         end
     end
 
-    I_resolved = [resolve_index(ctx, i) for i in ctx.G_I]
-    J_resolved = [resolve_index(ctx, j) for j in ctx.G_J]
+    I_resolved = Int[resolve_index(ctx, i) for i in ctx.G_I]
+    J_resolved = Int[resolve_index(ctx, j) for j in ctx.G_J]
 
     if gmin > 0
         # Add GMIN from each voltage node to ground
@@ -137,8 +137,8 @@ function assemble_C(ctx::MNAContext)
         return spzeros(Float64, n, n)
     end
     # Resolve any negative indices (current variables)
-    I_resolved = [resolve_index(ctx, i) for i in ctx.C_I]
-    J_resolved = [resolve_index(ctx, j) for j in ctx.C_J]
+    I_resolved = Int[resolve_index(ctx, i) for i in ctx.C_I]
+    J_resolved = Int[resolve_index(ctx, j) for j in ctx.C_J]
     return sparse(I_resolved, J_resolved, ctx.C_V, n, n)
 end
 

--- a/src/mna/build.jl
+++ b/src/mna/build.jl
@@ -42,8 +42,15 @@ struct MNASystem{T<:Real}
     b::Vector{T}
     node_names::Vector{Symbol}
     current_names::Vector{Symbol}
+    charge_names::Vector{Symbol}
     n_nodes::Int
     n_currents::Int
+    n_charges::Int
+end
+
+# Backwards-compatible constructor (no charges)
+function MNASystem{T}(G, C, b, node_names, current_names, n_nodes, n_currents) where {T<:Real}
+    MNASystem{T}(G, C, b, node_names, current_names, Symbol[], n_nodes, n_currents, 0)
 end
 
 """
@@ -51,7 +58,7 @@ end
 
 Return the total system size (number of unknowns).
 """
-system_size(sys::MNASystem) = sys.n_nodes + sys.n_currents
+system_size(sys::MNASystem) = sys.n_nodes + sys.n_currents + sys.n_charges
 
 #==============================================================================#
 # Matrix Assembly
@@ -200,8 +207,10 @@ function assemble!(ctx::MNAContext)
         G, C, b,
         copy(ctx.node_names),
         copy(ctx.current_names),
+        copy(ctx.charge_names),
         ctx.n_nodes,
-        ctx.n_currents
+        ctx.n_currents,
+        ctx.n_charges
     )
 end
 
@@ -222,6 +231,13 @@ node_voltage_indices(sys::MNASystem) = 1:sys.n_nodes
 Return the indices in the solution vector corresponding to current variables.
 """
 current_variable_indices(sys::MNASystem) = (sys.n_nodes + 1):(sys.n_nodes + sys.n_currents)
+
+"""
+    charge_variable_indices(sys::MNASystem) -> UnitRange{Int}
+
+Return the indices in the solution vector corresponding to charge variables.
+"""
+charge_variable_indices(sys::MNASystem) = (sys.n_nodes + sys.n_currents + 1):(sys.n_nodes + sys.n_currents + sys.n_charges)
 
 """
     get_node_index(sys::MNASystem, name::Symbol) -> Int
@@ -245,6 +261,16 @@ function get_current_index(sys::MNASystem, name::Symbol)
     return idx === nothing ? error("Unknown current: $name") : sys.n_nodes + idx
 end
 
+"""
+    get_charge_index(sys::MNASystem, name::Symbol) -> Int
+
+Get the solution vector index for a charge variable by name.
+"""
+function get_charge_index(sys::MNASystem, name::Symbol)
+    idx = findfirst(==(name), sys.charge_names)
+    return idx === nothing ? error("Unknown charge: $name") : sys.n_nodes + sys.n_currents + idx
+end
+
 #==============================================================================#
 # Pretty Printing
 #==============================================================================#
@@ -263,6 +289,7 @@ function Base.show(io::IO, ::MIME"text/plain", sys::MNASystem{T}) where T
     println(io, "  System size: $n")
     println(io, "  Voltage nodes: $(sys.n_nodes)")
     println(io, "  Current variables: $(sys.n_currents)")
+    println(io, "  Charge variables: $(sys.n_charges)")
     println(io, "  G matrix: $(nnz(sys.G)) nonzeros")
     println(io, "  C matrix: $(nnz(sys.C)) nonzeros")
     if !isempty(sys.node_names)
@@ -270,6 +297,9 @@ function Base.show(io::IO, ::MIME"text/plain", sys::MNASystem{T}) where T
     end
     if !isempty(sys.current_names)
         println(io, "  Currents: $(join(sys.current_names, ", "))")
+    end
+    if !isempty(sys.charge_names)
+        println(io, "  Charges: $(join(sys.charge_names, ", "))")
     end
 end
 
@@ -321,7 +351,7 @@ end
 Display the G matrix (for debugging small circuits).
 """
 function show_G(sys::MNASystem)
-    all_names = vcat(sys.node_names, sys.current_names)
+    all_names = vcat(sys.node_names, sys.current_names, sys.charge_names)
     show_matrix(stdout, sys.G, all_names)
 end
 
@@ -331,6 +361,6 @@ end
 Display the C matrix (for debugging small circuits).
 """
 function show_C(sys::MNASystem)
-    all_names = vcat(sys.node_names, sys.current_names)
+    all_names = vcat(sys.node_names, sys.current_names, sys.charge_names)
     show_matrix(stdout, sys.C, all_names)
 end

--- a/src/mna/contrib.jl
+++ b/src/mna/contrib.jl
@@ -111,6 +111,7 @@ ForwardDiff.:≺(::Type, ::Type{CapacitanceDerivTag}) = true
 
 export CapacitanceDerivTag, is_voltage_dependent_charge
 
+
 """
     is_voltage_dependent_charge(contrib_fn, Vp::Real, Vn::Real) -> Bool
 

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -1488,6 +1488,12 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
         # Same sign convention as G matrix
         # Only stamp if device has reactive components (determined by TYPE, not value)
         # This ensures consistent COO structure for precompilation
+        #
+        # NOTE: Charge formulation for voltage-dependent capacitors is available via
+        # stamp_charge_state!() in contrib.jl. To use it, detect voltage dependence
+        # with is_voltage_dependent_charge() and call stamp_charge_state!() instead.
+        # For now, we use standard C matrix stamping which works for linear capacitors.
+        # Voltage-dependent capacitors will result in a state-dependent mass matrix.
         for k in 1:n_all_nodes
             k_node = all_node_params[k]
             dq_sym = Symbol("dq_dV", k)

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -475,6 +475,15 @@ function (to_julia::MNAScope)(cs::VANode{BinaryExpression})
         return Expr(:call, (|), to_julia(cs.lhs), to_julia(cs.rhs))
     elseif op == :(&&)
         return Expr(:call, (&), to_julia(cs.lhs), to_julia(cs.rhs))
+    elseif op == Symbol("**")
+        # Power operator (**) in Verilog-A: use `pow` from VerilogAEnvironment
+        # which uses NaNMath.pow and handles ForwardDiff duals correctly
+        return Expr(:call, :pow, to_julia(cs.lhs), to_julia(cs.rhs))
+    elseif op == :^
+        # XOR operator (^) in Verilog-A: bitwise XOR for integers
+        # Note: ^ is NOT power in Verilog-A! Power is **
+        # We pass through to the VA environment's ^ which is Base.:(⊻)
+        return Expr(:call, :^, to_julia(cs.lhs), to_julia(cs.rhs))
     else
         return Expr(:call, op, to_julia(cs.lhs), to_julia(cs.rhs))
     end
@@ -1434,6 +1443,10 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
         #
         # IMPORTANT: has_reactive is set based on TYPE, not value. This ensures
         # consistent COO structure for precompilation regardless of operating point.
+        # Generate charge variable name for this branch (used if voltage-dependent)
+        charge_name_suffix = QuoteNode(Symbol(symname, "_Q_", p_sym, "_", n_sym))
+        charge_name_expr = :(_mna_instance_ == Symbol("") ? $charge_name_suffix : Symbol(_mna_instance_, "_", $charge_name_suffix))
+
         branch_stamp = quote
             # Evaluate the branch current
             I_branch = $sum_expr
@@ -1443,20 +1456,51 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
                 I_resist = ForwardDiff.value(I_branch)       # Dual{JacobianTag} for I and ∂I/∂V
                 I_react = ForwardDiff.partials(I_branch, 1)  # Dual{JacobianTag} for q and ∂q/∂V
 
-                I_val = ForwardDiff.value(I_resist)
-                $([:($(Symbol("dI_dV", k)) = ForwardDiff.partials(I_resist, $k)) for k in 1:n_all_nodes]...)
+                # Extract resistive values - unwrap CapacitanceDerivTag layer
+                _I_inner = ForwardDiff.value(I_resist)  # Dual{CapacitanceDerivTag}
+                I_val = ForwardDiff.value(_I_inner)     # Float64
 
-                q_val = ForwardDiff.value(I_react)
-                $([:($(Symbol("dq_dV", k)) = ForwardDiff.partials(I_react, $k)) for k in 1:n_all_nodes]...)
+                # Extract dI/dV - each is Dual{CapacitanceDerivTag}, take value
+                $([:($(Symbol("dI_dV", k)) = ForwardDiff.value(ForwardDiff.partials(I_resist, $k))) for k in 1:n_all_nodes]...)
+
+                # Extract charge value - unwrap CapacitanceDerivTag layer
+                _q_inner = ForwardDiff.value(I_react)   # Dual{CapacitanceDerivTag}
+                q_val = ForwardDiff.value(_q_inner)     # Float64
+
+                # Extract dq/dV - each is Dual{CapacitanceDerivTag}
+                # Keep as dual to check second derivatives for voltage dependence
+                $([:($(Symbol("dq_dV_dual", k)) = ForwardDiff.partials(I_react, $k)) for k in 1:n_all_nodes]...)
+
+                # Extract actual capacitance values (first derivatives)
+                $([:($(Symbol("dq_dV", k)) = ForwardDiff.value($(Symbol("dq_dV_dual", k)))) for k in 1:n_all_nodes]...)
+
+                # Check for voltage-dependent charge by looking at second derivatives
+                # If any d²q/dV² ≠ 0, the charge is voltage-dependent
+                _is_voltage_dependent = false
+                $([quote
+                    _dq_dual = $(Symbol("dq_dV_dual", k))
+                    if _dq_dual isa ForwardDiff.Dual
+                        for _p in ForwardDiff.partials(_dq_dual)
+                            if !iszero(_p)
+                                _is_voltage_dependent = true
+                                break
+                            end
+                        end
+                    end
+                end for k in 1:n_all_nodes]...)
+
                 has_reactive = true
 
             elseif I_branch isa ForwardDiff.Dual
                 # Pure resistive: just voltage dual, no ContributionTag
-                I_val = ForwardDiff.value(I_branch)
-                $([:($(Symbol("dI_dV", k)) = ForwardDiff.partials(I_branch, $k)) for k in 1:n_all_nodes]...)
+                # Unwrap CapacitanceDerivTag layer
+                _I_inner = ForwardDiff.value(I_branch)  # Dual{CapacitanceDerivTag}
+                I_val = ForwardDiff.value(_I_inner)
+                $([:($(Symbol("dI_dV", k)) = ForwardDiff.value(ForwardDiff.partials(I_branch, $k))) for k in 1:n_all_nodes]...)
                 q_val = 0.0
                 $([:($(Symbol("dq_dV", k)) = 0.0) for k in 1:n_all_nodes]...)
                 has_reactive = false
+                _is_voltage_dependent = false
 
             else
                 # Scalar result (constant contribution)
@@ -1465,6 +1509,7 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
                 q_val = 0.0
                 $([:($(Symbol("dq_dV", k)) = 0.0) for k in 1:n_all_nodes]...)
                 has_reactive = false
+                _is_voltage_dependent = false
             end
         end
 
@@ -1484,30 +1529,72 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
             end)
         end
 
-        # Stamp reactive Jacobians (capacitances) into C matrix
+        # Stamp reactive Jacobians (capacitances) into C matrix OR use charge formulation
         # Same sign convention as G matrix
         # Only stamp if device has reactive components (determined by TYPE, not value)
         # This ensures consistent COO structure for precompilation
         #
-        # NOTE: Charge formulation for voltage-dependent capacitors is available via
-        # stamp_charge_state!() in contrib.jl. To use it, detect voltage dependence
-        # with is_voltage_dependent_charge() and call stamp_charge_state!() instead.
-        # For now, we use standard C matrix stamping which works for linear capacitors.
-        # Voltage-dependent capacitors will result in a state-dependent mass matrix.
-        for k in 1:n_all_nodes
-            k_node = all_node_params[k]
-            dq_sym = Symbol("dq_dV", k)
-            push!(branch_stamp.args, quote
-                if has_reactive
-                    if $p_node != 0 && $k_node != 0
-                        CedarSim.MNA.stamp_C!(ctx, $p_node, $k_node, $dq_sym)
+        # For voltage-dependent capacitors (detected via second derivatives), we use
+        # the charge formulation to achieve a constant mass matrix:
+        # - Allocate a charge state variable q
+        # - Stamp constraint: q = Q(V) as algebraic equation
+        # - Stamp KCL coupling: dq/dt appears in node equations
+        #
+        # For linear capacitors, we use standard C matrix stamping (no extra variables).
+
+        # Build the stamping code with runtime detection
+        push!(branch_stamp.args, quote
+            if has_reactive
+                if _is_voltage_dependent
+                    # Voltage-dependent charge: use charge formulation for constant mass matrix
+                    # Allocate charge variable (or get existing one)
+                    _q_idx = CedarSim.MNA.alloc_charge!(ctx, $charge_name_expr, $p_node, $n_node)
+
+                    # --- Mass matrix (constant entries!) ---
+                    # KCL coupling: I = dq/dt flows from p to n
+                    if $p_node != 0
+                        CedarSim.MNA.stamp_C!(ctx, $p_node, _q_idx, 1.0)
                     end
-                    if $n_node != 0 && $k_node != 0
-                        CedarSim.MNA.stamp_C!(ctx, $n_node, $k_node, -$dq_sym)
+                    if $n_node != 0
+                        CedarSim.MNA.stamp_C!(ctx, $n_node, _q_idx, -1.0)
                     end
+
+                    # --- Constraint Jacobian (in G matrix) ---
+                    # Constraint: F = q - Q(V) = 0
+                    # ∂F/∂q = 1
+                    CedarSim.MNA.stamp_G!(ctx, _q_idx, _q_idx, 1.0)
+
+                    # ∂F/∂V_k = -∂Q/∂V_k for each node k
+                    $([quote
+                        if $(all_node_params[k]) != 0
+                            CedarSim.MNA.stamp_G!(ctx, _q_idx, $(all_node_params[k]), -$(Symbol("dq_dV", k)))
+                        end
+                    end for k in 1:n_all_nodes]...)
+
+                    # --- Constraint RHS (Newton companion) ---
+                    # Newton: G*x = b where b = G*x₀ - F(x₀)
+                    # Constraint F = q - Q(V), so F(x₀) = q₀ - Q(V₀)
+                    # G*x₀ = 1*q₀ + Σ(-∂Q/∂V_k)*V_k = q₀ - Σ(∂Q/∂V_k * V_k)
+                    # b = G*x₀ - F(x₀) = q₀ - Σ(dQ/dV_k * V_k) - (q₀ - Q(V₀))
+                    #   = Q(V₀) - Σ(dQ/dV_k * V_k)
+                    _b_constraint = q_val  # Q(V₀)
+                    $([quote
+                        _b_constraint -= $(Symbol("dq_dV", k)) * $(Symbol("V_", k))  # - dQ/dV_k * V_k
+                    end for k in 1:n_all_nodes]...)
+                    CedarSim.MNA.stamp_b!(ctx, _q_idx, _b_constraint)
+                else
+                    # Linear capacitor: use standard C matrix stamping
+                    $([quote
+                        if $p_node != 0 && $(all_node_params[k]) != 0
+                            CedarSim.MNA.stamp_C!(ctx, $p_node, $(all_node_params[k]), $(Symbol("dq_dV", k)))
+                        end
+                        if $n_node != 0 && $(all_node_params[k]) != 0
+                            CedarSim.MNA.stamp_C!(ctx, $n_node, $(all_node_params[k]), -$(Symbol("dq_dV", k)))
+                        end
+                    end for k in 1:n_all_nodes]...)
                 end
-            end)
-        end
+            end
+        end)
 
         # Stamp RHS: Ieq = I_val - sum(dI/dVk * Vk)
         # MNA sign convention: b[p] -= Ieq, b[n] += Ieq
@@ -1611,13 +1698,38 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
 
     # Generate dual creation for all nodes (terminals + internal)
     # Each node gets a dual with identity partials: ∂V_i/∂V_k = δ_ik
+    #
+    # For voltage-dependent capacitor detection, we use triple-nested duals:
+    # CapacitanceDerivTag < JacobianTag < ContributionTag
+    #
+    # Inner (CapacitanceDerivTag): carries ∂/∂V for second derivative detection
+    # Outer (JacobianTag): carries ∂/∂V for Jacobian extraction
+    #
+    # When we extract dq_dV from the reactive part, it will be Dual{CapacitanceDerivTag}.
+    # If its partials are non-zero, d²q/dV² ≠ 0 → voltage-dependent charge.
     dual_creation = Expr(:block)
     for i in 1:n_all_nodes
         node_sym = all_node_syms[i]
-        # Create dual with partials: (0,...,1,...,0) where 1 is at position i
-        partials_tuple = Expr(:tuple, [k == i ? 1.0 : 0.0 for k in 1:n_all_nodes]...)
+        # Create inner dual (CapacitanceDerivTag) with partials for second derivative
+        inner_partials = Expr(:tuple, [k == i ? 1.0 : 0.0 for k in 1:n_all_nodes]...)
+        inner_dual = :(Dual{CedarSim.MNA.CapacitanceDerivTag}($(Symbol("V_", i)), $inner_partials...))
+
+        # Create outer dual (JacobianTag) wrapping the inner dual
+        # The partials are also inner duals to propagate second derivatives
+        outer_partials_exprs = []
+        for k in 1:n_all_nodes
+            if k == i
+                # ∂V_i/∂V_i = 1 (inner dual with value 1, zero partials)
+                push!(outer_partials_exprs, :(Dual{CedarSim.MNA.CapacitanceDerivTag}(1.0, $(Expr(:tuple, zeros(n_all_nodes)...)))))
+            else
+                # ∂V_i/∂V_k = 0 (inner dual with value 0, zero partials)
+                push!(outer_partials_exprs, :(Dual{CedarSim.MNA.CapacitanceDerivTag}(0.0, $(Expr(:tuple, zeros(n_all_nodes)...)))))
+            end
+        end
+        outer_partials = Expr(:tuple, outer_partials_exprs...)
+
         push!(dual_creation.args,
-            :($node_sym = Dual{CedarSim.MNA.JacobianTag}($(Symbol("V_", i)), $partials_tuple...)))
+            :($node_sym = Dual{CedarSim.MNA.JacobianTag}($inner_dual, $outer_partials...)))
     end
 
     # Generate branch current extraction for named branches

--- a/test/mna/charge_formulation.jl
+++ b/test/mna/charge_formulation.jl
@@ -1,0 +1,350 @@
+#==============================================================================#
+# Tests for Voltage-Dependent Capacitor Detection and Charge Formulation
+#
+# See doc/voltage_dependent_capacitors.md for design details.
+#==============================================================================#
+
+using Test
+using CedarSim
+using CedarSim.MNA
+using CedarSim.MNA: va_ddt, is_voltage_dependent_charge, CapacitanceDerivTag
+using CedarSim.MNA: ContributionTag, JacobianTag
+using ForwardDiff: Dual, value, partials
+
+@testset "Voltage-Dependent Capacitor Detection" begin
+
+    @testset "Detection basics - constant capacitors" begin
+        # Linear capacitor: I = C * ddt(V)
+        # Q(V) = C * V, so ∂²Q/∂V² = 0 -> constant capacitance
+        C0 = 1e-12
+        linear_cap(V) = C0 * va_ddt(V)
+
+        @test !is_voltage_dependent_charge(linear_cap, 0.0, 0.0)
+        @test !is_voltage_dependent_charge(linear_cap, 1.0, 0.0)
+        @test !is_voltage_dependent_charge(linear_cap, 5.0, 2.0)
+
+        # Parallel RC: I = V/R + C * ddt(V)
+        # Still constant capacitance
+        R = 1000.0
+        parallel_rc(V) = V/R + C0 * va_ddt(V)
+
+        @test !is_voltage_dependent_charge(parallel_rc, 1.0, 0.0)
+    end
+
+    @testset "Detection basics - voltage-dependent capacitors" begin
+        # Quadratic charge: Q(V) = C0 * V^2
+        # C(V) = dQ/dV = 2*C0*V -> varies with V
+        # ∂C/∂V = 2*C0 ≠ 0
+        C0 = 1e-12
+        quadratic_cap(V) = va_ddt(C0 * V^2)
+
+        @test is_voltage_dependent_charge(quadratic_cap, 1.0, 0.0)
+        @test is_voltage_dependent_charge(quadratic_cap, 0.0, 0.0)  # Even at V=0, ∂C/∂V ≠ 0
+
+        # Cubic charge: Q(V) = C0 * V^3
+        # C(V) = 3*C0*V^2 -> varies with V
+        # ∂²Q/∂V² = 6*C0*V = 0 at V=0, but perturbation detects it
+        cubic_cap(V) = va_ddt(C0 * V^3)
+
+        @test is_voltage_dependent_charge(cubic_cap, 1.0, 0.0)
+        @test is_voltage_dependent_charge(cubic_cap, 0.0, 0.0)  # Detected via perturbation
+    end
+
+    @testset "Detection - junction capacitance model" begin
+        # Standard junction capacitance: Q(V) = Cj0 * φ * (1 - (1 - V/φ)^(1-m))
+        # This is the integral of C(V) = Cj0 * (1 - V/φ)^(-m)
+        Cj0 = 1e-12
+        phi = 0.7
+        m = 0.5
+
+        function junction_charge(V)
+            # Avoid singularity at V = φ
+            V_clamped = min(V, 0.95 * phi)
+            Q = Cj0 * phi * (1 - (1 - V_clamped/phi)^(1-m)) / (1-m)
+            return va_ddt(Q)
+        end
+
+        @test is_voltage_dependent_charge(junction_charge, 0.0, 0.0)
+        @test is_voltage_dependent_charge(junction_charge, 0.3, 0.0)
+        @test is_voltage_dependent_charge(junction_charge, 0.5, 0.0)
+    end
+
+    @testset "Detection - pure resistive (no capacitance)" begin
+        # Resistor: I = V/R
+        R = 1000.0
+        resistor(V) = V / R
+
+        @test !is_voltage_dependent_charge(resistor, 1.0, 0.0)
+
+        # Diode: I = Is*(exp(V/Vt) - 1)
+        Is = 1e-14
+        Vt = 0.026
+        diode(V) = Is * (exp(V / Vt) - 1)
+
+        @test !is_voltage_dependent_charge(diode, 0.6, 0.0)
+    end
+
+    @testset "Detection - mixed resistive and constant capacitive" begin
+        # Diode with constant junction capacitance
+        # I = Is*(exp(V/Vt) - 1) + C * ddt(V)
+        Is = 1e-14
+        Vt = 0.026
+        Cj = 1e-12
+
+        diode_with_cap(V) = Is * (exp(V / Vt) - 1) + Cj * va_ddt(V)
+
+        # Capacitance is constant, so should return false
+        @test !is_voltage_dependent_charge(diode_with_cap, 0.6, 0.0)
+    end
+
+    @testset "Detection - mixed resistive and voltage-dependent capacitive" begin
+        # Diode with voltage-dependent junction capacitance
+        Is = 1e-14
+        Vt = 0.026
+        Cj0 = 1e-12
+        phi = 0.7
+        m = 0.5
+
+        function diode_with_vdep_cap(V)
+            I_res = Is * (exp(V / Vt) - 1)
+            V_clamped = min(V, 0.95 * phi)
+            Q = Cj0 * phi * (1 - (1 - V_clamped/phi)^(1-m)) / (1-m)
+            return I_res + va_ddt(Q)
+        end
+
+        @test is_voltage_dependent_charge(diode_with_vdep_cap, 0.3, 0.0)
+    end
+
+end
+
+@testset "Charge State Variable Allocation" begin
+    using CedarSim.MNA: MNAContext, get_node!, alloc_charge!, has_charge, get_charge_idx
+    using CedarSim.MNA: system_size, n_charges
+
+    ctx = MNAContext()
+    a = get_node!(ctx, :a)
+    c = get_node!(ctx, :c)
+
+    @test n_charges(ctx) == 0
+    @test system_size(ctx) == 2  # Just nodes
+
+    # Allocate a charge variable
+    q_idx = alloc_charge!(ctx, :Q_test, a, c)
+
+    @test n_charges(ctx) == 1
+    @test system_size(ctx) == 3  # nodes + charge
+    @test has_charge(ctx, :Q_test)
+    @test get_charge_idx(ctx, :Q_test) == q_idx
+    @test q_idx == 3  # After 2 nodes
+
+    # Allocate another
+    b = get_node!(ctx, :b)
+    q_idx2 = alloc_charge!(ctx, :Q_test2, b, c)
+
+    @test n_charges(ctx) == 2
+    @test system_size(ctx) == 5  # 3 nodes + 2 charges
+    @test q_idx2 == 5
+end
+
+@testset "stamp_charge_state! basic" begin
+    using CedarSim.MNA: MNAContext, MNASystem, get_node!, stamp!, assemble!
+    using CedarSim.MNA: stamp_charge_state!, VoltageSource
+
+    # Test: voltage source + nonlinear capacitor to ground
+    ctx = MNAContext()
+    vcc = get_node!(ctx, :vcc)
+
+    # Voltage source
+    stamp!(VoltageSource(1.0; name=:V1), ctx, vcc, 0)
+
+    # Quadratic charge: Q(V) = C0 * V^2, so C(V) = 2*C0*V
+    C0 = 1e-12
+    q_fn(V) = C0 * V^2
+
+    # Need to provide x vector for operating point
+    x = [1.0, 0.0]  # [Vcc, I_V1]
+
+    q_idx = stamp_charge_state!(ctx, vcc, 0, q_fn, x, :Q_cap)
+
+    @test q_idx == 3  # After node + current
+
+    sys = assemble!(ctx)
+
+    # Check C matrix has charge formulation entries
+    # The charge constraint row is ALGEBRAIC (no C[q_idx, q_idx])
+    # The dq/dt terms appear in KCL rows via C[vcc, q_idx]
+    @test sys.C[q_idx, q_idx] ≈ 0.0  # Algebraic constraint - no mass
+
+    # C[vcc, q_idx] = 1 (current flows out of vcc)
+    @test sys.C[vcc, q_idx] ≈ 1.0
+
+    # G matrix has constraint entries
+    # G[q_idx, q_idx] = 1
+    @test sys.G[q_idx, q_idx] ≈ 1.0
+
+    # G[q_idx, vcc] = -dQ/dVp = -2*C0*V = -2e-12 at V=1
+    @test sys.G[q_idx, vcc] ≈ -2e-12
+end
+
+@testset "stamp_charge_state! with both nodes" begin
+    using CedarSim.MNA: MNAContext, get_node!, assemble!
+    using CedarSim.MNA: stamp_charge_state!
+
+    ctx = MNAContext()
+    p = get_node!(ctx, :p)
+    n = get_node!(ctx, :n)
+
+    # Linear charge for simpler verification: Q(V) = C * V
+    C = 1e-9
+    q_fn(V) = C * V
+
+    x = [2.0, 1.0]  # Vp=2, Vn=1, so Vpn=1
+
+    q_idx = stamp_charge_state!(ctx, p, n, q_fn, x, :Q_C)
+
+    sys = assemble!(ctx)
+
+    # KCL coupling
+    @test sys.C[p, q_idx] ≈ 1.0   # Current leaves p
+    @test sys.C[n, q_idx] ≈ -1.0  # Current enters n
+
+    # Constraint Jacobian
+    @test sys.G[q_idx, q_idx] ≈ 1.0
+    @test sys.G[q_idx, p] ≈ -C     # -dQ/dVp
+    @test sys.G[q_idx, n] ≈ C      # -dQ/dVn = -(-C) = C
+end
+
+@testset "stamp_reactive_with_detection!" begin
+    using CedarSim.MNA: MNAContext, get_node!, assemble!
+    using CedarSim.MNA: stamp_reactive_with_detection!, va_ddt, n_charges
+
+    @testset "Linear capacitor -> C matrix stamping" begin
+        ctx = MNAContext()
+        p = get_node!(ctx, :p)
+        n = get_node!(ctx, :n)
+
+        C = 1e-12
+        contrib_fn(V) = C * va_ddt(V)  # Linear: Q = C*V
+
+        x = [1.0, 0.0]
+        used_charge = stamp_reactive_with_detection!(ctx, p, n, contrib_fn, x, :Q_test)
+
+        @test !used_charge  # Should use C matrix, not charge variable
+        @test n_charges(ctx) == 0
+
+        sys = assemble!(ctx)
+
+        # C matrix should have standard capacitance pattern
+        @test sys.C[p, p] ≈ C
+        @test sys.C[p, n] ≈ -C
+        @test sys.C[n, p] ≈ -C
+        @test sys.C[n, n] ≈ C
+    end
+
+    @testset "Nonlinear capacitor -> charge formulation" begin
+        ctx = MNAContext()
+        p = get_node!(ctx, :p)
+        n = get_node!(ctx, :n)
+
+        C0 = 1e-12
+        contrib_fn(V) = va_ddt(C0 * V^2)  # Nonlinear: Q = C0*V^2, C = 2*C0*V
+
+        x = [1.0, 0.0]
+        used_charge = stamp_reactive_with_detection!(ctx, p, n, contrib_fn, x, :Q_test)
+
+        @test used_charge  # Should use charge formulation
+        @test n_charges(ctx) == 1
+
+        sys = assemble!(ctx)
+
+        # Should have charge variable
+        q_idx = 3  # After 2 nodes
+
+        # Charge formulation entries
+        # The constraint row is ALGEBRAIC (no C[q_idx, q_idx])
+        @test sys.C[q_idx, q_idx] ≈ 0.0  # Algebraic constraint
+        @test sys.C[p, q_idx] ≈ 1.0      # KCL coupling
+        @test sys.C[n, q_idx] ≈ -1.0
+
+        # Constraint entries in G
+        @test sys.G[q_idx, q_idx] ≈ 1.0  # ∂/∂q = 1
+    end
+
+    @testset "Mixed resistive + linear capacitive" begin
+        ctx = MNAContext()
+        p = get_node!(ctx, :p)
+        n = get_node!(ctx, :n)
+
+        R = 1000.0
+        C = 1e-12
+        contrib_fn(V) = V/R + C * va_ddt(V)  # Resistive + linear capacitive
+
+        x = [1.0, 0.0]
+        used_charge = stamp_reactive_with_detection!(ctx, p, n, contrib_fn, x, :Q_test)
+
+        @test !used_charge  # Linear capacitor, use C matrix
+        @test n_charges(ctx) == 0
+    end
+end
+
+@testset "Charge formulation solver integration" begin
+    using CedarSim.MNA: MNAContext, get_node!, stamp!, VoltageSource, assemble!
+    using CedarSim.MNA: stamp_charge_state!, detect_differential_vars
+
+    @testset "Charge constraint is algebraic" begin
+        # Create a simple circuit with a nonlinear capacitor
+        ctx = MNAContext()
+        vcc = get_node!(ctx, :vcc)
+
+        # Voltage source to provide DC bias
+        stamp!(VoltageSource(1.0; name=:V1), ctx, vcc, 0)
+
+        # Nonlinear capacitor: Q(V) = C0 * V^2
+        C0 = 1e-12
+        q_fn(V) = C0 * V^2
+
+        x = [1.0, 0.0]  # [Vcc, I_V1]
+        q_idx = stamp_charge_state!(ctx, vcc, 0, q_fn, x, :Q_cap)
+
+        sys = assemble!(ctx)
+
+        # Detect which variables are differential
+        diff_vars = detect_differential_vars(sys)
+
+        # vcc node should be differential (has KCL with dq/dt term)
+        @test diff_vars[vcc] == true
+
+        # Charge variable should be ALGEBRAIC (constraint q = Q(V))
+        @test diff_vars[q_idx] == false
+
+        # Current variable (voltage source) should be algebraic
+        I_idx = 2  # After vcc node
+        @test diff_vars[I_idx] == false
+    end
+
+    @testset "KCL has dq/dt terms" begin
+        # Create circuit with nonlinear cap between two nodes
+        ctx = MNAContext()
+        p = get_node!(ctx, :p)
+        n = get_node!(ctx, :n)
+
+        C0 = 1e-12
+        q_fn(V) = C0 * V^2
+
+        x = [1.0, 0.5]  # [Vp, Vn]
+        q_idx = stamp_charge_state!(ctx, p, n, q_fn, x, :Q_cap)
+
+        sys = assemble!(ctx)
+
+        # KCL at p includes +dq/dt (current leaves)
+        @test sys.C[p, q_idx] ≈ 1.0
+
+        # KCL at n includes -dq/dt (current enters)
+        @test sys.C[n, q_idx] ≈ -1.0
+
+        # Constraint row has no C entries (algebraic)
+        @test sys.C[q_idx, q_idx] ≈ 0.0
+        @test sys.C[q_idx, p] ≈ 0.0
+        @test sys.C[q_idx, n] ≈ 0.0
+    end
+end


### PR DESCRIPTION
Implement runtime detection of voltage-dependent capacitors using nested automatic differentiation, avoiding AST analysis. When detected, the charge formulation reformulates the problem with an explicit charge state variable to achieve a constant mass matrix suitable for SciML solvers.

Key changes:
- Add CapacitanceDerivTag for second derivative detection
- Add is_voltage_dependent_charge() using triple-nested duals
- Add stamp_charge_state!() for charge formulation stamping
- Add stamp_reactive_with_detection!() helper for automatic detection
- Update MNASystem and MNAContext to track charge variables
- Add comprehensive tests for charge formulation

The charge constraint is algebraic (no C matrix diagonal entry), with dq/dt terms appearing in KCL equations via C[p, q_idx] coupling. This correctly enforces q = Q(V) at each time step rather than relaxing to it.

Detection uses perturbation (tests at V and V+ε) to achieve type-level detection, catching cases like Q = V³ where ∂²Q/∂V² = 0 at V=0.