### PR TITLE
Deduplicate stamp allocations in conditional hoisting

### DIFF
--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -1242,7 +1242,14 @@ function hoist_conditional_stamps(ifex::Expr)
     end
 
     # Hoist stamp calls (with resolved index expressions)
-    for (i, stamp) in enumerate(stamps)
+    # IMPORTANT: Deduplicate stamps by (matrix, row, col) to avoid allocating multiple
+    # indices for stamps that target the same position in different branches.
+    # Without deduplication, stamps to the same position from if/else branches would
+    # each get their own get_*_idx! call, causing counter mismatch in DirectStampContext.
+    position_to_idx = Dict{Tuple{Symbol, Any, Any}, Symbol}()
+    idx_counter = Ref(0)
+
+    for stamp in stamps
         row_resolved, row_ok = resolve_index_expr(stamp.row_expr, let_var_map)
         if stamp.matrix == :b
             col_resolved, col_ok = nothing, true
@@ -1255,19 +1262,30 @@ function hoist_conditional_stamps(ifex::Expr)
             continue
         end
 
-        if stamp.matrix == :G
-            idx_sym = Symbol("_hoist_G_idx_", i)
-            push!(hoisted_exprs, :($idx_sym = CedarSim.MNA.get_G_idx!(ctx, $row_resolved, $col_resolved)))
-            stamp_replacements[objectid(stamp.original_expr)] = (idx_sym, :G)
-        elseif stamp.matrix == :C
-            idx_sym = Symbol("_hoist_C_idx_", i)
-            push!(hoisted_exprs, :($idx_sym = CedarSim.MNA.get_C_idx!(ctx, $row_resolved, $col_resolved)))
-            stamp_replacements[objectid(stamp.original_expr)] = (idx_sym, :C)
-        elseif stamp.matrix == :b
-            idx_sym = Symbol("_hoist_b_idx_", i)
-            push!(hoisted_exprs, :($idx_sym = CedarSim.MNA.get_b_idx!(ctx, $row_resolved)))
-            stamp_replacements[objectid(stamp.original_expr)] = (idx_sym, :b)
+        # Create position key for deduplication
+        pos_key = (stamp.matrix, row_resolved, col_resolved)
+
+        # Check if we already have an index for this position
+        if haskey(position_to_idx, pos_key)
+            # Reuse existing index symbol
+            idx_sym = position_to_idx[pos_key]
+        else
+            # Create new index symbol and allocation
+            idx_counter[] += 1
+            if stamp.matrix == :G
+                idx_sym = Symbol("_hoist_G_idx_", idx_counter[])
+                push!(hoisted_exprs, :($idx_sym = CedarSim.MNA.get_G_idx!(ctx, $row_resolved, $col_resolved)))
+            elseif stamp.matrix == :C
+                idx_sym = Symbol("_hoist_C_idx_", idx_counter[])
+                push!(hoisted_exprs, :($idx_sym = CedarSim.MNA.get_C_idx!(ctx, $row_resolved, $col_resolved)))
+            elseif stamp.matrix == :b
+                idx_sym = Symbol("_hoist_b_idx_", idx_counter[])
+                push!(hoisted_exprs, :($idx_sym = CedarSim.MNA.get_b_idx!(ctx, $row_resolved)))
+            end
+            position_to_idx[pos_key] = idx_sym
         end
+
+        stamp_replacements[objectid(stamp.original_expr)] = (idx_sym, stamp.matrix)
     end
 
     # Step 4: Transform the conditional


### PR DESCRIPTION
## Summary
Fix a bug in `hoist_conditional_stamps` where stamps targeting the same matrix position from different branches of an if/else statement would each allocate separate indices, causing counter mismatches in `DirectStampContext`.

## Changes
- **Deduplication logic**: Introduced a `position_to_idx` dictionary that maps `(matrix, row, col)` tuples to their allocated index symbols. This ensures that stamps targeting the same position reuse the same index allocation regardless of which branch they appear in.
- **Index counter**: Replaced the enumerate-based counter with an explicit `idx_counter` reference to maintain correct numbering when stamps are deduplicated.
- **Conditional allocation**: Index symbols and their corresponding `get_*_idx!` calls are now only created once per unique position, with subsequent stamps to the same position reusing the existing symbol.

## Implementation Details
The fix prevents a subtle bug where if/else branches containing stamps to identical matrix positions would each call `get_G_idx!`, `get_C_idx!`, or `get_b_idx!` separately. This caused the internal counter in `DirectStampContext` to increment multiple times for the same logical position, leading to mismatched indices. By deduplicating at the hoisting stage, we ensure each unique position gets exactly one index allocation, regardless of how many branches reference it.

https://claude.ai/code/session_01Ptq8CbueADdmY1esKZ9EZZ