### PR TITLE
Reduce nested duals from 3 to 2 for VA device stamping

### DIFF
--- a/src/mna/context.jl
+++ b/src/mna/context.jl
@@ -9,6 +9,7 @@
 
 export MNAContext, MNASystem
 export MNAIndex, NodeIndex, CurrentIndex, ChargeIndex, GroundIndex
+export ZeroVector, ZERO_VECTOR
 export get_node!, alloc_current!, get_current_idx, has_current, resolve_index
 export alloc_internal_node!, is_internal_node, n_internal_nodes
 export alloc_charge!, get_charge_idx, has_charge, n_charges
@@ -79,6 +80,30 @@ Base.iszero(::GroundIndex) = true
 Base.iszero(::NodeIndex) = false
 Base.iszero(::CurrentIndex) = false
 Base.iszero(::ChargeIndex) = false
+
+#==============================================================================#
+# ZeroVector - phantom vector for initial stamping
+#
+# During initial circuit stamping, there's no state vector yet. Instead of
+# runtime bounds checks like `isempty(x) || i > length(x) ? 0.0 : x[i]`,
+# we use a ZeroVector that returns 0.0 for any index access.
+#==============================================================================#
+
+"""
+    ZeroVector
+
+A phantom vector that returns 0.0 for any index access.
+Used as the default `_mna_x_` during initial stamping when there's no state vector yet.
+
+This eliminates runtime bounds checks in voltage/current extraction code.
+Any getindex call returns 0.0, including index 0 (ground) and out-of-bounds indices.
+"""
+struct ZeroVector <: AbstractVector{Float64} end
+
+Base.size(::ZeroVector) = (0,)
+Base.getindex(::ZeroVector, ::Integer) = 0.0
+
+const ZERO_VECTOR = ZeroVector()
 
 """
     MNAContext

--- a/src/mna/context.jl
+++ b/src/mna/context.jl
@@ -163,6 +163,11 @@ mutable struct MNAContext
     # Branch nodes (p, n) for each charge - links charge to KCL
     charge_branches::Vector{Tuple{Int,Int}}
 
+    # Cache for voltage-dependent charge detection (build-time optimization)
+    # Maps charge_name => is_voltage_dependent
+    # This allows detection to run once at circuit construction, not every Newton iteration
+    charge_is_vdep::Dict{Symbol, Bool}
+
     # Track if system has been finalized
     finalized::Bool
 end
@@ -192,6 +197,7 @@ function MNAContext()
         Symbol[],           # charge_names
         0,                  # n_charges
         Tuple{Int,Int}[],   # charge_branches
+        Dict{Symbol,Bool}(), # charge_is_vdep (detection cache)
         false               # finalized
     )
 end

--- a/src/mna/contrib.jl
+++ b/src/mna/contrib.jl
@@ -131,14 +131,16 @@ Tag ordering rules ensure ForwardDiff.Tag{F,V} is inner to our tags.
 """
 @inline function is_voltage_dependent_charge(contrib_fn, Vp::Real, Vn::Real)::Bool
     # Extract charge from contribution - returns the reactive part
-    # Strips any JacobianTag wrapper that may leak from outer scope
     function extract_charge(Vpn)
         result = contrib_fn(Vpn)
         if result isa Dual{ContributionTag}
             # Has ddt: get the reactive part (charge)
             react = partials(result, 1)
-            # Strip JacobianTag if present (leaked from outer scope)
-            # Keep only the ForwardDiff.derivative's tag or scalar
+            # Strip JacobianTag if present - can leak from outer stamp! scope
+            # because the detection lambda is called during Newton iteration
+            # where node voltages are JacobianTag duals. Even with let-block
+            # shadowing, some expressions in sum_expr may reference unshadowed
+            # variables or parameters that carry JacobianTag.
             while react isa Dual{JacobianTag}
                 react = value(react)
             end

--- a/src/mna/devices.jl
+++ b/src/mna/devices.jl
@@ -1145,7 +1145,7 @@ The stamp! method takes `x` parameter for the current operating point.
 
 # Example
 ```julia
-function build_circuit(params, spec; x=Float64[])
+function build_circuit(params, spec; x=ZERO_VECTOR)
     ctx = MNAContext()
     vin = get_node!(ctx, :vin)
     out = get_node!(ctx, :out)

--- a/src/mna/precompile.jl
+++ b/src/mna/precompile.jl
@@ -157,7 +157,7 @@ Create a mutable evaluation workspace for the given compiled structure.
 function create_workspace(cs::CompiledStructure{F,P,S}) where {F,P,S}
     # Create a preallocated MNAContext for this workspace
     # We call the builder once to get a fully initialized context with correct structure
-    ctx = cs.builder(cs.params, cs.spec, 0.0; x=Float64[])
+    ctx = cs.builder(cs.params, cs.spec, 0.0; x=ZERO_VECTOR)
 
     # Check if builder supports ctx reuse
     ctx_reuse = supports_ctx_kwarg(cs.builder, cs.params, cs.spec)
@@ -367,7 +367,7 @@ then creates the sparse matrices and COO→CSC mappings.
 
 # Arguments
 - `builder`: Circuit builder function with signature:
-    `(params, spec, t::Real=0.0; x=Float64[]) -> MNAContext`
+    `(params, spec, t::Real=0.0; x=ZERO_VECTOR) -> MNAContext`
   Time is passed explicitly for zero-allocation iteration.
 - `params`: Circuit parameters (NamedTuple)
 - `spec`: Simulation specification (MNASpec)
@@ -378,7 +378,7 @@ Use `create_workspace(cs)` to create a mutable workspace for evaluation.
 """
 function compile_structure(builder::F, params::P, spec::S) where {F,P,S}
     # First pass: discover structure at zero operating point (t=0.0)
-    ctx0 = builder(params, spec, 0.0; x=Float64[])
+    ctx0 = builder(params, spec, 0.0; x=ZERO_VECTOR)
     n = system_size(ctx0)
 
     if n == 0
@@ -453,7 +453,7 @@ then creates the sparse matrices and COO→CSC mappings.
 
 # Arguments
 - `builder`: Circuit builder function with signature:
-    `(params, spec, t::Real=0.0; x=Float64[]) -> MNAContext`
+    `(params, spec, t::Real=0.0; x=ZERO_VECTOR) -> MNAContext`
   Time is passed explicitly for zero-allocation iteration.
 - `params`: Circuit parameters (NamedTuple)
 - `spec`: Simulation specification (MNASpec)
@@ -506,7 +506,7 @@ points, consider:
 function compile_circuit(builder::F, params::P, spec::S;
                         capacity_factor::Float64=2.0) where {F,P,S}
     # First pass: discover structure at zero operating point (t=0.0)
-    ctx0 = builder(params, spec, 0.0; x=Float64[])
+    ctx0 = builder(params, spec, 0.0; x=ZERO_VECTOR)
     n = system_size(ctx0)
 
     # Check if builder supports ctx reuse (for zero-allocation path)
@@ -813,7 +813,7 @@ Time is passed explicitly to the builder, avoiding MNASpec allocation.
 
 # Builder API
 Builders must accept time as explicit parameter:
-    builder(params, spec, t::Real; x=Float64[]) -> MNAContext
+    builder(params, spec, t::Real; x=ZERO_VECTOR) -> MNAContext
 
 The spec contains temperature, mode, and tolerances (immutable during simulation).
 Time is passed separately since it changes every iteration.
@@ -963,7 +963,7 @@ during transient simulation.
 # Usage
 ```julia
 # Define circuit builder
-function build_rc(params, spec; x=Float64[])
+function build_rc(params, spec; x=ZERO_VECTOR)
     ctx = MNAContext()
     # ... stamp devices ...
     return ctx

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -1737,11 +1737,14 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
 
     # Generate branch current extraction for named branches
     # ZeroVector returns 0.0 for any index, eliminating bounds checks
+    # NOTE: We use begin/end instead of let to avoid local scope issues
+    # (the variable must be accessible in contrib_eval and voltage_stamp_code)
     branch_current_extraction = Expr(:block)
     for (branch_name, I_var) in branch_current_vars
         I_sym = Symbol("_I_branch_", branch_name)
         push!(branch_current_extraction.args,
-            :(let _i_idx = CedarSim.MNA.resolve_index(ctx, $I_var)
+            :(begin
+                _i_idx = CedarSim.MNA.resolve_index(ctx, $I_var)
                 $I_sym = _mna_x_[_i_idx]
             end))
     end

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -1558,7 +1558,7 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
         push!(branch_stamp.args, quote
             if has_reactive
                 # Get cached voltage dependence result (populated by detection_block)
-                _is_voltage_dependent = get(ctx.charge_is_vdep, $charge_name_expr, false)
+                _is_voltage_dependent = Base.get(ctx.charge_is_vdep, $charge_name_expr, false)
                 if _is_voltage_dependent
                     # Voltage-dependent charge: use charge formulation for constant mass matrix
                     # Allocate charge variable (or get existing one)
@@ -1954,7 +1954,7 @@ function make_mna_module(va::VANode)
 
     Expr(:toplevel, :(baremodule $s
         using Base: AbstractVector, Real, Symbol, Float64, Int, String, isempty, max, zeros, zero, length
-        using Base: hasproperty, getproperty, getfield, error, !==, iszero, abs, get
+        using Base: hasproperty, getproperty, getfield, error, !==, iszero, abs
         import Base  # For getproperty override in aliasparam
         import ..CedarSim
         using ..CedarSim.VerilogAEnvironment
@@ -2153,7 +2153,7 @@ function load_mna_va_modules(into::Module, file::String)
             # Create module expression
             module_expr = :(baremodule $mod_name
                 using Base: AbstractVector, Real, Symbol, Float64, Int, String, isempty, max, zeros, zero, length
-                using Base: hasproperty, getproperty, getfield, error, !==, iszero, abs, get
+                using Base: hasproperty, getproperty, getfield, error, !==, iszero, abs
                 import Base
                 import ..CedarSim
                 using ..CedarSim.VerilogAEnvironment

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -1738,9 +1738,11 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
     branch_current_extraction = Expr(:block)
     for (branch_name, I_var) in branch_current_vars
         I_sym = Symbol("_I_branch_", branch_name)
-        # Check for valid positive index within bounds
+        # Use resolve_index to get actual system index, check if x is large enough
         push!(branch_current_extraction.args,
-            :($I_sym = isempty(_mna_x_) || $I_var < 1 || $I_var > length(_mna_x_) ? 0.0 : _mna_x_[$I_var]))
+            :(let _i_idx = CedarSim.MNA.resolve_index(ctx, $I_var)
+                $I_sym = isempty(_mna_x_) || _i_idx < 1 || _i_idx > length(_mna_x_) ? 0.0 : _mna_x_[_i_idx]
+            end))
     end
 
     # Initialize branch current variables for named branches that don't have voltage contributions

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -1452,55 +1452,27 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
             I_branch = $sum_expr
 
             if I_branch isa ForwardDiff.Dual{CedarSim.MNA.ContributionTag}
-                # Has ddt: ContributionTag wraps voltage duals
+                # Has ddt: ContributionTag wraps JacobianTag duals
                 I_resist = ForwardDiff.value(I_branch)       # Dual{JacobianTag} for I and ∂I/∂V
                 I_react = ForwardDiff.partials(I_branch, 1)  # Dual{JacobianTag} for q and ∂q/∂V
 
-                # Extract resistive values - unwrap CapacitanceDerivTag layer
-                _I_inner = ForwardDiff.value(I_resist)  # Dual{CapacitanceDerivTag}
-                I_val = ForwardDiff.value(_I_inner)     # Float64
+                # Extract resistive values (JacobianTag partials are plain floats)
+                I_val = ForwardDiff.value(I_resist)
+                $([:($(Symbol("dI_dV", k)) = ForwardDiff.partials(I_resist, $k)) for k in 1:n_all_nodes]...)
 
-                # Extract dI/dV - each is Dual{CapacitanceDerivTag}, take value
-                $([:($(Symbol("dI_dV", k)) = ForwardDiff.value(ForwardDiff.partials(I_resist, $k))) for k in 1:n_all_nodes]...)
-
-                # Extract charge value - unwrap CapacitanceDerivTag layer
-                _q_inner = ForwardDiff.value(I_react)   # Dual{CapacitanceDerivTag}
-                q_val = ForwardDiff.value(_q_inner)     # Float64
-
-                # Extract dq/dV - each is Dual{CapacitanceDerivTag}
-                # Keep as dual to check second derivatives for voltage dependence
-                $([:($(Symbol("dq_dV_dual", k)) = ForwardDiff.partials(I_react, $k)) for k in 1:n_all_nodes]...)
-
-                # Extract actual capacitance values (first derivatives)
-                $([:($(Symbol("dq_dV", k)) = ForwardDiff.value($(Symbol("dq_dV_dual", k)))) for k in 1:n_all_nodes]...)
-
-                # Check for voltage-dependent charge by looking at second derivatives
-                # If any d²q/dV² ≠ 0, the charge is voltage-dependent
-                _is_voltage_dependent = false
-                $([quote
-                    _dq_dual = $(Symbol("dq_dV_dual", k))
-                    if _dq_dual isa ForwardDiff.Dual
-                        for _p in ForwardDiff.partials(_dq_dual)
-                            if !iszero(_p)
-                                _is_voltage_dependent = true
-                                break
-                            end
-                        end
-                    end
-                end for k in 1:n_all_nodes]...)
+                # Extract charge value and capacitances
+                q_val = ForwardDiff.value(I_react)
+                $([:($(Symbol("dq_dV", k)) = ForwardDiff.partials(I_react, $k)) for k in 1:n_all_nodes]...)
 
                 has_reactive = true
 
             elseif I_branch isa ForwardDiff.Dual
-                # Pure resistive: just voltage dual, no ContributionTag
-                # Unwrap CapacitanceDerivTag layer
-                _I_inner = ForwardDiff.value(I_branch)  # Dual{CapacitanceDerivTag}
-                I_val = ForwardDiff.value(_I_inner)
-                $([:($(Symbol("dI_dV", k)) = ForwardDiff.value(ForwardDiff.partials(I_branch, $k))) for k in 1:n_all_nodes]...)
+                # Pure resistive: just JacobianTag dual, no ContributionTag
+                I_val = ForwardDiff.value(I_branch)
+                $([:($(Symbol("dI_dV", k)) = ForwardDiff.partials(I_branch, $k)) for k in 1:n_all_nodes]...)
                 q_val = 0.0
                 $([:($(Symbol("dq_dV", k)) = 0.0) for k in 1:n_all_nodes]...)
                 has_reactive = false
-                _is_voltage_dependent = false
 
             else
                 # Scalar result (constant contribution)
@@ -1509,7 +1481,6 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
                 q_val = 0.0
                 $([:($(Symbol("dq_dV", k)) = 0.0) for k in 1:n_all_nodes]...)
                 has_reactive = false
-                _is_voltage_dependent = false
             end
         end
 
@@ -1542,9 +1513,38 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
         #
         # For linear capacitors, we use standard C matrix stamping (no extra variables).
 
-        # Build the stamping code with runtime detection
+        # Build the stamping code with cached detection
+        # Detection runs BEFORE evaluating the main contribution
+        # Uses a let block to ensure proper scoping and avoid dual type conflicts
+
+        # Generate bindings for all node symbols within the detection lambda
+        # Use let block to ensure complete isolation from outer scope
+        detect_let_bindings = Expr(:block)
+        for sym in all_node_syms
+            if sym == p_sym
+                push!(detect_let_bindings.args, :($sym = _Vpn))
+            elseif sym == n_sym
+                push!(detect_let_bindings.args, :($sym = zero(_Vpn)))
+            else
+                push!(detect_let_bindings.args, :($sym = zero(_Vpn)))
+            end
+        end
+
         push!(branch_stamp.args, quote
             if has_reactive
+                # Check voltage dependence using cached detection (runs once at build time)
+                # Use let block to completely shadow all node symbols
+                _is_voltage_dependent = CedarSim.MNA.detect_or_cached!(
+                    ctx, $charge_name_expr,
+                    function (_Vpn)
+                        # Use let to create fresh bindings that shadow outer scope
+                        let $([:($(sym) = $(sym == p_sym ? :_Vpn : :(zero(_Vpn)))) for sym in all_node_syms]...)
+                            $sum_expr
+                        end
+                    end,
+                    $(Symbol("V_", p_idx !== nothing ? p_idx : 1)),
+                    $(Symbol("V_", n_idx !== nothing ? n_idx : 1))
+                )
                 if _is_voltage_dependent
                     # Voltage-dependent charge: use charge formulation for constant mass matrix
                     # Allocate charge variable (or get existing one)
@@ -1699,37 +1699,17 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
     # Generate dual creation for all nodes (terminals + internal)
     # Each node gets a dual with identity partials: ∂V_i/∂V_k = δ_ik
     #
-    # For voltage-dependent capacitor detection, we use triple-nested duals:
-    # CapacitanceDerivTag < JacobianTag < ContributionTag
-    #
-    # Inner (CapacitanceDerivTag): carries ∂/∂V for second derivative detection
-    # Outer (JacobianTag): carries ∂/∂V for Jacobian extraction
-    #
-    # When we extract dq_dV from the reactive part, it will be Dual{CapacitanceDerivTag}.
-    # If its partials are non-zero, d²q/dV² ≠ 0 → voltage-dependent charge.
+    # We use single-layer JacobianTag duals for ddx() support.
+    # Voltage-dependent capacitor detection uses detect_or_cached!() which
+    # internally uses triple-nested duals but only on first call (build time).
+    # This avoids expensive nested duals during Newton iterations (solve time).
     dual_creation = Expr(:block)
     for i in 1:n_all_nodes
         node_sym = all_node_syms[i]
-        # Create inner dual (CapacitanceDerivTag) with partials for second derivative
-        inner_partials = Expr(:tuple, [k == i ? 1.0 : 0.0 for k in 1:n_all_nodes]...)
-        inner_dual = :(Dual{CedarSim.MNA.CapacitanceDerivTag}($(Symbol("V_", i)), $inner_partials...))
-
-        # Create outer dual (JacobianTag) wrapping the inner dual
-        # The partials are also inner duals to propagate second derivatives
-        outer_partials_exprs = []
-        for k in 1:n_all_nodes
-            if k == i
-                # ∂V_i/∂V_i = 1 (inner dual with value 1, zero partials)
-                push!(outer_partials_exprs, :(Dual{CedarSim.MNA.CapacitanceDerivTag}(1.0, $(Expr(:tuple, zeros(n_all_nodes)...)))))
-            else
-                # ∂V_i/∂V_k = 0 (inner dual with value 0, zero partials)
-                push!(outer_partials_exprs, :(Dual{CedarSim.MNA.CapacitanceDerivTag}(0.0, $(Expr(:tuple, zeros(n_all_nodes)...)))))
-            end
-        end
-        outer_partials = Expr(:tuple, outer_partials_exprs...)
-
+        # Create JacobianTag dual with identity partials for ddx() support
+        partials = Expr(:tuple, [k == i ? 1.0 : 0.0 for k in 1:n_all_nodes]...)
         push!(dual_creation.args,
-            :($node_sym = Dual{CedarSim.MNA.JacobianTag}($inner_dual, $outer_partials...)))
+            :($node_sym = Dual{CedarSim.MNA.JacobianTag}($(Symbol("V_", i)), $partials...)))
     end
 
     # Generate branch current extraction for named branches

--- a/test/mna/charge_formulation.jl
+++ b/test/mna/charge_formulation.jl
@@ -7,7 +7,7 @@
 using Test
 using CedarSim
 using CedarSim.MNA
-using CedarSim.MNA: va_ddt, is_voltage_dependent_charge, CapacitanceDerivTag
+using CedarSim.MNA: va_ddt, is_voltage_dependent_charge
 using CedarSim.MNA: ContributionTag, JacobianTag
 using ForwardDiff: Dual, value, partials
 

--- a/test/mna/vadistiller_integration.jl
+++ b/test/mna/vadistiller_integration.jl
@@ -23,6 +23,7 @@ using ForwardDiff: Dual, value, partials
 using OrdinaryDiffEq: QNDF
 using VerilogAParser
 using Sundials: IDA
+using SciMLBase
 using CedarSim: tran!, dc!
 
 const deftol = 1e-6


### PR DESCRIPTION
This optimization reduces the number of nested dual layers used during Newton iterations from 3 (CapacitanceDerivTag + JacobianTag + ContributionTag) to 2 (JacobianTag + ContributionTag).

Key changes:
- Move voltage-dependent capacitor detection to build time via caching
- Add detect_or_cached!() helper that runs detection once per branch
- Simplify dual creation to use only JacobianTag (CapacitanceDerivTag is now only used internally by detect_or_cached! on first call)
- Use let block in detection lambda to ensure proper scope isolation

This reduces the AD overhead when SciML threads its own AD through complex models like BSIM4/PSP103, going from 4 nested dual layers to 3.