### PR TITLE
Fix variable declarations in named analog blocks not being initialized

### DIFF
--- a/benchmarks/vacask/run_benchmarks.jl
+++ b/benchmarks/vacask/run_benchmarks.jl
@@ -219,13 +219,8 @@ function main()
     push!(results, run_rc_benchmark())
     push!(results, run_graetz_benchmark())
     push!(results, run_mul_benchmark())
-
-    # PSP103-based benchmarks are disabled until PSP103 model initialization is fixed
-    # See benchmarks/vacask/cedarsim/STATUS.md for details
-    # push!(results, run_ring_benchmark())
-    # push!(results, run_c6288_benchmark())
-    push!(results, BenchmarkResult("Ring Oscillator", :skipped, "PSP103 model initialization not yet supported"))
-    push!(results, BenchmarkResult("C6288 Multiplier", :skipped, "PSP103 model initialization not yet supported"))
+    push!(results, run_ring_benchmark())
+    push!(results, run_c6288_benchmark())
 
     println()
     println("=" ^ 60)


### PR DESCRIPTION
Verilog-A allows variable declarations inside named blocks like `begin : evaluateblock`. The PSP103 model uses this extensively.

Previously, these nested declarations were not being extracted and added to var_types, causing UndefVarError for variables like Igdov when they were referenced in detection closures before being assigned.

This adds collect_nested_var_decls! which walks the analog block AST to find all IntRealDeclaration nodes in named blocks (AnalogSeqBlock with a non-null decl field) and adds them to var_types so they're initialized in local_var_init before use.