### PR TITLE
Patch bump all registered package versions

### DIFF
--- a/NyanLexers.jl/Project.toml
+++ b/NyanLexers.jl/Project.toml
@@ -1,7 +1,7 @@
 name = "NyanLexers"
 uuid = "d66291fa-f43e-4b10-8b90-d63ec5d3f0a1"
 authors = ["JuliaHub, Inc. and other contributors"]
-version = "0.4.0"
+version = "0.4.1"
 
 [compat]
 julia = "1.9"

--- a/NyanSpectreNetlistParser.jl/Project.toml
+++ b/NyanSpectreNetlistParser.jl/Project.toml
@@ -1,7 +1,7 @@
 name = "NyanSpectreNetlistParser"
 uuid = "f050a39a-f089-4c65-a86a-958b8b907b9b"
 authors = ["JuliaHub, Inc. and other contributors"]
-version = "0.6.1"
+version = "0.6.2"
 
 [workspace]
 projects = ["docs", "test"]

--- a/NyanVerilogAParser.jl/Project.toml
+++ b/NyanVerilogAParser.jl/Project.toml
@@ -1,6 +1,6 @@
 name = "NyanVerilogAParser"
 uuid = "28caa042-5edb-4d1f-abcd-02ce41b2dd3d"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["JuliaHub, Inc. and other contributors"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Cadnip"
 uuid = "28ce5535-9df1-4533-abc1-da0fb7327efb"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["JuliaHub, Inc. and other contributors"]
 
 [workspace]

--- a/SpiceArmyKnife.jl/Project.toml
+++ b/SpiceArmyKnife.jl/Project.toml
@@ -1,6 +1,6 @@
 name = "SpiceArmyKnife"
 uuid = "9bd5f295-a833-4c5a-8e17-8bae7b000705"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Pepijn de Vos <pepijndevos@gmail.com>"]
 
 [workspace]


### PR DESCRIPTION
## Summary
- Patch bump Cadnip (0.12.0 → 0.12.1), NyanLexers (0.4.0 → 0.4.1), NyanSpectreNetlistParser (0.6.1 → 0.6.2), NyanVerilogAParser (0.3.1 → 0.3.2), SpiceArmyKnife (0.1.0 → 0.1.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)