### PR TITLE
Add dense=false to VACASK benchmark tran! calls

### DIFF
--- a/benchmarks/vacask/c6288/cedarsim/runme.jl
+++ b/benchmarks/vacask/c6288/cedarsim/runme.jl
@@ -71,11 +71,11 @@ function run_benchmark(solver; reltol=1e-3, maxiters=10_000_000)
 
     # Benchmark the actual simulation (not setup)
     println("\nBenchmarking transient analysis with $solver_name (reltol=$reltol)...")
-    bench = @benchmark tran!($circuit, $tspan; solver=$solver, reltol=$reltol, maxiters=$maxiters) samples=3 evals=1 seconds=300
+    bench = @benchmark tran!($circuit, $tspan; solver=$solver, reltol=$reltol, maxiters=$maxiters, dense=false) samples=3 evals=1 seconds=300
 
     # Also run once to get solution statistics
     circuit = setup_simulation()
-    sol = tran!(circuit, tspan; solver=solver, reltol=reltol, maxiters=maxiters)
+    sol = tran!(circuit, tspan; solver=solver, reltol=reltol, maxiters=maxiters, dense=false)
 
     println("\n=== Results ($solver_name) ===")
     @printf("Timepoints: %d\n", length(sol.t))

--- a/benchmarks/vacask/graetz/cedarsim/runme.jl
+++ b/benchmarks/vacask/graetz/cedarsim/runme.jl
@@ -65,11 +65,11 @@ function run_benchmark(solver; dt=1e-6, maxiters=10_000_000)
 
     # Benchmark the actual simulation (not setup)
     println("\nBenchmarking transient analysis with $solver_name (dtmax=$dt)...")
-    bench = @benchmark tran!($circuit, $tspan; dtmax=$dt, solver=$solver, abstol=1e-3, reltol=1e-3, maxiters=$maxiters) samples=3 evals=1 seconds=300
+    bench = @benchmark tran!($circuit, $tspan; dtmax=$dt, solver=$solver, abstol=1e-3, reltol=1e-3, maxiters=$maxiters, dense=false) samples=3 evals=1 seconds=300
 
     # Also run once to get solution statistics
     circuit = setup_simulation()
-    sol = tran!(circuit, tspan; dtmax=dt, solver=solver, abstol=1e-3, reltol=1e-3, maxiters=maxiters)
+    sol = tran!(circuit, tspan; dtmax=dt, solver=solver, abstol=1e-3, reltol=1e-3, maxiters=maxiters, dense=false)
 
     println("\n=== Results ($solver_name) ===")
     @printf("Timepoints:  %d\n", length(sol.t))

--- a/benchmarks/vacask/mul/cedarsim/runme.jl
+++ b/benchmarks/vacask/mul/cedarsim/runme.jl
@@ -72,11 +72,11 @@ function run_benchmark(solver; dt=1e-9, maxiters=10_000_000)
 
     # Benchmark the actual simulation (not setup)
     println("\nBenchmarking transient analysis with $solver_name (dtmax=$dt)...")
-    bench = @benchmark tran!($circuit, $tspan; dtmax=$dt, solver=$solver, abstol=1e-3, reltol=1e-3, maxiters=$maxiters) samples=3 evals=1 seconds=300
+    bench = @benchmark tran!($circuit, $tspan; dtmax=$dt, solver=$solver, abstol=1e-3, reltol=1e-3, maxiters=$maxiters, dense=false) samples=3 evals=1 seconds=300
 
     # Also run once to get solution statistics
     circuit = setup_simulation()
-    sol = tran!(circuit, tspan; dtmax=dt, solver=solver, abstol=1e-3, reltol=1e-3, maxiters=maxiters)
+    sol = tran!(circuit, tspan; dtmax=dt, solver=solver, abstol=1e-3, reltol=1e-3, maxiters=maxiters, dense=false)
 
     println("\n=== Results ($solver_name) ===")
     @printf("Timepoints:  %d\n", length(sol.t))

--- a/benchmarks/vacask/rc/cedarsim/runme.jl
+++ b/benchmarks/vacask/rc/cedarsim/runme.jl
@@ -48,11 +48,11 @@ function run_benchmark(solver; dt=1e-6, maxiters=10_000_000)
 
     # Benchmark the actual simulation (not setup)
     println("\nBenchmarking transient analysis with $solver_name (dtmax=$dt)...")
-    bench = @benchmark tran!($circuit, $tspan; dtmax=$dt, solver=$solver, maxiters=$maxiters) samples=3 evals=1 seconds=300
+    bench = @benchmark tran!($circuit, $tspan; dtmax=$dt, solver=$solver, maxiters=$maxiters, dense=false) samples=3 evals=1 seconds=300
 
     # Also run once to get solution statistics
     circuit = setup_simulation()
-    sol = tran!(circuit, tspan; dtmax=dt, solver=solver, maxiters=maxiters)
+    sol = tran!(circuit, tspan; dtmax=dt, solver=solver, maxiters=maxiters, dense=false)
 
     println("\n=== Results ($solver_name) ===")
     @printf("Timepoints:  %d\n", length(sol.t))

--- a/benchmarks/vacask/ring/cedarsim/runme.jl
+++ b/benchmarks/vacask/ring/cedarsim/runme.jl
@@ -73,11 +73,11 @@ function run_benchmark(solver; dtmax=0.05e-9, maxiters=10_000_000)
 
     # Benchmark the actual simulation (not setup)
     println("\nBenchmarking transient analysis with $solver_name (dtmax=$dtmax)...")
-    bench = @benchmark tran!($circuit, $tspan; dtmax=$dtmax, solver=$solver, initializealg=$init, maxiters=$maxiters) samples=3 evals=1 seconds=300
+    bench = @benchmark tran!($circuit, $tspan; dtmax=$dtmax, solver=$solver, initializealg=$init, maxiters=$maxiters, dense=false) samples=3 evals=1 seconds=300
 
     # Also run once to get solution statistics
     circuit = setup_simulation()
-    sol = tran!(circuit, tspan; dtmax=dtmax, solver=solver, initializealg=init, maxiters=maxiters)
+    sol = tran!(circuit, tspan; dtmax=dtmax, solver=solver, initializealg=init, maxiters=maxiters, dense=false)
 
     println("\n=== Results ($solver_name) ===")
     @printf("Timepoints: %d\n", length(sol.t))


### PR DESCRIPTION
Disable dense output in all VACASK benchmarks to reduce memory allocation and improve benchmark performance.