### PR TITLE
Add audio_integration.jl test file with BJT Ebers-Moll model

### DIFF
--- a/test/common.jl
+++ b/test/common.jl
@@ -233,5 +233,10 @@ function make_mna_spice_circuit(spice_code::String; temp::Real=27.0, imported_hd
     end
     circuit_fn = Base.eval(m, code)
 
-    return circuit_fn, m
+    # Wrap in invokelatest to handle world age issues (especially on Julia 1.12)
+    # This is needed because circuit_fn was defined via eval and may be called
+    # later from a different world age (e.g., inside MNACircuit/tran!)
+    wrapped_fn = (args...; kwargs...) -> Base.invokelatest(circuit_fn, args...; kwargs...)
+
+    return wrapped_fn, m
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -190,17 +190,25 @@ using CedarSim.MNA: MNACircuit
 
 Parse SPICE code and return an MNACircuit ready for simulation.
 
-Note: This uses `invokelatest` internally to handle world age issues with
-runtime-parsed code. For maximum performance in production, use the
-compile-time `mna_sp"..."` macro instead.
+This is a convenience function for test code. It uses `invokelatest` internally
+to handle world age issues with runtime-parsed code.
 
-# Example
+For production code loading SPICE from files, use the top-level eval pattern:
+
 ```julia
-va\"\"\"
-module npnbjt(b, e, c); ...
-endmodule
-\"\"\"
+# At module/file load time (top level)
+using CedarSim: parse_spice_to_mna
+const circuit_code = parse_spice_to_mna(read("circuit.sp", String);
+                                        imported_hdl_modules=[MyVA_module])
+eval(circuit_code)  # Defines `circuit` function, advances world
 
+# Now can use normally without invokelatest
+circuit = MNACircuit(circuit)
+sol = tran!(circuit, (0.0, 1e-3))
+```
+
+# Example (test code)
+```julia
 spice = \"\"\"
 * BJT amplifier
 V1 vcc 0 DC 12

--- a/test/mna/audio_integration.jl
+++ b/test/mna/audio_integration.jl
@@ -1,0 +1,435 @@
+#==============================================================================#
+# Audio Integration Tests: SPICE Circuits with Simplified Verilog-A BJT Models
+#
+# This file tests mixed SPICE/Verilog-A circuit simulation using:
+# - VA BJT models (Ebers-Moll equations)
+# - Transient simulation with sinusoidal inputs
+# - Signal processing analysis (gain measurement)
+#
+# Key patterns demonstrated:
+# 1. va"""...""" for creating device models
+# 2. Builder function pattern with solve_dc()
+# 3. tran!() for transient simulation
+# 4. MNASolutionAccessor for accessing results
+#==============================================================================#
+
+using Test
+using CedarSim
+using CedarSim.MNA
+using CedarSim.MNA: MNAContext, MNASpec, MNACircuit, MNASystem, MNASolutionAccessor
+using CedarSim.MNA: get_node!, stamp!, assemble!, solve_dc, reset_for_restamping!
+using CedarSim.MNA: voltage, current
+using CedarSim.MNA: VoltageSource, Resistor, Capacitor, SinVoltageSource
+using CedarSim: tran!
+using OrdinaryDiffEq
+using SciMLBase
+
+const deftol = 1e-6
+isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
+
+#==============================================================================#
+# BJT Device Model: Simplified Ebers-Moll
+#
+# The Ebers-Moll model describes BJT behavior using two coupled diodes:
+# - Base-emitter junction: forward biased in active mode
+# - Base-collector junction: reverse biased in active mode
+#
+# Parameters (hardcoded for simplicity):
+# - Is = 1e-14 A (saturation current)
+# - Vt = 25 mV (thermal voltage at room temp)
+# - BF = 100 (forward current gain)
+#
+# Terminal currents:
+# Ibe = Is*(exp(Vbe/Vt) - 1) - Is/(1+BF)*(exp(Vbc/Vt) - 1)
+# Icb = BF/(1+BF)*Is*(exp(Vbe/Vt) - 1) - Is*(exp(Vbc/Vt) - 1)
+#==============================================================================#
+
+va"""
+module npnBJTEbersMoll(b, e, c);
+    inout b, e, c;
+    electrical b, e, c;
+    analog I(b,e) <+ 1.0e-14*(exp(V(b,e)/25.0e-3) - 1) - 1.0/(1 + 100.0)*1.0e-14*(exp(V(b,c)/25.0e-3) - 1);
+    analog I(c,b) <+ 100.0/(1 + 100.0)*1.0e-14*(exp(V(b,e)/25.0e-3) - 1) - 1.0e-14*(exp(V(b,c)/25.0e-3) - 1);
+endmodule
+"""
+
+@testset "Audio Integration Tests" begin
+
+    #==========================================================================#
+    # Test 1: BJT with Fixed Voltage Sources
+    #
+    # Test the BJT model at a known operating point using voltage sources.
+    # This verifies the BJT model produces correct terminal currents.
+    #==========================================================================#
+    @testset "BJT with fixed voltages - active region" begin
+        # Apply known voltages and verify currents
+        # Vbe = 0.65V (forward biased), Vbc = -4.35V (reverse biased)
+        # Active mode: Ic ≈ BF * Ib
+
+        function bjt_fixed_voltage(params, spec, t::Real=0.0; x=Float64[])
+            ctx = MNAContext()
+            b = get_node!(ctx, :b)
+            c = get_node!(ctx, :c)
+
+            # Fixed voltage sources to set operating point
+            stamp!(VoltageSource(0.65; name=:Vbe), ctx, b, 0)    # Base at 0.65V
+            stamp!(VoltageSource(5.0; name=:Vce), ctx, c, 0)     # Collector at 5V
+
+            # BJT: b, e, c with emitter grounded
+            stamp!(npnBJTEbersMoll(), ctx, b, 0, c; _mna_x_=x)
+
+            return ctx
+        end
+
+        sol = solve_dc(bjt_fixed_voltage, (;), MNASpec())
+
+        # Check voltages are as expected
+        @test isapprox(voltage(sol, :b), 0.65; atol=1e-6)
+        @test isapprox(voltage(sol, :c), 5.0; atol=1e-6)
+
+        # The voltage source currents tell us the terminal currents
+        I_Vbe = current(sol, :I_Vbe)  # Current into base
+        I_Vce = current(sol, :I_Vce)  # Current into collector
+
+        # Base current should be small (μA range), collector current larger (mA range)
+        # For Vbe=0.65V: Ib ≈ 19μA, Ic ≈ 1.9mA
+        @test abs(I_Vbe) > 1e-6   # Base current exists
+        @test abs(I_Vce) > abs(I_Vbe)  # Collector current > base current
+
+        # Check that Ic/Ib ≈ BF (current gain)
+        BF = 100.0
+        @test abs(I_Vce / I_Vbe) > 0.8 * BF
+    end
+
+    #==========================================================================#
+    # Test 2: BJT with Collector Resistor (Simplest Amplifier)
+    #
+    # Use voltage sources for base bias (stable convergence) and
+    # a resistor load at the collector. This forms the simplest amplifier.
+    #==========================================================================#
+    @testset "BJT with collector resistor" begin
+        # Circuit:
+        # Vcc --+-- Rc --+-- collector
+        #       |        |
+        #       |      (BJT)
+        #       |        |
+        #      Vb ----+--base
+        #              \
+        #               emitter -- gnd
+
+        function bjt_with_rc(params, spec, t::Real=0.0; x=Float64[])
+            ctx = MNAContext()
+            vcc = get_node!(ctx, :vcc)
+            base = get_node!(ctx, :base)
+            coll = get_node!(ctx, :coll)
+
+            # Power supply
+            stamp!(VoltageSource(params.Vcc; name=:Vcc), ctx, vcc, 0)
+
+            # Base bias voltage (stable convergence)
+            stamp!(VoltageSource(params.Vb; name=:Vb), ctx, base, 0)
+
+            # Collector load resistor
+            stamp!(Resistor(params.Rc), ctx, vcc, coll)
+
+            # NPN BJT: b, e, c terminals - emitter grounded
+            stamp!(npnBJTEbersMoll(), ctx, base, 0, coll; _mna_x_=x)
+
+            return ctx
+        end
+
+        params = (Vcc=12.0, Vb=0.65, Rc=4.7e3)
+        sol = solve_dc(bjt_with_rc, params, MNASpec())
+
+        V_coll = voltage(sol, :coll)
+        V_base = voltage(sol, :base)
+
+        # Base should be at Vb
+        @test isapprox(V_base, params.Vb; atol=1e-6)
+
+        # Collector voltage = Vcc - Ic * Rc
+        # For Vbe=0.65V, Ic ≈ 1.9mA, so Vc ≈ 12 - 1.9e-3 * 4.7e3 ≈ 3.1V
+        @test V_coll > 1.0 && V_coll < 10.0  # In reasonable range
+        @test V_coll < params.Vcc  # Below supply
+    end
+
+    #==========================================================================#
+    # Test 3: Common Emitter Amplifier Transient with Sine Input
+    #
+    # This is the main test: a common emitter amplifier with:
+    # - Fixed DC bias using voltage source (for stable convergence)
+    # - Small-signal sinusoidal input superimposed
+    # - Measurement of voltage gain
+    #==========================================================================#
+    @testset "Common emitter amplifier transient" begin
+
+        function build_ce_amplifier(params, spec, t::Real=0.0; x=Float64[], ctx=nothing)
+            if ctx === nothing
+                ctx = MNAContext()
+            else
+                reset_for_restamping!(ctx)
+            end
+
+            vcc = get_node!(ctx, :vcc)
+            base = get_node!(ctx, :base)
+            coll = get_node!(ctx, :coll)
+
+            # Power supply
+            stamp!(VoltageSource(params.Vcc; name=:Vcc), ctx, vcc, 0)
+
+            # Input: DC bias + small sinusoidal signal directly at base
+            # Using SIN source: V(t) = Vdc + Vac * sin(2π*freq*t)
+            sin_src = SinVoltageSource(
+                params.Vbias,   # DC offset (sets Vbe operating point)
+                params.Vac,     # AC amplitude (small signal)
+                params.freq;    # Frequency
+                name=:Vin
+            )
+            stamp!(sin_src, ctx, base, 0, t, spec.mode)
+
+            # Collector load resistor
+            stamp!(Resistor(params.Rc), ctx, vcc, coll)
+
+            # Small load capacitor (represents parasitic/output capacitance)
+            # This provides differential states for the transient solver
+            stamp!(Capacitor(params.Cload), ctx, coll, 0)
+
+            # NPN BJT: b, e, c terminals - emitter grounded
+            stamp!(npnBJTEbersMoll(), ctx, base, 0, coll; _mna_x_=x)
+
+            return ctx
+        end
+
+        # Circuit parameters - designed for small-signal linear amplification
+        params = (
+            Vcc = 12.0,        # Supply voltage
+            Vbias = 0.65,      # DC bias at base (sets Vbe)
+            Vac = 0.001,       # 1mV AC amplitude (small signal)
+            freq = 1000.0,     # 1kHz audio frequency
+            Rc = 4.7e3,        # Collector load
+            Cload = 100e-12    # 100pF load capacitor (parasitic/output)
+        )
+
+        # First verify DC operating point
+        dc_sol = solve_dc(build_ce_amplifier, params, MNASpec())
+        V_coll_dc = voltage(dc_sol, :coll)
+        V_base_dc = voltage(dc_sol, :base)
+
+        # Verify BJT is biased properly
+        @test isapprox(V_base_dc, params.Vbias; atol=0.01)
+        @test V_coll_dc > 1.0 && V_coll_dc < 11.0
+
+        # Create circuit for transient
+        circuit = MNACircuit(build_ce_amplifier; params...)
+
+        # Run transient simulation
+        freq = params.freq
+        period = 1.0 / freq
+        tspan = (0.0, 5 * period)  # 5 periods
+
+        sol = tran!(circuit, tspan; solver=Rodas5P(), abstol=1e-9, reltol=1e-7)
+        @test sol.retcode == ReturnCode.Success
+
+        # Access results
+        sys = assemble!(circuit)
+        acc = MNASolutionAccessor(sol, sys)
+
+        # Measure output after initial transient (last 2 periods)
+        t_start = 3 * period
+        times = range(t_start, 5*period; length=100)
+
+        V_coll = [voltage(acc, :coll, t) for t in times]
+        V_base = [voltage(acc, :base, t) for t in times]
+
+        # Calculate peak-to-peak voltages
+        Vout_pp = maximum(V_coll) - minimum(V_coll)
+        Vin_pp = maximum(V_base) - minimum(V_base)
+
+        # Input should be 2mV peak-to-peak (1mV amplitude)
+        @test isapprox(Vin_pp, 2 * params.Vac; rtol=0.15)
+
+        # Calculate voltage gain magnitude
+        gain = Vout_pp / Vin_pp
+
+        # Common emitter gain: |Av| ≈ gm * Rc where gm = Ic/Vt
+        # For Ic ≈ 1.9mA, Vt = 25mV: gm ≈ 76mS
+        # Expected gain: gm * Rc ≈ 76e-3 * 4.7e3 ≈ 357
+        # But this is very high - let's just check it's significant
+        @test gain > 10.0    # Should have significant amplification
+        @test gain < 1000.0  # But not unreasonably large
+
+        # Verify phase inversion (input peak → output trough)
+        t_max_inp = times[argmax(V_base)]
+        V_out_at_inp_max = voltage(acc, :coll, t_max_inp)
+
+        # At input maximum, output should be below DC level (inverted)
+        @test V_out_at_inp_max < V_coll_dc
+    end
+
+    #==========================================================================#
+    # Test 4: Gain Measurement with Different Signal Levels
+    #
+    # Test linearity by measuring gain with different input amplitudes.
+    # For small signals, gain should be relatively constant.
+    #==========================================================================#
+    @testset "Gain linearity with signal level" begin
+
+        function build_ce_amp_level(params, spec, t::Real=0.0; x=Float64[], ctx=nothing)
+            if ctx === nothing
+                ctx = MNAContext()
+            else
+                reset_for_restamping!(ctx)
+            end
+
+            vcc = get_node!(ctx, :vcc)
+            base = get_node!(ctx, :base)
+            coll = get_node!(ctx, :coll)
+
+            # Power supply
+            stamp!(VoltageSource(params.Vcc; name=:Vcc), ctx, vcc, 0)
+
+            # Input with configurable AC amplitude
+            sin_src = SinVoltageSource(params.Vbias, params.Vac, params.freq; name=:Vin)
+            stamp!(sin_src, ctx, base, 0, t, spec.mode)
+
+            # Collector load
+            stamp!(Resistor(params.Rc), ctx, vcc, coll)
+            stamp!(Capacitor(params.Cload), ctx, coll, 0)
+
+            # BJT
+            stamp!(npnBJTEbersMoll(), ctx, base, 0, coll; _mna_x_=x)
+
+            return ctx
+        end
+
+        base_params = (
+            Vcc = 12.0,
+            Vbias = 0.65,
+            Vac = 0.001,  # Will vary this
+            freq = 1000.0,
+            Rc = 4.7e3,
+            Cload = 100e-12
+        )
+
+        gains = Float64[]
+
+        # Test with different input levels (all small-signal)
+        for vac in [0.0005, 0.001, 0.002]
+            params = merge(base_params, (Vac=vac,))
+            circuit = MNACircuit(build_ce_amp_level; params...)
+
+            period = 1.0 / params.freq
+            tspan = (0.0, 5 * period)
+
+            sol = tran!(circuit, tspan; solver=Rodas5P(), abstol=1e-9, reltol=1e-7)
+
+            if sol.retcode == ReturnCode.Success
+                sys = assemble!(circuit)
+                acc = MNASolutionAccessor(sol, sys)
+
+                # Measure in last 2 periods
+                t_start = 3 * period
+                times = range(t_start, 5*period; length=100)
+
+                V_coll = [voltage(acc, :coll, t) for t in times]
+                V_base = [voltage(acc, :base, t) for t in times]
+
+                Vout_pp = maximum(V_coll) - minimum(V_coll)
+                Vin_pp = maximum(V_base) - minimum(V_base)
+
+                gain = Vout_pp / Vin_pp
+                push!(gains, gain)
+            else
+                push!(gains, NaN)
+            end
+        end
+
+        # All simulations should succeed
+        @test all(!isnan, gains)
+
+        # For small signals, gain should be relatively constant (within 30%)
+        if all(!isnan, gains) && length(gains) >= 2
+            avg_gain = sum(gains) / length(gains)
+            @test all(abs.(gains .- avg_gain) ./ avg_gain .< 0.3)
+        end
+    end
+
+    #==========================================================================#
+    # Test 5: Frequency Response (optional - if time permits)
+    #
+    # Test gain at different frequencies to verify proper operation
+    # across audio band.
+    #==========================================================================#
+    @testset "Frequency response" begin
+
+        function build_ce_freq(params, spec, t::Real=0.0; x=Float64[], ctx=nothing)
+            if ctx === nothing
+                ctx = MNAContext()
+            else
+                reset_for_restamping!(ctx)
+            end
+
+            vcc = get_node!(ctx, :vcc)
+            base = get_node!(ctx, :base)
+            coll = get_node!(ctx, :coll)
+
+            stamp!(VoltageSource(params.Vcc; name=:Vcc), ctx, vcc, 0)
+            sin_src = SinVoltageSource(params.Vbias, params.Vac, params.freq; name=:Vin)
+            stamp!(sin_src, ctx, base, 0, t, spec.mode)
+            stamp!(Resistor(params.Rc), ctx, vcc, coll)
+            stamp!(Capacitor(params.Cload), ctx, coll, 0)
+            stamp!(npnBJTEbersMoll(), ctx, base, 0, coll; _mna_x_=x)
+
+            return ctx
+        end
+
+        base_params = (
+            Vcc = 12.0,
+            Vbias = 0.65,
+            Vac = 0.001,
+            freq = 1000.0,
+            Rc = 4.7e3,
+            Cload = 100e-12
+        )
+
+        gains = Float64[]
+
+        for freq in [100.0, 1000.0, 10000.0]
+            params = merge(base_params, (freq=freq,))
+            circuit = MNACircuit(build_ce_freq; params...)
+
+            period = 1.0 / freq
+            tspan = (0.0, 10 * period)  # More periods for accuracy
+
+            sol = tran!(circuit, tspan; solver=Rodas5P(), abstol=1e-9, reltol=1e-7)
+
+            if sol.retcode == ReturnCode.Success
+                sys = assemble!(circuit)
+                acc = MNASolutionAccessor(sol, sys)
+
+                t_start = 7 * period
+                times = range(t_start, 10*period; length=100)
+
+                V_coll = [voltage(acc, :coll, t) for t in times]
+                V_base = [voltage(acc, :base, t) for t in times]
+
+                Vout_pp = maximum(V_coll) - minimum(V_coll)
+                Vin_pp = maximum(V_base) - minimum(V_base)
+
+                push!(gains, Vout_pp / Vin_pp)
+            else
+                push!(gains, NaN)
+            end
+        end
+
+        # At least one should succeed
+        @test any(!isnan, gains)
+
+        # For a resistor-only load, gain should be constant with frequency
+        valid_gains = filter(!isnan, gains)
+        if length(valid_gains) >= 2
+            @test maximum(valid_gains) / minimum(valid_gains) < 2.0
+        end
+    end
+
+end  # testset "Audio Integration Tests"

--- a/test/mna/audio_integration.jl
+++ b/test/mna/audio_integration.jl
@@ -5,7 +5,7 @@
 # - va"""...""" macro for creating VA device models (BJT Ebers-Moll)
 # - SPICE netlists with X device syntax for VA model instantiation
 # - solve_mna_spice_code() for DC analysis with Newton iteration
-# - make_mna_spice_circuit() + MNACircuit for transient simulation
+# - make_mna_spice_circuit() for transient simulation (returns MNACircuit)
 #
 # Key patterns demonstrated:
 # 1. VA device models defined separately, imported via imported_hdl_modules
@@ -157,8 +157,7 @@ endmodule
         @test V_coll_dc > 1.0 && V_coll_dc < 11.0
 
         # Create circuit for transient
-        builder, _ = make_mna_spice_circuit(spice; imported_hdl_modules=[npnbjt_module])
-        circuit = MNACircuit(builder)
+        circuit = make_mna_spice_circuit(spice; imported_hdl_modules=[npnbjt_module])
 
         # Run transient simulation
         period = 1.0 / freq
@@ -224,8 +223,7 @@ endmodule
             X1 base 0 coll npnbjt
             """
 
-            builder, _ = make_mna_spice_circuit(spice; imported_hdl_modules=[npnbjt_module])
-            circuit = MNACircuit(builder)
+            circuit = make_mna_spice_circuit(spice; imported_hdl_modules=[npnbjt_module])
 
             period = 1.0 / freq
             tspan = (0.0, 5 * period)
@@ -286,8 +284,7 @@ endmodule
             X1 base 0 coll npnbjt
             """
 
-            builder, _ = make_mna_spice_circuit(spice; imported_hdl_modules=[npnbjt_module])
-            circuit = MNACircuit(builder)
+            circuit = make_mna_spice_circuit(spice; imported_hdl_modules=[npnbjt_module])
 
             period = 1.0 / freq
             tspan = (0.0, 10 * period)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,9 @@ if PHASE0_MINIMAL
         @testset "VADistiller Integration" begin
             @testset "mna/vadistiller_integration.jl" include("mna/vadistiller_integration.jl")
         end
+        @testset "Audio Integration" begin
+            @testset "mna/audio_integration.jl" include("mna/audio_integration.jl")
+        end
     elseif RUN_CORE
         @info "Running Phase 0/1 tests (parsing/codegen + MNA core)"
 
@@ -75,6 +78,9 @@ if PHASE0_MINIMAL
             GC.gc()  # Clean up before heavy tests
             @testset "VADistiller Integration" begin
                 @testset "mna/vadistiller_integration.jl" include("mna/vadistiller_integration.jl")
+            end
+            @testset "Audio Integration" begin
+                @testset "mna/audio_integration.jl" include("mna/audio_integration.jl")
             end
         end
     end


### PR DESCRIPTION
This test file demonstrates mixed SPICE/Verilog-A circuit simulation:
- Simplified NPN BJT Ebers-Moll VA model with 3 terminals (b, e, c)
- Common emitter amplifier circuit with DC bias and AC signal
- Transient simulation using SinVoltageSource for audio signals
- Voltage gain measurement and phase inversion verification

Tests include:
1. BJT with fixed voltages - verifies current gain (βF ≈ 100)
2. BJT with collector resistor - basic amplifier DC bias
3. Common emitter amplifier transient - gain and phase inversion
4. Gain linearity with signal level
5. Frequency response across audio band

Key learnings:
- VA BJT models work with stamp!() pattern and _mna_x_ for Newton iteration
- Load capacitor needed for transient solver (provides differential states)
- SinVoltageSource for AC stimulus in transient analysis
- MNASolutionAccessor for extracting voltage trajectories