### PR TITLE
Document gVisor workaround for precompilation segfaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,25 @@
   - Julia 1.12 has threading bugs that cause segfaults during artifact downloads
   - Don't add compatibility hacks for older Julia versions
 
+### gVisor Runtime Workaround
+
+If running in a gVisor-sandboxed environment (check with `uname -r` showing `runsc` or kernel 4.4.0),
+Julia's precompilation may segfault during `@compile_workload` execution due to gVisor's syscall
+emulation limitations.
+
+**Fix:** Create `test/LocalPreferences.toml` to disable precompile workloads:
+
+```toml
+[PSPModels]
+precompile_workload = false
+
+[VADistillerModels]
+precompile_workload = false
+```
+
+This file is gitignored. The packages will still work but with slower first-call latency.
+See [PrecompileTools docs](https://julialang.github.io/PrecompileTools.jl/stable/) for details.
+
 ## Development Guidelines
 
 ### Code Modification Philosophy

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -11,6 +11,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 PSPModels = "abf2981e-f194-4833-b9e6-388029af7f41"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -22,8 +23,8 @@ VADistillerModels = "2129788e-3e5d-4aba-9c60-0ef5ee775297"
 VerilogAParser = "b333aca1-b97d-47c9-9908-8e5a8c115e58"
 
 [sources]
-CedarSim = {path = ".."}
 CMCModels = {path = "../models/CMCModels.jl"}
+CedarSim = {path = ".."}
 Lexers = {path = "../Lexers.jl"}
 PSPModels = {path = "../models/PSPModels.jl"}
 SpectreNetlistParser = {path = "../SpectreNetlistParser.jl"}


### PR DESCRIPTION
gVisor's syscall emulation causes Julia's precompilation to segfault during @compile_workload execution in PSPModels and VADistillerModels.

Add instructions to CLAUDE.md for creating test/LocalPreferences.toml to disable precompile workloads in gVisor environments. Also add Preferences.jl to test deps for programmatic preference management.