### PR TITLE
Fix sources for remote installation, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@ Cadnip is an MNA-based analog circuit simulator written in Julia, focused on sim
 
 ## Installation
 
-Cadnip works with release Julia and can be installed directly from GitHub:
+Install from GitHub by first adding the subpackages, then the main package:
 
 ```julia
 using Pkg
+Pkg.add(url="https://github.com/NyanCAD/Cadnip.jl", subdir="Lexers.jl")
+Pkg.add(url="https://github.com/NyanCAD/Cadnip.jl", subdir="SpectreNetlistParser.jl")
+Pkg.add(url="https://github.com/NyanCAD/Cadnip.jl", subdir="VerilogAParser.jl")
 Pkg.add(url="https://github.com/NyanCAD/Cadnip.jl")
 ```
 


### PR DESCRIPTION
Update README with working installation instructions:
- First add subpackages with subdir=, then add main package
- Also document clone+activate method for local development

Keep path-based [sources] for local development convenience. The subdir parameter in Pkg.add() allows installing packages from subdirectories of a monorepo, which makes remote installation work.