### PR TITLE
Fix alloc_current! hoisting for single-argument calls

### DIFF
--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -1151,7 +1151,14 @@ function hoist_conditional_stamps(ifex::Expr)
 
     # Hoist alloc_current! calls
     for alloc in allocs
-        push!(hoisted_exprs, :($(alloc.hoisted_sym) = CedarSim.MNA.alloc_current!(ctx, $(alloc.base_name), $(alloc.instance_arg))))
+        # Generate appropriate call based on whether instance_arg was present
+        # If instance_arg is :_, the original call had only one argument (name)
+        # and we should generate a single-argument call to avoid creating wrong symbols
+        if alloc.instance_arg == :_
+            push!(hoisted_exprs, :($(alloc.hoisted_sym) = CedarSim.MNA.alloc_current!(ctx, $(alloc.base_name))))
+        else
+            push!(hoisted_exprs, :($(alloc.hoisted_sym) = CedarSim.MNA.alloc_current!(ctx, $(alloc.base_name), $(alloc.instance_arg))))
+        end
         alloc_replacements[objectid(alloc.original_expr)] = alloc.hoisted_sym
     end
 


### PR DESCRIPTION
## Summary
Fixed a bug in the `hoist_conditional_stamps` function where `alloc_current!` calls with only a single argument (the context and base name) were incorrectly being hoisted with an extra argument, causing incorrect symbol generation.

## Changes
- Added conditional logic to detect when `instance_arg` is `:_` (indicating no instance argument was present in the original call)
- Generate single-argument `alloc_current!(ctx, base_name)` calls when no instance argument exists
- Generate two-argument `alloc_current!(ctx, base_name, instance_arg)` calls when an instance argument is present
- Added clarifying comments explaining the distinction between the two cases

## Implementation Details
The fix uses the sentinel value `:_` to distinguish between calls that originally had one vs. two arguments. This prevents the hoisting process from inadvertently adding arguments that weren't in the original expression, which would result in creating incorrect symbol names in the MNA context.

https://claude.ai/code/session_01RHtb1DfYkzNW8zMeHWSkAA