### PR TITLE
Implement ValueOnlyContext support for Verilog-A code

### DIFF
--- a/src/mna/context.jl
+++ b/src/mna/context.jl
@@ -193,6 +193,10 @@ mutable struct MNAContext
     # This allows detection to run once at circuit construction, not every Newton iteration
     charge_is_vdep::Dict{Symbol, Bool}
 
+    # Order of charge detection calls (for ValueOnlyContext counter-based access)
+    # Populated by detect_or_cached! in the order calls are made
+    charge_is_vdep_order::Vector{Symbol}
+
     # Track if system has been finalized
     finalized::Bool
 end
@@ -223,6 +227,7 @@ function MNAContext()
         0,                  # n_charges
         Tuple{Int,Int}[],   # charge_branches
         Dict{Symbol,Bool}(), # charge_is_vdep (detection cache)
+        Symbol[],           # charge_is_vdep_order (insertion order for value-only mode)
         false               # finalized
     )
 end
@@ -803,6 +808,8 @@ function clear!(ctx::MNAContext)
     empty!(ctx.charge_names)
     ctx.n_charges = 0
     empty!(ctx.charge_branches)
+    empty!(ctx.charge_is_vdep)
+    empty!(ctx.charge_is_vdep_order)
     ctx.finalized = false
     return nothing
 end

--- a/src/mna/contrib.jl
+++ b/src/mna/contrib.jl
@@ -171,11 +171,14 @@ end
 Check cache for voltage-dependent charge detection result, or run detection if not cached.
 
 This is a build-time optimization: detection only needs to run once per branch.
-After the first call, results are cached in the context.
+After the first call, results are cached in the context using counter-based access.
+
+On first run through stamp code: pos > length(cache), so detect and push result.
+On subsequent runs (re-stamping): pos <= length(cache), so return cached result.
 
 # Arguments
 - `ctx`: MNA context containing the detection cache
-- `name`: Unique name for this branch (used as cache key)
+- `name`: Unique name for this branch (ignored, uses counter access)
 - `contrib_fn`: Contribution function `V -> I` that may contain `va_ddt(Q(V))`
 - `Vp`, `Vn`: Operating point voltages
 
@@ -196,16 +199,18 @@ end
 """
 @inline function detect_or_cached!(ctx::MNAContext, name::Symbol, contrib_fn, Vp::Real, Vn::Real)::Bool
     cache = ctx.charge_is_vdep
-    cached = get(cache, name, nothing)
-    if cached !== nothing
-        return cached
+    pos = ctx.charge_detection_pos
+    ctx.charge_detection_pos = pos + 1
+
+    if pos > length(cache)
+        # First time: run detection and cache result
+        result = is_voltage_dependent_charge(contrib_fn, Vp, Vn)
+        push!(cache, result)
+        return result
+    else
+        # Subsequent runs: return cached result
+        return @inbounds cache[pos]
     end
-    # First time: run detection via finite-difference (comparing C at two voltages)
-    result = is_voltage_dependent_charge(contrib_fn, Vp, Vn)
-    cache[name] = result
-    # Track insertion order for ValueOnlyContext counter-based access
-    push!(ctx.charge_is_vdep_order, name)
-    return result
 end
 
 """
@@ -232,10 +237,15 @@ export detect_or_cached!
 """
     get_is_vdep(ctx::MNAContext, name::Symbol) -> Bool
 
-Get cached voltage-dependent charge detection result by name.
+Counter-based lookup of cached charge detection result.
 Used in generated stamp code to check if a branch has voltage-dependent capacitance.
+The name parameter is ignored - uses position counter for O(1) access.
 """
-@inline get_is_vdep(ctx::MNAContext, name::Symbol)::Bool = get(ctx.charge_is_vdep, name, false)
+@inline function get_is_vdep(ctx::MNAContext, name::Symbol)::Bool
+    pos = ctx.charge_detection_pos
+    ctx.charge_detection_pos = pos + 1
+    return @inbounds ctx.charge_is_vdep[pos]
+end
 
 """
     get_is_vdep(vctx::ValueOnlyContext, name::Symbol) -> Bool
@@ -255,7 +265,7 @@ end
 Reset the charge detection counter for the stamping phase.
 Called between detection_block and stamp_code in generated VA stamp methods.
 """
-@inline reset_detection_counter!(::MNAContext) = nothing  # No-op for MNAContext (uses Dict)
+@inline reset_detection_counter!(ctx::MNAContext) = (ctx.charge_detection_pos = 1; nothing)
 @inline reset_detection_counter!(vctx::ValueOnlyContext) = (vctx.charge_detection_pos = 1; nothing)
 
 export get_is_vdep, reset_detection_counter!


### PR DESCRIPTION
Add zero-allocation mode for VA-generated stamp! methods:

- Add charge_is_vdep_order::Vector{Symbol} to MNAContext to track detection order for counter-based access in ValueOnlyContext
- Add charge_is_vdep::Vector{Bool} and charge_detection_pos to ValueOnlyContext for O(1) cached charge detection lookup
- Add charge_pos counter to ValueOnlyContext for alloc_charge!
- Add detect_or_cached!(::ValueOnlyContext, ...) method that uses counter-based lookup instead of Dict
- Add get_is_vdep helper for both context types
- Add reset_detection_counter! to reset counter between detection and stamp phases
- Add alloc_internal_node! and alloc_charge! methods for ValueOnlyContext
- Update VA stamp! method signature from MNAContext to AnyMNAContext
- Update vasim.jl to use get_is_vdep and reset_detection_counter!
- Update generated module imports to include new helpers

This enables true zero-allocation Newton iterations for circuits containing Verilog-A devices with voltage-dependent capacitance.