### PR TITLE
Refactor to fully deferred b vector stamping

### DIFF
--- a/src/mna/build.jl
+++ b/src/mna/build.jl
@@ -150,8 +150,8 @@ end
 
 Get the RHS vector b, properly sized.
 
-Note: Deferred b stamps (for current variables with negative indices)
-are resolved and applied here.
+All b stamps are stored in COO format (b_I, b_V) and resolved here.
+This matches the G and C matrix assembly pattern for consistency.
 """
 function get_rhs(ctx::MNAContext)
     n = system_size(ctx)
@@ -159,15 +159,8 @@ function get_rhs(ctx::MNAContext)
         return Float64[]
     end
 
-    # Create result vector
+    # Create result vector and apply all deferred stamps
     result = zeros(Float64, n)
-
-    # Copy existing direct stamps
-    for i in 1:min(length(ctx.b), n)
-        result[i] = ctx.b[i]
-    end
-
-    # Apply deferred stamps (negative indices for current variables)
     for (i, v) in zip(ctx.b_I, ctx.b_V)
         idx = resolve_index(ctx, i)
         if 1 <= idx <= n

--- a/src/mna/precompile.jl
+++ b/src/mna/precompile.jl
@@ -336,8 +336,9 @@ function compile_structure(builder::F, params::P, spec::S; ctx::Union{MNAContext
     n_G = length(ctx0.G_I)
     n_C = length(ctx0.C_I)
 
-    # Resolve deferred b stamp indices (CurrentIndex/ChargeIndex → actual b vector positions)
-    # These are fixed after the first build and can be reused in value-only mode
+    # Resolve ALL b stamp indices to actual b vector positions
+    # All b stamps are now deferred (stored in b_I/b_V during stamping)
+    # Pre-resolving enables zero-allocation value-only restamping
     n_b_deferred = length(ctx0.b_I)
     b_deferred_resolved = Vector{Int}(undef, n_b_deferred)
     for k in 1:n_b_deferred

--- a/src/mna/value_only.jl
+++ b/src/mna/value_only.jl
@@ -294,23 +294,17 @@ end
 """
     stamp_b!(dctx::DirectStampContext, i, val)
 
-Stamp b vector value. Direct for nodes, deferred for currents/charges.
+Stamp b vector value. All stamps are deferred and applied via pre-resolved indices.
+This provides a consistent interface matching G and C stamping.
 """
 @inline function stamp_b!(dctx::DirectStampContext, i, val)
     iszero(i) && return nothing
     v = extract_value(val)
-    typed = _to_typed(i)
 
-    if typed isa CurrentIndex || typed isa ChargeIndex
-        # Deferred stamp: store value, apply later with pre-resolved index
-        pos = dctx.b_deferred_pos
-        dctx.b_V[pos] = v
-        dctx.b_deferred_pos = pos + 1
-    else
-        # NodeIndex: direct stamp
-        idx = typed.idx
-        dctx.b[idx] += v
-    end
+    # All b stamps are deferred - applied via pre-resolved indices after stamping
+    pos = dctx.b_deferred_pos
+    dctx.b_V[pos] = v
+    dctx.b_deferred_pos = pos + 1
     return nothing
 end
 

--- a/test/mna/core.jl
+++ b/test/mna/core.jl
@@ -211,12 +211,14 @@ using VerilogAParser
         stamp_C!(ctx, n1, n1, 1e-6)
         @test length(ctx.C_V) == 1
 
-        # Stamp RHS
+        # Stamp RHS (all b stamps are deferred, check via get_rhs)
         stamp_b!(ctx, n1, 5.0)
-        @test ctx.b[n1] == 5.0
+        b = get_rhs(ctx)
+        @test b[n1] == 5.0
 
         stamp_b!(ctx, n1, 3.0)  # Accumulates
-        @test ctx.b[n1] == 8.0
+        b = get_rhs(ctx)
+        @test b[n1] == 8.0
 
         # Ground stamps are ignored
         stamp_G!(ctx, 0, n1, 1.0)


### PR DESCRIPTION
Unified the b vector stamping approach to match G and C matrices:
- All b stamps now go to COO format (b_I, b_V) arrays
- Removed hybrid immediate/deferred approach for NodeIndex vs CurrentIndex
- Simplified stamp_b! in both MNAContext and DirectStampContext
- Removed unused ctx.b field from MNAContext struct
- Updated get_rhs() to resolve all stamps from COO arrays
- Updated reset_values!, reset_for_restamping!, clear! functions

This simplifies the codebase by having a consistent stamping pattern across all matrix/vector components and removes conditional branching in the hot stamping path.