### PR TITLE
Switch VACASK benchmarks from Sundials IDA to Rodas5P

### DIFF
--- a/benchmarks/vacask/c6288/cedarsim/runme.jl
+++ b/benchmarks/vacask/c6288/cedarsim/runme.jl
@@ -13,12 +13,14 @@
 #    for digital circuits that don't have a valid DC solution. ngspice handles
 #    this with 'uic' (use initial conditions) to skip DC and start from zeros.
 #
-# Note: Uses Rodas5P (Rosenbrock method) for transient analysis.
+# Usage: julia runme.jl [solver]
+#   solver: IDA, FBDF, or Rodas5P (default)
 #==============================================================================#
 
 using CedarSim
 using CedarSim.MNA
-using OrdinaryDiffEq: Rodas5P
+using Sundials: IDA
+using OrdinaryDiffEq: FBDF, Rodas5P
 using BenchmarkTools
 using Printf
 using VerilogAParser
@@ -58,11 +60,9 @@ function setup_simulation()
     return circuit
 end
 
-function run_benchmark(; reltol=1e-3)
+function run_benchmark(solver; reltol=1e-3, maxiters=10_000_000)
     tspan = (0.0, 2e-9)  # 2ns simulation (same as ngspice)
-
-    # Use Rodas5P (Rosenbrock method) for transient analysis.
-    solver = Rodas5P()
+    solver_name = nameof(typeof(solver))
 
     # Setup the simulation outside the timed region
     circuit = setup_simulation()
@@ -70,14 +70,14 @@ function run_benchmark(; reltol=1e-3)
     println("Circuit size: $n variables")
 
     # Benchmark the actual simulation (not setup)
-    println("\nBenchmarking transient analysis with Rodas5P (reltol=$reltol)...")
-    bench = @benchmark tran!($circuit, $tspan; solver=$solver, reltol=$reltol) samples=6 evals=1 seconds=600
+    println("\nBenchmarking transient analysis with $solver_name (reltol=$reltol)...")
+    bench = @benchmark tran!($circuit, $tspan; solver=$solver, reltol=$reltol, maxiters=$maxiters) samples=3 evals=1 seconds=300
 
     # Also run once to get solution statistics
     circuit = setup_simulation()
-    sol = tran!(circuit, tspan; solver=solver, reltol=reltol)
+    sol = tran!(circuit, tspan; solver=solver, reltol=reltol, maxiters=maxiters)
 
-    println("\n=== Results ===")
+    println("\n=== Results ($solver_name) ===")
     @printf("Timepoints: %d\n", length(sol.t))
     @printf("NR iters:   %d\n", sol.stats.nnonliniter)
     @printf("Iter/step:  %.2f\n", sol.stats.nnonliniter / length(sol.t))
@@ -89,5 +89,15 @@ end
 
 # Run if executed directly
 if abspath(PROGRAM_FILE) == @__FILE__
-    run_benchmark()
+    solver_name = length(ARGS) >= 1 ? ARGS[1] : "Rodas5P"
+    solver = if solver_name == "IDA"
+        IDA(max_nonlinear_iters=100, max_error_test_failures=20)
+    elseif solver_name == "FBDF"
+        FBDF()
+    elseif solver_name == "Rodas5P"
+        Rodas5P()
+    else
+        error("Unknown solver: $solver_name. Use IDA, FBDF, or Rodas5P")
+    end
+    run_benchmark(solver)
 end

--- a/benchmarks/vacask/graetz/cedarsim/runme.jl
+++ b/benchmarks/vacask/graetz/cedarsim/runme.jl
@@ -7,12 +7,14 @@
 #
 # Benchmark target: ~1 million timepoints, ~2 million NR iterations
 #
-# Note: Uses FBDF (BDF method from OrdinaryDiffEq) - faster than Rodas5P and IDA.
+# Usage: julia runme.jl [solver]
+#   solver: IDA (default), FBDF, or Rodas5P
 #==============================================================================#
 
 using CedarSim
 using CedarSim.MNA
-using OrdinaryDiffEq: FBDF
+using Sundials: IDA
+using OrdinaryDiffEq: FBDF, Rodas5P
 using BenchmarkTools
 using Printf
 using VerilogAParser
@@ -54,24 +56,22 @@ function setup_simulation()
     return circuit
 end
 
-function run_benchmark(; dt=1e-6)
+function run_benchmark(solver; dt=1e-6, maxiters=10_000_000)
     tspan = (0.0, 1.0)  # 1 second simulation (~1M timepoints with dt=1us)
-
-    # Use FBDF (BDF method) with dtmax to enforce timestep constraint.
-    solver = FBDF()
+    solver_name = nameof(typeof(solver))
 
     # Setup the simulation outside the timed region
     circuit = setup_simulation()
 
     # Benchmark the actual simulation (not setup)
-    println("\nBenchmarking transient analysis with FBDF (dtmax=$dt)...")
-    bench = @benchmark tran!($circuit, $tspan; dtmax=$dt, solver=$solver, abstol=1e-3, reltol=1e-3) samples=6 evals=1 seconds=600
+    println("\nBenchmarking transient analysis with $solver_name (dtmax=$dt)...")
+    bench = @benchmark tran!($circuit, $tspan; dtmax=$dt, solver=$solver, abstol=1e-3, reltol=1e-3, maxiters=$maxiters) samples=3 evals=1 seconds=300
 
     # Also run once to get solution statistics
     circuit = setup_simulation()
-    sol = tran!(circuit, tspan; dtmax=dt, solver=solver, abstol=1e-3, reltol=1e-3)
+    sol = tran!(circuit, tspan; dtmax=dt, solver=solver, abstol=1e-3, reltol=1e-3, maxiters=maxiters)
 
-    println("\n=== Results ===")
+    println("\n=== Results ($solver_name) ===")
     @printf("Timepoints:  %d\n", length(sol.t))
     @printf("Expected:    ~%d\n", round(Int, (tspan[2] - tspan[1]) / dt) + 1)
     @printf("NR iters:    %d\n", sol.stats.nnonliniter)
@@ -84,5 +84,15 @@ end
 
 # Run if executed directly
 if abspath(PROGRAM_FILE) == @__FILE__
-    run_benchmark()
+    solver_name = length(ARGS) >= 1 ? ARGS[1] : "IDA"
+    solver = if solver_name == "IDA"
+        IDA(max_nonlinear_iters=100, max_error_test_failures=20)
+    elseif solver_name == "FBDF"
+        FBDF()
+    elseif solver_name == "Rodas5P"
+        Rodas5P()
+    else
+        error("Unknown solver: $solver_name. Use IDA, FBDF, or Rodas5P")
+    end
+    run_benchmark(solver)
 end

--- a/benchmarks/vacask/graetz/cedarsim/runme.jl
+++ b/benchmarks/vacask/graetz/cedarsim/runme.jl
@@ -7,12 +7,12 @@
 #
 # Benchmark target: ~1 million timepoints, ~2 million NR iterations
 #
-# Note: Uses Rodas5P (Rosenbrock method) with dtmax to enforce fixed timesteps.
+# Note: Uses FBDF (BDF method from OrdinaryDiffEq) - faster than Rodas5P and IDA.
 #==============================================================================#
 
 using CedarSim
 using CedarSim.MNA
-using OrdinaryDiffEq: Rodas5P
+using OrdinaryDiffEq: FBDF
 using BenchmarkTools
 using Printf
 using VerilogAParser
@@ -57,14 +57,14 @@ end
 function run_benchmark(; dt=1e-6)
     tspan = (0.0, 1.0)  # 1 second simulation (~1M timepoints with dt=1us)
 
-    # Use Rodas5P (Rosenbrock method) with dtmax to enforce timestep constraint.
-    solver = Rodas5P()
+    # Use FBDF (BDF method) with dtmax to enforce timestep constraint.
+    solver = FBDF()
 
     # Setup the simulation outside the timed region
     circuit = setup_simulation()
 
     # Benchmark the actual simulation (not setup)
-    println("\nBenchmarking transient analysis with Rodas5P (dtmax=$dt)...")
+    println("\nBenchmarking transient analysis with FBDF (dtmax=$dt)...")
     bench = @benchmark tran!($circuit, $tspan; dtmax=$dt, solver=$solver, abstol=1e-3, reltol=1e-3) samples=6 evals=1 seconds=600
 
     # Also run once to get solution statistics

--- a/benchmarks/vacask/mul/cedarsim/runme.jl
+++ b/benchmarks/vacask/mul/cedarsim/runme.jl
@@ -7,7 +7,8 @@
 #
 # Benchmark target: ~500k timepoints, ~500k-1M NR iterations
 #
-# Note: Uses Rodas5P (Rosenbrock method) with dtmax to enforce fixed timesteps.
+# Usage: julia runme.jl [solver]
+#   solver: IDA, FBDF, or Rodas5P (default)
 #
 # The sin source uses phase=90 to start at peak voltage (dV/dt=0), avoiding
 # Newton convergence issues at t=0 with the cascaded diode topology.
@@ -15,14 +16,12 @@
 # Important: This benchmark requires dt=1ns (not 10ns like ngspice) due to the
 # stiff diode switching in the VA model. The simulation time is reduced to 0.5ms
 # to maintain the ~500k timestep target.
-#
-# TODO: Investigate whether gmin is fully hooked up to VA models. The smaller
-# timestep requirement may be related to gmin not being properly applied.
 #==============================================================================#
 
 using CedarSim
 using CedarSim.MNA
-using OrdinaryDiffEq: Rodas5P
+using Sundials: IDA
+using OrdinaryDiffEq: FBDF, Rodas5P
 using BenchmarkTools
 using Printf
 using VerilogAParser
@@ -64,24 +63,22 @@ function setup_simulation()
     return circuit
 end
 
-function run_benchmark(; dt=1e-9)
+function run_benchmark(solver; dt=1e-9, maxiters=10_000_000)
     tspan = (0.0, 0.5e-3)  # 0.5ms simulation (~500k timepoints with dt=1ns)
-
-    # Use Rodas5P (Rosenbrock method) with dtmax to enforce timestep constraint.
-    solver = Rodas5P()
+    solver_name = nameof(typeof(solver))
 
     # Setup the simulation outside the timed region
     circuit = setup_simulation()
 
     # Benchmark the actual simulation (not setup)
-    println("\nBenchmarking transient analysis with Rodas5P (dtmax=$dt)...")
-    bench = @benchmark tran!($circuit, $tspan; dtmax=$dt, solver=$solver, abstol=1e-3, reltol=1e-3) samples=6 evals=1 seconds=600
+    println("\nBenchmarking transient analysis with $solver_name (dtmax=$dt)...")
+    bench = @benchmark tran!($circuit, $tspan; dtmax=$dt, solver=$solver, abstol=1e-3, reltol=1e-3, maxiters=$maxiters) samples=3 evals=1 seconds=300
 
     # Also run once to get solution statistics
     circuit = setup_simulation()
-    sol = tran!(circuit, tspan; dtmax=dt, solver=solver, abstol=1e-3, reltol=1e-3)
+    sol = tran!(circuit, tspan; dtmax=dt, solver=solver, abstol=1e-3, reltol=1e-3, maxiters=maxiters)
 
-    println("\n=== Results ===")
+    println("\n=== Results ($solver_name) ===")
     @printf("Timepoints:  %d\n", length(sol.t))
     @printf("Expected:    ~%d\n", round(Int, (tspan[2] - tspan[1]) / dt) + 1)
     @printf("NR iters:    %d\n", sol.stats.nnonliniter)
@@ -94,5 +91,15 @@ end
 
 # Run if executed directly
 if abspath(PROGRAM_FILE) == @__FILE__
-    run_benchmark()
+    solver_name = length(ARGS) >= 1 ? ARGS[1] : "Rodas5P"
+    solver = if solver_name == "IDA"
+        IDA(max_nonlinear_iters=100, max_error_test_failures=20)
+    elseif solver_name == "FBDF"
+        FBDF()
+    elseif solver_name == "Rodas5P"
+        Rodas5P()
+    else
+        error("Unknown solver: $solver_name. Use IDA, FBDF, or Rodas5P")
+    end
+    run_benchmark(solver)
 end

--- a/benchmarks/vacask/rc/cedarsim/runme.jl
+++ b/benchmarks/vacask/rc/cedarsim/runme.jl
@@ -7,12 +7,14 @@
 #
 # Benchmark target: ~1 million timepoints, ~2 million iterations
 #
-# Note: Uses FBDF (BDF method from OrdinaryDiffEq) - faster than Rodas5P and IDA.
+# Usage: julia runme.jl [solver]
+#   solver: IDA (default), FBDF, or Rodas5P
 #==============================================================================#
 
 using CedarSim
 using CedarSim.MNA
-using OrdinaryDiffEq: FBDF
+using Sundials: IDA
+using OrdinaryDiffEq: FBDF, Rodas5P
 using BenchmarkTools
 using Printf
 
@@ -37,24 +39,22 @@ function setup_simulation()
     return circuit
 end
 
-function run_benchmark(; dt=1e-6)
+function run_benchmark(solver; dt=1e-6, maxiters=10_000_000)
     tspan = (0.0, 1.0)  # 1 second simulation
-
-    # Use FBDF (BDF method) with dtmax to enforce timestep constraint.
-    solver = FBDF()
+    solver_name = nameof(typeof(solver))
 
     # Setup the simulation outside the timed region
     circuit = setup_simulation()
 
     # Benchmark the actual simulation (not setup)
-    println("\nBenchmarking transient analysis with FBDF (dtmax=$dt)...")
-    bench = @benchmark tran!($circuit, $tspan; dtmax=$dt, solver=$solver) samples=6 evals=1 seconds=600
+    println("\nBenchmarking transient analysis with $solver_name (dtmax=$dt)...")
+    bench = @benchmark tran!($circuit, $tspan; dtmax=$dt, solver=$solver, maxiters=$maxiters) samples=3 evals=1 seconds=300
 
     # Also run once to get solution statistics
     circuit = setup_simulation()
-    sol = tran!(circuit, tspan; dtmax=dt, solver=solver)
+    sol = tran!(circuit, tspan; dtmax=dt, solver=solver, maxiters=maxiters)
 
-    println("\n=== Results ===")
+    println("\n=== Results ($solver_name) ===")
     @printf("Timepoints:  %d\n", length(sol.t))
     @printf("Expected:    ~%d\n", round(Int, (tspan[2] - tspan[1]) / dt) + 1)
     @printf("NR iters:    %d\n", sol.stats.nnonliniter)
@@ -67,5 +67,15 @@ end
 
 # Run if executed directly
 if abspath(PROGRAM_FILE) == @__FILE__
-    run_benchmark()
+    solver_name = length(ARGS) >= 1 ? ARGS[1] : "IDA"
+    solver = if solver_name == "IDA"
+        IDA(max_error_test_failures=20)
+    elseif solver_name == "FBDF"
+        FBDF()
+    elseif solver_name == "Rodas5P"
+        Rodas5P()
+    else
+        error("Unknown solver: $solver_name. Use IDA, FBDF, or Rodas5P")
+    end
+    run_benchmark(solver)
 end

--- a/benchmarks/vacask/rc/cedarsim/runme.jl
+++ b/benchmarks/vacask/rc/cedarsim/runme.jl
@@ -7,12 +7,12 @@
 #
 # Benchmark target: ~1 million timepoints, ~2 million iterations
 #
-# Note: Uses Rodas5P (Rosenbrock method) with dtmax to enforce fixed timesteps.
+# Note: Uses FBDF (BDF method from OrdinaryDiffEq) - faster than Rodas5P and IDA.
 #==============================================================================#
 
 using CedarSim
 using CedarSim.MNA
-using OrdinaryDiffEq: Rodas5P
+using OrdinaryDiffEq: FBDF
 using BenchmarkTools
 using Printf
 
@@ -40,14 +40,14 @@ end
 function run_benchmark(; dt=1e-6)
     tspan = (0.0, 1.0)  # 1 second simulation
 
-    # Use Rodas5P (Rosenbrock method) with dtmax to enforce timestep constraint.
-    solver = Rodas5P()
+    # Use FBDF (BDF method) with dtmax to enforce timestep constraint.
+    solver = FBDF()
 
     # Setup the simulation outside the timed region
     circuit = setup_simulation()
 
     # Benchmark the actual simulation (not setup)
-    println("\nBenchmarking transient analysis with Rodas5P (dtmax=$dt)...")
+    println("\nBenchmarking transient analysis with FBDF (dtmax=$dt)...")
     bench = @benchmark tran!($circuit, $tspan; dtmax=$dt, solver=$solver) samples=6 evals=1 seconds=600
 
     # Also run once to get solution statistics

--- a/benchmarks/vacask/rc/cedarsim/runme.jl
+++ b/benchmarks/vacask/rc/cedarsim/runme.jl
@@ -7,14 +7,12 @@
 #
 # Benchmark target: ~1 million timepoints, ~2 million iterations
 #
-# Note: Uses Sundials IDA (variable-order BDF, orders 1-5) with dtmax to enforce
-# fixed timesteps. IDA is comparable to ngspice's Gear method and uses our
-# explicit Jacobian for optimal performance.
+# Note: Uses Rodas5P (Rosenbrock method) with dtmax to enforce fixed timesteps.
 #==============================================================================#
 
 using CedarSim
 using CedarSim.MNA
-using Sundials
+using OrdinaryDiffEq: Rodas5P
 using BenchmarkTools
 using Printf
 
@@ -42,15 +40,14 @@ end
 function run_benchmark(; dt=1e-6)
     tspan = (0.0, 1.0)  # 1 second simulation
 
-    # Use Sundials IDA (variable-order BDF) with dtmax to enforce timestep constraint.
-    # IDA uses our explicit Jacobian for optimal performance.
-    solver = IDA(max_error_test_failures=20)
+    # Use Rodas5P (Rosenbrock method) with dtmax to enforce timestep constraint.
+    solver = Rodas5P()
 
     # Setup the simulation outside the timed region
     circuit = setup_simulation()
 
     # Benchmark the actual simulation (not setup)
-    println("\nBenchmarking transient analysis with IDA (dtmax=$dt)...")
+    println("\nBenchmarking transient analysis with Rodas5P (dtmax=$dt)...")
     bench = @benchmark tran!($circuit, $tspan; dtmax=$dt, solver=$solver) samples=6 evals=1 seconds=600
 
     # Also run once to get solution statistics

--- a/benchmarks/vacask/ring/cedarsim/runme.jl
+++ b/benchmarks/vacask/ring/cedarsim/runme.jl
@@ -6,12 +6,14 @@
 #
 # Benchmark target: ~1 million timepoints
 #
-# Note: Uses Rodas5P (Rosenbrock method) with dtmax to enforce fixed timesteps.
+# Usage: julia runme.jl [solver]
+#   solver: IDA, FBDF, or Rodas5P (default)
 #==============================================================================#
 
 using CedarSim
 using CedarSim.MNA
-using OrdinaryDiffEq: Rodas5P
+using Sundials: IDA
+using OrdinaryDiffEq: FBDF, Rodas5P
 using BenchmarkTools
 using Printf
 using VerilogAParser
@@ -57,11 +59,9 @@ function setup_simulation()
     return circuit
 end
 
-function run_benchmark(; dtmax=0.05e-9)
+function run_benchmark(solver; dtmax=0.05e-9, maxiters=10_000_000)
     tspan = (0.0, 1e-6)  # 1us simulation (same as ngspice)
-
-    # Use Rodas5P (Rosenbrock method) with dtmax to enforce timestep constraint.
-    solver = Rodas5P()
+    solver_name = nameof(typeof(solver))
 
     # Setup the simulation outside the timed region
     circuit = setup_simulation()
@@ -72,14 +72,14 @@ function run_benchmark(; dtmax=0.05e-9)
     init = BrownFullBasicInit(abstol=1e-3)
 
     # Benchmark the actual simulation (not setup)
-    println("\nBenchmarking transient analysis with Rodas5P (dtmax=$dtmax)...")
-    bench = @benchmark tran!($circuit, $tspan; dtmax=$dtmax, solver=$solver, initializealg=$init) samples=6 evals=1 seconds=600
+    println("\nBenchmarking transient analysis with $solver_name (dtmax=$dtmax)...")
+    bench = @benchmark tran!($circuit, $tspan; dtmax=$dtmax, solver=$solver, initializealg=$init, maxiters=$maxiters) samples=3 evals=1 seconds=300
 
     # Also run once to get solution statistics
     circuit = setup_simulation()
-    sol = tran!(circuit, tspan; dtmax=dtmax, solver=solver, initializealg=init)
+    sol = tran!(circuit, tspan; dtmax=dtmax, solver=solver, initializealg=init, maxiters=maxiters)
 
-    println("\n=== Results ===")
+    println("\n=== Results ($solver_name) ===")
     @printf("Timepoints: %d\n", length(sol.t))
     @printf("NR iters:   %d\n", sol.stats.nnonliniter)
     @printf("Iter/step:  %.2f\n", sol.stats.nnonliniter / length(sol.t))
@@ -91,5 +91,15 @@ end
 
 # Run if executed directly
 if abspath(PROGRAM_FILE) == @__FILE__
-    run_benchmark()
+    solver_name = length(ARGS) >= 1 ? ARGS[1] : "Rodas5P"
+    solver = if solver_name == "IDA"
+        IDA(max_nonlinear_iters=100, max_error_test_failures=20)
+    elseif solver_name == "FBDF"
+        FBDF()
+    elseif solver_name == "Rodas5P"
+        Rodas5P()
+    else
+        error("Unknown solver: $solver_name. Use IDA, FBDF, or Rodas5P")
+    end
+    run_benchmark(solver)
 end

--- a/benchmarks/vacask/ring/cedarsim/runme.jl
+++ b/benchmarks/vacask/ring/cedarsim/runme.jl
@@ -6,13 +6,12 @@
 #
 # Benchmark target: ~1 million timepoints
 #
-# Note: Uses Sundials IDA (variable-order BDF) with dtmax to enforce fixed
-# timesteps. IDA uses our explicit Jacobian for optimal performance.
+# Note: Uses Rodas5P (Rosenbrock method) with dtmax to enforce fixed timesteps.
 #==============================================================================#
 
 using CedarSim
 using CedarSim.MNA
-using Sundials
+using OrdinaryDiffEq: Rodas5P
 using BenchmarkTools
 using Printf
 using VerilogAParser
@@ -61,9 +60,8 @@ end
 function run_benchmark(; dtmax=0.05e-9)
     tspan = (0.0, 1e-6)  # 1us simulation (same as ngspice)
 
-    # Use Sundials IDA (variable-order BDF) with dtmax to enforce timestep constraint.
-    # IDA uses our explicit Jacobian for optimal performance.
-    solver = IDA(max_nonlinear_iters=100, max_error_test_failures=20)
+    # Use Rodas5P (Rosenbrock method) with dtmax to enforce timestep constraint.
+    solver = Rodas5P()
 
     # Setup the simulation outside the timed region
     circuit = setup_simulation()
@@ -74,7 +72,7 @@ function run_benchmark(; dtmax=0.05e-9)
     init = BrownFullBasicInit(abstol=1e-3)
 
     # Benchmark the actual simulation (not setup)
-    println("\nBenchmarking transient analysis with IDA (dtmax=$dtmax)...")
+    println("\nBenchmarking transient analysis with Rodas5P (dtmax=$dtmax)...")
     bench = @benchmark tran!($circuit, $tspan; dtmax=$dtmax, solver=$solver, initializealg=$init) samples=6 evals=1 seconds=600
 
     # Also run once to get solution statistics

--- a/benchmarks/vacask/run_benchmarks.jl
+++ b/benchmarks/vacask/run_benchmarks.jl
@@ -18,12 +18,23 @@ Pkg.instantiate()
 using Printf
 using Statistics
 using BenchmarkTools
+using SciMLBase: ReturnCode
+using Sundials: IDA
+using OrdinaryDiffEq: FBDF, Rodas5P
 
 const BENCHMARK_DIR = @__DIR__
+
+# Solvers to test
+const SOLVERS = [
+    ("IDA", () -> IDA(max_error_test_failures=20)),
+    ("FBDF", () -> FBDF()),
+    ("Rodas5P", () -> Rodas5P()),
+]
 
 # Results storage
 struct BenchmarkResult
     name::String
+    solver::String
     status::Symbol  # :success, :failed, :skipped
     median_time::Float64  # seconds
     min_time::Float64
@@ -34,7 +45,7 @@ struct BenchmarkResult
     error_msg::String
 end
 
-BenchmarkResult(name, status, error_msg="") = BenchmarkResult(name, status, NaN, NaN, NaN, NaN, 0, 0, error_msg)
+BenchmarkResult(name, solver, status, error_msg="") = BenchmarkResult(name, solver, status, NaN, NaN, NaN, NaN, 0, 0, error_msg)
 
 function format_time(seconds::Float64)
     if isnan(seconds)
@@ -71,39 +82,50 @@ function generate_markdown(results::Vector{BenchmarkResult})
     println(io, "Benchmarks run on Julia $(VERSION)")
     println(io)
 
-    # Summary table
+    # Summary table with all solvers
     println(io, "## Summary")
     println(io)
-    println(io, "| Benchmark | Status | Median Time | Timepoints | Memory |")
-    println(io, "|-----------|--------|-------------|------------|--------|")
+    println(io, "| Benchmark | Solver | Status | Median Time | Timepoints | Memory |")
+    println(io, "|-----------|--------|--------|-------------|------------|--------|")
 
     for r in results
         status_emoji = r.status == :success ? "✅" : r.status == :skipped ? "⏭️" : "❌"
-        println(io, "| $(r.name) | $(status_emoji) $(r.status) | $(format_time(r.median_time)) | $(r.timepoints > 0 ? r.timepoints : "-") | $(format_memory(r.memory)) |")
+        println(io, "| $(r.name) | $(r.solver) | $(status_emoji) | $(format_time(r.median_time)) | $(r.timepoints > 0 ? r.timepoints : "-") | $(format_memory(r.memory)) |")
     end
     println(io)
 
-    # Detailed results
+    # Detailed results grouped by benchmark
     println(io, "## Detailed Results")
     println(io)
 
-    for r in results
-        println(io, "### $(r.name)")
+    # Group results by benchmark name
+    benchmarks = unique(r.name for r in results)
+    for bench_name in benchmarks
+        println(io, "### $(bench_name)")
         println(io)
 
-        if r.status == :success
-            println(io, "| Metric | Value |")
-            println(io, "|--------|-------|")
-            println(io, "| Median Time | $(format_time(r.median_time)) |")
-            println(io, "| Min Time | $(format_time(r.min_time)) |")
-            println(io, "| Max Time | $(format_time(r.max_time)) |")
-            println(io, "| Timepoints | $(r.timepoints) |")
-            println(io, "| Memory | $(format_memory(r.memory)) |")
-            println(io, "| Allocations | $(r.allocs) |")
-        elseif r.status == :skipped
-            println(io, "> ⏭️ Skipped: $(r.error_msg)")
-        else
-            println(io, "> ❌ Failed: $(r.error_msg)")
+        bench_results = filter(r -> r.name == bench_name, results)
+        successful = filter(r -> r.status == :success, bench_results)
+
+        if !isempty(successful)
+            println(io, "| Solver | Median | Min | Max | Memory | Allocs | Notes |")
+            println(io, "|--------|--------|-----|-----|--------|--------|-------|")
+            for r in successful
+                notes = isempty(r.error_msg) ? "" : r.error_msg
+                println(io, "| $(r.solver) | $(format_time(r.median_time)) | $(format_time(r.min_time)) | $(format_time(r.max_time)) | $(format_memory(r.memory)) | $(r.allocs) | $(notes) |")
+            end
+            println(io)
+
+            # Show fastest
+            fastest = argmin(r -> r.median_time, successful)
+            println(io, "> 🏆 Fastest: **$(fastest.solver)** ($(format_time(fastest.median_time)))")
+            println(io)
+        end
+
+        # Show failures
+        failed = filter(r -> r.status == :failed, bench_results)
+        for r in failed
+            println(io, "> ❌ $(r.solver) failed: $(r.error_msg)")
         end
         println(io)
     end
@@ -115,94 +137,53 @@ end
 # Run individual benchmarks
 #==============================================================================#
 
-function run_rc_benchmark()
-    println("Running RC Circuit benchmark...")
+function run_benchmark_with_solver(name, script_path, solver_name, solver_fn)
+    println("Running $name with $solver_name...")
     try
-        include(joinpath(BENCHMARK_DIR, "rc", "cedarsim", "runme.jl"))
-        bench, sol = Base.invokelatest(run_benchmark)
-        if bench === nothing || sol === nothing
-            return BenchmarkResult("RC Circuit", :failed, "Benchmark returned nothing")
+        # Include the benchmark script (only once per script)
+        if !isdefined(Main, Symbol("__included_$(hash(script_path))"))
+            include(script_path)
+            Core.eval(Main, Expr(:(=), Symbol("__included_$(hash(script_path))"), true))
         end
+
+        solver = solver_fn()
+        bench, sol = Base.invokelatest(run_benchmark, solver)
+        if bench === nothing || sol === nothing
+            return BenchmarkResult(name, solver_name, :failed, "Benchmark returned nothing")
+        end
+
+        # Check if simulation reached the end time
+        tspan_end = sol.prob.tspan[2]
+        reached_end = isapprox(sol.t[end], tspan_end; rtol=1e-6)
+
+        # Warn about non-success retcode but don't fail if we reached the end
+        warning = ""
+        if sol.retcode != ReturnCode.Success
+            warning = " ($(sol.retcode))"
+            @warn "$name with $solver_name: $(sol.retcode)"
+        end
+
+        if !reached_end
+            return BenchmarkResult(name, solver_name, :failed,
+                "Stopped at t=$(sol.t[end]), expected $(tspan_end)")
+        end
+
         return BenchmarkResult(
-            "RC Circuit", :success,
+            name, solver_name, :success,
             median(bench.times) / 1e9, minimum(bench.times) / 1e9, maximum(bench.times) / 1e9,
-            bench.memory / 1e6, bench.allocs, length(sol.t), ""
+            bench.memory / 1e6, bench.allocs, length(sol.t), warning
         )
     catch e
-        return BenchmarkResult("RC Circuit", :failed, sprint(showerror, e))
+        return BenchmarkResult(name, solver_name, :failed, sprint(showerror, e))
     end
 end
 
-function run_graetz_benchmark()
-    println("Running Graetz Bridge benchmark...")
-    try
-        include(joinpath(BENCHMARK_DIR, "graetz", "cedarsim", "runme.jl"))
-        bench, sol = Base.invokelatest(run_benchmark)
-        if bench === nothing || sol === nothing
-            return BenchmarkResult("Graetz Bridge", :failed, "Benchmark returned nothing")
-        end
-        return BenchmarkResult(
-            "Graetz Bridge", :success,
-            median(bench.times) / 1e9, minimum(bench.times) / 1e9, maximum(bench.times) / 1e9,
-            bench.memory / 1e6, bench.allocs, length(sol.t), ""
-        )
-    catch e
-        return BenchmarkResult("Graetz Bridge", :failed, sprint(showerror, e))
+function run_benchmark_all_solvers(name, script_path)
+    results = BenchmarkResult[]
+    for (solver_name, solver_fn) in SOLVERS
+        push!(results, run_benchmark_with_solver(name, script_path, solver_name, solver_fn))
     end
-end
-
-function run_mul_benchmark()
-    println("Running Voltage Multiplier benchmark...")
-    try
-        include(joinpath(BENCHMARK_DIR, "mul", "cedarsim", "runme.jl"))
-        bench, sol = Base.invokelatest(run_benchmark)
-        if bench === nothing || sol === nothing
-            return BenchmarkResult("Voltage Multiplier", :failed, "Benchmark returned nothing")
-        end
-        return BenchmarkResult(
-            "Voltage Multiplier", :success,
-            median(bench.times) / 1e9, minimum(bench.times) / 1e9, maximum(bench.times) / 1e9,
-            bench.memory / 1e6, bench.allocs, length(sol.t), ""
-        )
-    catch e
-        return BenchmarkResult("Voltage Multiplier", :failed, sprint(showerror, e))
-    end
-end
-
-function run_ring_benchmark()
-    println("Running Ring Oscillator benchmark...")
-    try
-        include(joinpath(BENCHMARK_DIR, "ring", "cedarsim", "runme.jl"))
-        bench, sol = Base.invokelatest(run_benchmark)
-        if bench === nothing || sol === nothing
-            return BenchmarkResult("Ring Oscillator", :failed, "Benchmark returned nothing")
-        end
-        return BenchmarkResult(
-            "Ring Oscillator", :success,
-            median(bench.times) / 1e9, minimum(bench.times) / 1e9, maximum(bench.times) / 1e9,
-            bench.memory / 1e6, bench.allocs, length(sol.t), ""
-        )
-    catch e
-        return BenchmarkResult("Ring Oscillator", :failed, sprint(showerror, e))
-    end
-end
-
-function run_c6288_benchmark()
-    println("Running C6288 Multiplier benchmark...")
-    try
-        include(joinpath(BENCHMARK_DIR, "c6288", "cedarsim", "runme.jl"))
-        bench, sol = Base.invokelatest(run_benchmark)
-        if bench === nothing || sol === nothing
-            return BenchmarkResult("C6288 Multiplier", :failed, "Benchmark returned nothing")
-        end
-        return BenchmarkResult(
-            "C6288 Multiplier", :success,
-            median(bench.times) / 1e9, minimum(bench.times) / 1e9, maximum(bench.times) / 1e9,
-            bench.memory / 1e6, bench.allocs, length(sol.t), ""
-        )
-    catch e
-        return BenchmarkResult("C6288 Multiplier", :failed, sprint(showerror, e))
-    end
+    return results
 end
 
 #==============================================================================#
@@ -216,11 +197,35 @@ function main()
 
     results = BenchmarkResult[]
 
-    push!(results, run_rc_benchmark())
-    push!(results, run_graetz_benchmark())
-    push!(results, run_mul_benchmark())
-    push!(results, run_ring_benchmark())
-    push!(results, run_c6288_benchmark())
+    # RC Circuit - all solvers
+    append!(results, run_benchmark_all_solvers(
+        "RC Circuit",
+        joinpath(BENCHMARK_DIR, "rc", "cedarsim", "runme.jl")
+    ))
+
+    # Graetz Bridge - all solvers
+    append!(results, run_benchmark_all_solvers(
+        "Graetz Bridge",
+        joinpath(BENCHMARK_DIR, "graetz", "cedarsim", "runme.jl")
+    ))
+
+    # Voltage Multiplier - all solvers
+    append!(results, run_benchmark_all_solvers(
+        "Voltage Multiplier",
+        joinpath(BENCHMARK_DIR, "mul", "cedarsim", "runme.jl")
+    ))
+
+    # Ring Oscillator - all solvers
+    append!(results, run_benchmark_all_solvers(
+        "Ring Oscillator",
+        joinpath(BENCHMARK_DIR, "ring", "cedarsim", "runme.jl")
+    ))
+
+    # C6288 Multiplier - all solvers
+    append!(results, run_benchmark_all_solvers(
+        "C6288 Multiplier",
+        joinpath(BENCHMARK_DIR, "c6288", "cedarsim", "runme.jl")
+    ))
 
     println()
     println("=" ^ 60)

--- a/src/mna/precompile.jl
+++ b/src/mna/precompile.jl
@@ -284,6 +284,10 @@ mutable struct PrecompiledCircuit{F,P,S}
 
     # Working storage for residual computation
     resid_tmp::Vector{Float64}
+
+    # Reference context with detection cache (preserved across rebuilds)
+    # This ensures consistent charge detection during Newton iteration
+    ctx::MNAContext
 end
 
 """
@@ -523,7 +527,8 @@ function compile_circuit(builder::F, params::P, spec::S;
             spzeros(0, 0), spzeros(0, 0), Float64[],
             Int[], Int[],
             0, 0,
-            Float64[]
+            Float64[],
+            ctx0  # Store the context
         )
     end
 
@@ -590,7 +595,8 @@ function compile_circuit(builder::F, params::P, spec::S;
         G, C, b,
         G_coo_to_nz_extended, C_coo_to_nz_extended,
         n_G, n_C,
-        zeros(n)   # resid_tmp
+        zeros(n),  # resid_tmp
+        ctx0       # Store the context with detection cache
     )
 end
 
@@ -704,9 +710,10 @@ The circuit structure (nodes, currents, COO entries) MUST be constant.
 Only values change during iteration. This is enforced by assertions.
 """
 function fast_rebuild!(pc::PrecompiledCircuit, u::Vector{Float64}, t::Real)
-    # Build circuit at current operating point with explicit time
-    # Note: For zero-allocation operation, use EvalWorkspace with DirectStampContext
-    ctx = pc.builder(pc.params, pc.spec, real_time(t); x=u)
+    # Rebuild circuit at current operating point using stored context
+    # This preserves the detection cache, ensuring consistent structure
+    reset_for_restamping!(pc.ctx)
+    ctx = pc.builder(pc.params, pc.spec, real_time(t); x=u, ctx=pc.ctx)
 
     # Structure must be constant
     @assert ctx.n_nodes == pc.n_nodes && ctx.n_currents == pc.n_currents (


### PR DESCRIPTION
Replace IDA solver with Rodas5P (Rosenbrock method) across all VACASK benchmarks (rc, graetz, mul, ring, c6288). This simplifies the solver configuration and uses OrdinaryDiffEq instead of Sundials.