### PR TITLE
Unify VoltageSource and CurrentSource types with dc/ac/tran fields

### DIFF
--- a/test/mna/vadistiller_integration.jl
+++ b/test/mna/vadistiller_integration.jl
@@ -17,7 +17,7 @@ using CedarSim.MNA
 using CedarSim.MNA: MNAContext, MNASpec, get_node!, stamp!, assemble!
 using CedarSim.MNA: voltage, current, make_ode_problem
 using CedarSim.MNA: VoltageSource, Resistor, Capacitor, CurrentSource
-using CedarSim.MNA: MNACircuit, SinVoltageSource, MNASolutionAccessor
+using CedarSim.MNA: MNACircuit, MNASolutionAccessor
 using CedarSim.MNA: reset_for_restamping!, CedarUICOp, CedarDCOp
 using ForwardDiff: Dual, value, partials
 using OrdinaryDiffEq: QNDF, Rodas5P
@@ -679,7 +679,8 @@ eval(monostable_code)
                 vdrain = get_node!(ctx, :vdrain)
 
                 stamp!(VoltageSource(params.Vdd; name=:Vdd), ctx, vdd, 0)
-                stamp!(SinVoltageSource(params.Vbias, params.Vac, params.freq; name=:Vg),
+                stamp!(VoltageSource(params.Vbias;
+                       tran=_t -> params.Vbias + params.Vac * sin(2π * params.freq * _t), name=:Vg),
                        ctx, vgate, 0, t, spec.mode)
                 stamp!(sp_resistor(; r=params.Rd), ctx, vdd, vdrain; _mna_spec_=spec, _mna_x_=x)
                 stamp!(sp_mos1(; vto=1.0, kp=1e-4),
@@ -713,7 +714,8 @@ eval(monostable_code)
                 vcollector = get_node!(ctx, :vcollector)
 
                 stamp!(VoltageSource(params.Vcc; name=:Vcc), ctx, vcc, 0)
-                stamp!(SinVoltageSource(params.Vbias, params.Vac, params.freq; name=:Vb),
+                stamp!(VoltageSource(params.Vbias;
+                       tran=_t -> params.Vbias + params.Vac * sin(2π * params.freq * _t), name=:Vb),
                        ctx, vbase, 0, t, spec.mode)
                 stamp!(sp_resistor(; r=params.Rc), ctx, vcc, vcollector; _mna_spec_=spec, _mna_x_=x)
                 stamp!(sp_bjt(; bf=100.0),
@@ -758,7 +760,8 @@ eval(monostable_code)
                 vin = get_node!(ctx, :vin)
                 vout = get_node!(ctx, :vout)
 
-                stamp!(SinVoltageSource(0.0, params.Vamp, params.freq; name=:Vin),
+                stamp!(VoltageSource(0.0;
+                       tran=_t -> params.Vamp * sin(2π * params.freq * _t), name=:Vin),
                        ctx, vin, 0, t, spec.mode)
                 stamp!(sp_diode(; is=1e-14, cjo=10e-12, m=0.5, vj=0.7),
                        ctx, vin, vout; _mna_x_=x, _mna_spec_=spec)
@@ -808,7 +811,8 @@ eval(monostable_code)
                 vdrain = get_node!(ctx, :vdrain)
 
                 stamp!(VoltageSource(params.Vdd; name=:Vdd), ctx, vdd, 0)
-                stamp!(SinVoltageSource(params.Vbias, params.Vac, params.freq; name=:Vg),
+                stamp!(VoltageSource(params.Vbias;
+                       tran=_t -> params.Vbias + params.Vac * sin(2π * params.freq * _t), name=:Vg),
                        ctx, vgate, 0, t, spec.mode)
                 stamp!(Resistor(params.Rd), ctx, vdd, vdrain)
                 stamp!(sp_mos1(; l=1e-6, w=10e-6, vto=0.7, kp=1e-4,
@@ -854,7 +858,8 @@ eval(monostable_code)
                 vin = get_node!(ctx, :vin)
                 vout = get_node!(ctx, :vout)
 
-                stamp!(SinVoltageSource(0.0, params.Vamp, params.freq; name=:Vin),
+                stamp!(VoltageSource(0.0;
+                       tran=_t -> params.Vamp * sin(2π * params.freq * _t), name=:Vin),
                        ctx, vin, 0, t, spec.mode)
                 stamp!(sp_diode(; is=1e-14, cjo=5e-12, m=0.5),
                        ctx, vin, vout; _mna_x_=x, _mna_spec_=spec)


### PR DESCRIPTION
This refactors the source types to use a unified model that handles DC, AC, and transient analysis modes consistently, similar to the old simpledevices.jl approach.

Key changes:

1. Unified VoltageSource{W} and CurrentSource{W} types:
   - `dc::Float64` - DC value for DC operating point analysis
   - `ac::ComplexF64` - AC phasor for small-signal AC analysis (prepared for future use)
   - `tran::W` - Transient waveform specification (ConstantWaveform, PWLWaveform, SinWaveform, or Function)
   - `name::Symbol` - Source name

2. New waveform specification types:
   - ConstantWaveform - Uses DC value for transient too
   - PWLWaveform{T,V} - Piecewise-linear with parameterized storage (Vector/SVector/NTuple)
   - SinWaveform - Sinusoidal with SPICE-compatible parameters

3. Mode-aware get_source_value():
   - :dcop -> returns dc field
   - :ac -> returns dc (AC phasor handled separately by AC solve)
   - :tran -> evaluates transient waveform at time t

4. Legacy constructors preserved as aliases:
   - PWLVoltageSource/PWLCurrentSource -> VoltageSource{PWLWaveform}
   - SinVoltageSource/SinCurrentSource -> VoltageSource{SinWaveform}
   - TimeDependentVoltageSource -> VoltageSource{Function}

5. stamp! methods updated:
   - Simple 2-arg version uses dc value for DC analysis
   - 4-arg version (t, mode) for time/mode-aware stamping
   - All codegen paths now pass t and spec.mode consistently

This allows running DC or AC analysis on circuits that contain PWL or SIN sources - the source will use its dc value during DC analysis and evaluate its transient waveform during transient analysis.