### PR TITLE
CI/docs/test improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,19 @@ jobs:
             Pkg.test()
           '
 
+      - name: Disable heavy precompile workloads
+        run: |
+          cat > test/LocalPreferences.toml << 'EOF'
+          [PSPModels]
+          precompile_workload = false
+
+          [VADistillerModels]
+          precompile_workload = false
+
+          [VACASKModels]
+          precompile_workload = false
+          EOF
+
       - name: Install and precompile test dependencies
         run: |
           julia --project=test -e '


### PR DESCRIPTION
## Summary
- Update CLAUDE.md with SPICE circuit patterns
- Replace outdated test skip with working subcircuit parameter test
- Skip heavy VA model precompile workloads for core tests (speeds up CI from ~1h to ~20min)

## Test plan
- [x] Core tests pass
- [x] No functional changes to simulation code

🤖 Generated with [Claude Code](https://claude.ai/code)