### PR TITLE
Fix b_V stamping to use assignment instead of accumulation

### DIFF
--- a/src/mna/value_only.jl
+++ b/src/mna/value_only.jl
@@ -510,10 +510,14 @@ end
 
 Stamp to deferred b value at pre-calculated index.
 If idx <= 0 (e.g., from ground or overflow), the stamp is skipped.
+
+Note: Uses assignment (=) not accumulation (+=) because b_V is not zeroed
+in reset_direct_stamp! (unlike G_nzval/C_nzval which are zeroed).
+Each b_V position represents a distinct deferred stamp, not a sum.
 """
 @inline function stamp_b_at_idx!(dctx::DirectStampContext, idx::Int, val)
     idx <= 0 && return nothing
-    dctx.b_V[idx] += extract_value(val)
+    dctx.b_V[idx] = extract_value(val)
     return nothing
 end
 


### PR DESCRIPTION
## Summary
Changed the `stamp_b_at_idx!` function to use assignment (`=`) instead of accumulation (`+=`) when stamping deferred b values. This fixes incorrect behavior where multiple stamps to the same index would accumulate instead of being replaced.

## Changes
- Modified `stamp_b_at_idx!` to assign values directly to `b_V[idx]` rather than accumulating them
- Added clarifying documentation explaining why assignment is correct for `b_V` (unlike `G_nzval`/`C_nzval` which are zeroed during reset)
- Each `b_V` position represents a distinct deferred stamp, not a sum of contributions

## Implementation Details
The key insight is that `b_V` is not zeroed in `reset_direct_stamp!`, unlike the matrix values (`G_nzval`/`C_nzval`). This means each position in `b_V` should hold a single deferred stamp value, not accumulate multiple contributions. Using accumulation (`+=`) would cause incorrect results when the same index is stamped multiple times.

https://claude.ai/code/session_012DCA99bocwXTCqzzMDGRwa