### PR TITLE
Fix UInt32 constructor extension warning for Julia 1.12+

### DIFF
--- a/VerilogAParser.jl/src/parse/preproc.jl
+++ b/VerilogAParser.jl/src/parse/preproc.jl
@@ -11,7 +11,7 @@ Base.:-(a::VirtPos, b::Integer) = VirtPos(a.pos - UInt32(b))
 Base.:-(a::VirtPos, b::VirtPos) = a.pos - b.pos
 Base.isless(a::VirtPos, b::VirtPos) = isless(a.pos, b.pos)
 Base.isfinite(a::VirtPos) = true
-UInt32(pos::VirtPos) = pos.pos
+Base.UInt32(pos::VirtPos) = pos.pos
 
 # Scalar Behavior otherwise
 Base.length(a::VirtPos) = 1


### PR DESCRIPTION
Add explicit Base. qualification to UInt32(pos::VirtPos) method extension to silence deprecation warning about extending Base types without explicit qualification.