### PR TITLE
API consolidation: file-first loading, SII solutions, two-tier resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,20 +123,82 @@ function circuit(params, spec, t::Real=0.0; x=Float64[], ctx=nothing)
 - `x`: Solution vector for nonlinear devices
 - `ctx`: MNAContext or DirectStampContext (reused across rebuilds)
 
-### Top-Level Eval for SPICE Circuits
-Parse and eval SPICE circuits at top level to avoid world age issues:
-```julia
-# Top-level - no invokelatest needed
-const circuit_code = Cadnip.make_mna_circuit(ast; circuit_name=:my_circuit)
-eval(circuit_code)
+### File-First Circuit Loading (canonical)
+Use `MNACircuit(path)` or `Base.include(@__MODULE__, SpiceFile(path))` for
+production code. The latter defines a builder function at top level and avoids
+all world-age and invokelatest overhead.
 
-# Now use directly in functions
+```julia
+# File path — language inferred from extension (.scs → Spectre, else SPICE)
+circuit = MNACircuit("amp.sp")
+sol = dc!(circuit)
+
+# For performance-sensitive code, define the builder at top level:
+Base.include(@__MODULE__, SpiceFile("amp.sp"))   # defines `amp(params, spec, ...)`
+c = MNACircuit(amp; R1=1e3)
+sol = dc!(c)
+
+# Inline SPICE (sp"...") and Spectre (spc"...") string macros work too:
+circuit = MNACircuit(sp"""
+* divider
+V1 vcc 0 DC 5
+R1 vcc out 1k
+R2 out 0 1k
+""")
+```
+
+For runtime-parsed netlist strings, `MNACircuit(code; lang=:spice|:spectre,
+source_dir=...)` works at the REPL or module top level. It eval's the builder
+on the spot. **Not safe inside a function body** — Julia freezes the caller's
+world age at entry and dispatch to the freshly-defined builder would error.
+Inside a function body, load the circuit at top level first and pass the
+builder fn:
+
+```julia
+Base.include(@__MODULE__, SpiceFile("amp.sp"))   # top level
+
 function run_sim()
-    circuit = MNACircuit(my_circuit)
-    sol = dc!(circuit)
+    c = MNACircuit(amp; R1=1e3)                  # no eval, no tax
+    dc!(c)
 end
 ```
-See `test/mna/audio_integration.jl` for the canonical pattern.
+
+The `sp"..."` / `spc"..."` / `va"..."` macros expand at the call site and
+work in both contexts.
+
+### Two-tier model resolution
+
+Device names in SPICE netlists resolve via two tiers:
+
+- **Tier 1 — builtins (registry).** R, C, L, D, and level-dispatched MOSFETs/BJTs
+  are resolved via `Cadnip.ModelRegistry.getmodel`. Populated by Cadnip +
+  stdlib packages (VADistillerModels, BSIM4, PSPModels). Just `using MyPkg`
+  and your `.model foo d` / `.model foo nmos level=1` picks it up.
+- **Tier 2 — scope (netlist directives).** PDK-specific and custom VA devices
+  are resolved from the sema scope walk list, populated by `.hdl "foo.va"`,
+  `.include "foo.sp"`, `.lib "foo.sp" section`, and `jlpkg://Package/path`
+  forms in the netlist. Most-recent include wins.
+
+PDK authors expose precompiled content via `Cadnip.precompile_pdk(@__MODULE__,
+"pdk.spice")` and `Cadnip.precompile_va(@__MODULE__, "device.va")`. End users
+reference the baked content via `.lib "jlpkg://MyPDK/..." typical` directives
+in their netlist.
+
+### Solution access: `sol[:name]`
+
+DC and transient solutions support name-based access via SymbolicIndexingInterface.
+
+```julia
+sol = dc!(circuit)
+sol[:vout]         # scalar voltage at node :vout
+sol[:I_v1]         # current through V1
+sol[:gnd]          # 0.0 (ground)
+
+# Transient:
+sol = tran!(circuit, (0.0, 1e-3))
+sol[:vout]         # trajectory
+sol(1e-4)          # state at t
+```
 
 ### ParamLens Pattern
 `ParamLens` navigates hierarchical params and merges overrides at `.params` fields:

--- a/README.md
+++ b/README.md
@@ -37,24 +37,87 @@ julia --project=. -e 'using Pkg; Pkg.instantiate()'
 
 ```julia
 using Cadnip
-using Cadnip.MNA: MNACircuit, MNASpec, voltage
+using Cadnip.MNA: MNACircuit
 
-# Define a circuit using SPICE syntax
-# Note: SPICE requires a title line as the first line
-builder = sp"""
-* Voltage divider circuit
+# --- File-first (production): load a netlist from disk ---
+circuit = MNACircuit("amp.sp")                 # extension → .scs Spectre, else SPICE
+sol = dc!(circuit)
+println("Output voltage: ", sol[:out])
+
+# --- Inline (tests, small samples): string macros ---
+circuit = MNACircuit(sp"""
+* Voltage divider
 V1 vcc 0 DC 5
 R1 vcc out 1k
 R2 out 0 1k
-"""
-
-# Create circuit and run DC analysis
-circuit = MNACircuit(builder)
+""")
 sol = dc!(circuit)
+println("Vout = ", sol[:out], " V")            # 2.5
 
-# Access results
-println("Output voltage: ", voltage(sol, :out))  # 2.5V (voltage divider)
+# --- Spectre syntax via spc"..." ---
+circuit = MNACircuit(spc"""
+v1 (vcc 0) vsource type=dc dc=5
+r1 (vcc out) resistor r=1k
+r2 (out 0) resistor r=1k
+""")
 ```
+
+### Loading options
+
+| Input                        | Loader                                            |
+| ---------------------------- | ------------------------------------------------- |
+| SPICE file                   | `MNACircuit("amp.sp")`                            |
+| Spectre file                 | `MNACircuit("amp.scs")`                           |
+| Top-level include in module  | `Base.include(@__MODULE__, SpiceFile("amp.sp"))`  |
+| SPICE string                 | `sp"""..."""` or `MNACircuit(code; lang=:spice)`  |
+| Spectre string               | `spc"""..."""` or `MNACircuit(code; lang=:spectre)` |
+| Verilog-A string             | `va"""..."""`                                     |
+| Already-compiled builder     | `MNACircuit(my_builder_fn; R=1e3)`                |
+| PDK package                  | `.lib "jlpkg://MyPDK/..." typical` in the netlist |
+
+**Top-level only for runtime parsing.** `MNACircuit("path")` and
+`MNACircuit(code; lang=...)` call `Base.eval` internally and must be used at
+the REPL or module top level. Inside a function body, Julia freezes the
+caller's world age at entry and the freshly-defined builder can't be
+dispatched. For that case, bring the circuit into scope at top level first:
+
+```julia
+Base.include(@__MODULE__, SpiceFile("amp.sp"))   # top level: defines `amp`
+
+function run_sim()
+    c = MNACircuit(amp; R1=1e3)                  # no eval, no world-age tax
+    dc!(c)
+end
+```
+
+The string macros (`sp"..."`, `spc"..."`, `va"..."`) expand at the call site
+and work transparently in both top-level and function-body contexts.
+
+### Analyses
+
+```julia
+sol = dc!(circuit)                             # DC operating point
+sol = tran!(circuit, (0.0, 1e-3))              # Transient
+sol = ac!(circuit, freqs)                      # AC small-signal
+result = dc!(CircuitSweep(circuit, sweep))     # Parameter sweep
+```
+
+`dc!(cs::CircuitSweep)` returns a `SweepResult` that iterates `(params, sol)`
+pairs. Solutions support name-based access via `sol[:node]` / `sol[:I_vsrc]`.
+
+### Two-tier model resolution
+
+Device names resolve via two tiers:
+
+- **Tier 1 (builtins).** R, C, L, D, level-dispatched MOSFETs/BJTs. Just
+  `using VADistillerModels` / `using BSIM4` and `.model nmosfet nmos level=1`
+  resolves automatically.
+- **Tier 2 (netlist scope).** PDKs and custom VA devices via netlist directives:
+  `.hdl "file.va"`, `.include "lib.sp"`, `.lib "lib.sp" section`, and
+  `jlpkg://Package/path`. Most-recent include wins.
+
+PDK authors expose content via `Cadnip.precompile_pdk(@__MODULE__, "pdk.spice")`
+and `Cadnip.precompile_va(@__MODULE__, "device.va")` at package build time.
 
 ## Testing
 

--- a/benchmarks/vacask/c6288/cedarsim/runme.jl
+++ b/benchmarks/vacask/c6288/cedarsim/runme.jl
@@ -32,13 +32,13 @@ using PSPModels
 const PSP103VA_module = sp_psp103va_module
 println("PSP103VA loaded from PSPModels package")
 
-# Load and parse the SPICE netlist from file
+# Parse SPICE file, inject PSP103VA module as Tier-2 scope so `.model` cards
+# referring to PSP103VA resolve. Codegen runs at top level (no world-age tax).
 const spice_file = joinpath(@__DIR__, "runme.sp")
-
-# Parse SPICE file to code, then evaluate to get the builder function
-const circuit_code = parse_spice_file_to_mna(spice_file; circuit_name=:c6288_circuit,
-                                              imported_hdl_modules=[PSP103VA_module])
-eval(circuit_code)
+let ast = Cadnip.NyanSpectreNetlistParser.parsefile(spice_file; start_lang=:spice, implicit_title=true),
+    sema_result = Cadnip.sema(ast; imported_hdl_modules=[PSP103VA_module])
+    eval(Cadnip._make_mna_circuit_with_sema(sema_result; circuit_name=:c6288_circuit))
+end
 
 """
     setup_simulation()

--- a/benchmarks/vacask/experiment_real.jl
+++ b/benchmarks/vacask/experiment_real.jl
@@ -29,22 +29,14 @@ const BENCHMARK_DIR = joinpath(@__DIR__)
 # Load actual benchmark circuits
 #==============================================================================#
 
-# RC Circuit
-const rc_spice = read(joinpath(BENCHMARK_DIR, "rc/cedarsim/runme.sp"), String)
-const rc_code = parse_spice_to_mna(rc_spice; circuit_name=:rc_circuit)
-eval(rc_code)
+# RC Circuit (no HDL dependency)
+Base.include(@__MODULE__, SpiceFile(joinpath(BENCHMARK_DIR, "rc/cedarsim/runme.sp"); name=:rc_circuit))
 
-# Graetz Bridge
-const graetz_spice = read(joinpath(BENCHMARK_DIR, "graetz/cedarsim/runme.sp"), String)
-const graetz_code = parse_spice_to_mna(graetz_spice; circuit_name=:graetz_circuit,
-                                       imported_hdl_modules=[sp_diode_module])
-eval(graetz_code)
+# Graetz Bridge — sp_diode resolves via ModelRegistry (Tier 1, from VADistillerModels).
+Base.include(@__MODULE__, SpiceFile(joinpath(BENCHMARK_DIR, "graetz/cedarsim/runme.sp"); name=:graetz_circuit))
 
-# Voltage Multiplier
-const mul_spice = read(joinpath(BENCHMARK_DIR, "mul/cedarsim/runme.sp"), String)
-const mul_code = parse_spice_to_mna(mul_spice; circuit_name=:mul_circuit,
-                                    imported_hdl_modules=[sp_diode_module])
-eval(mul_code)
+# Voltage Multiplier — same Tier-1 resolution for sp_diode.
+Base.include(@__MODULE__, SpiceFile(joinpath(BENCHMARK_DIR, "mul/cedarsim/runme.sp"); name=:mul_circuit))
 
 #==============================================================================#
 # Solver configurations

--- a/benchmarks/vacask/graetz/cedarsim/runme.jl
+++ b/benchmarks/vacask/graetz/cedarsim/runme.jl
@@ -21,15 +21,11 @@ using Printf
 # Import pre-parsed diode model from VADistillerModels package
 using VADistillerModels
 
-# Load and parse the SPICE netlist from file
+# Load and parse the SPICE netlist from file.
+# File-first load: `VADistillerModels` registers `sp_diode` via ModelRegistry
+# (Tier 1), so no imported_hdl_modules kwarg is needed.
 const spice_file = joinpath(@__DIR__, "runme.sp")
-const spice_code = read(spice_file, String)
-
-# Parse SPICE to code, then evaluate to get the builder function
-# Pass sp_diode_module so the SPICE parser knows about our VA device
-const circuit_code = parse_spice_to_mna(spice_code; circuit_name=:graetz_circuit,
-                                         imported_hdl_modules=[sp_diode_module])
-eval(circuit_code)
+Base.include(@__MODULE__, SpiceFile(spice_file; name=:graetz_circuit))
 
 """
     setup_simulation()

--- a/benchmarks/vacask/graetz/cedarsim/runme.sp
+++ b/benchmarks/vacask/graetz/cedarsim/runme.sp
@@ -1,11 +1,13 @@
 Full-wave rectifier with smoothing and load
 
+.model d1n4007 d is=76.9p rs=42.0m cjo=26.5p m=0.333 n=1.45
+
 vs inp inn 0 sin 0.0 20 50.0
 
-xd1 inp outp sp_diode is=76.9p rs=42.0m cjo=26.5p m=0.333 n=1.45
-xd2 outn inp sp_diode is=76.9p rs=42.0m cjo=26.5p m=0.333 n=1.45
-xd3 inn outp sp_diode is=76.9p rs=42.0m cjo=26.5p m=0.333 n=1.45
-xd4 outn inn sp_diode is=76.9p rs=42.0m cjo=26.5p m=0.333 n=1.45
+d1 inp outp d1n4007
+d2 outn inp d1n4007
+d3 inn outp d1n4007
+d4 outn inn d1n4007
 cl outp outn 100u
 rl outp outn 1k
 rgnd1 inn 0 1meg

--- a/benchmarks/vacask/mul/cedarsim/runme.jl
+++ b/benchmarks/vacask/mul/cedarsim/runme.jl
@@ -28,15 +28,9 @@ using Printf
 # Import pre-parsed diode model from VADistillerModels package
 using VADistillerModels
 
-# Load and parse the SPICE netlist from file
+# File-first load: VADistillerModels registers sp_diode via ModelRegistry.
 const spice_file = joinpath(@__DIR__, "runme.sp")
-const spice_code = read(spice_file, String)
-
-# Parse SPICE to code, then evaluate to get the builder function
-# Pass sp_diode_module so the SPICE parser knows about our VA device
-const circuit_code = parse_spice_to_mna(spice_code; circuit_name=:mul_circuit,
-                                         imported_hdl_modules=[sp_diode_module])
-eval(circuit_code)
+Base.include(@__MODULE__, SpiceFile(spice_file; name=:mul_circuit))
 
 """
     setup_simulation()

--- a/benchmarks/vacask/mul/cedarsim/runme.sp
+++ b/benchmarks/vacask/mul/cedarsim/runme.sp
@@ -2,15 +2,17 @@ Diode cascade (Voltage multiplier)
 * Note: Using phase=90 to start at peak (dV/dt=0) for better Newton convergence
 * at t=0. The cascaded diode topology has convergence issues with phase=0.
 
+.model diode d is=76.9p rs=42.0m cjo=26.5p m=0.333 n=1.45
+
 vs a 0 dc=0 sin 0 50 100k 0 0 90
 r1 a 1 0.01
 c1 1 2 100n
-xd1 0 1 sp_diode is=76.9p rs=42.0m cjo=26.5p m=0.333 n=1.45
+d1 0 1 diode
 c2 0 10 100n
-xd2 1 10 sp_diode is=76.9p rs=42.0m cjo=26.5p m=0.333 n=1.45
+d2 1 10 diode
 c3 1 2 100n
-xd3 10 2 sp_diode is=76.9p rs=42.0m cjo=26.5p m=0.333 n=1.45
+d3 10 2 diode
 c4 10 20 100n
-xd4 2 20 sp_diode is=76.9p rs=42.0m cjo=26.5p m=0.333 n=1.45
+d4 2 20 diode
 
 .end

--- a/benchmarks/vacask/profile_allocations.jl
+++ b/benchmarks/vacask/profile_allocations.jl
@@ -27,12 +27,10 @@ println("=" ^ 70)
 println("\nLoading circuits...")
 println("  Loaded: sp_diode from VADistillerModels package")
 
-# Load Graetz circuit (4 diodes)
+# Load Graetz circuit (4 diodes). VADistillerModels registers sp_diode via
+# ModelRegistry (Tier 1), so SpiceFile loading resolves the .model card.
 const graetz_spice_file = joinpath(@__DIR__, "graetz", "cedarsim", "runme.sp")
-const graetz_spice_code = read(graetz_spice_file, String)
-const graetz_circuit_code = parse_spice_to_mna(graetz_spice_code; circuit_name=:graetz_circuit,
-                                                imported_hdl_modules=[sp_diode_module])
-eval(graetz_circuit_code)
+Base.include(@__MODULE__, SpiceFile(graetz_spice_file; name=:graetz_circuit))
 println("  Loaded: Graetz rectifier circuit")
 
 #==============================================================================#
@@ -182,11 +180,13 @@ function profile_solver_allocations()
         return
     end
 
-    rc_spice_code = read(rc_spice_file, String)
-    rc_circuit_code = parse_spice_to_mna(rc_spice_code; circuit_name=:rc_circuit)
-    eval(rc_circuit_code)
-
-    rc_circ = MNACircuit(rc_circuit)
+    # Load the RC circuit at function scope. Because this is inside a function
+    # body (world-age frozen), we pass the freshly-eval'd builder through an
+    # invokelatest wrapper so dc!/tran! can dispatch it safely.
+    @eval Base.include(@__MODULE__, SpiceFile($rc_spice_file; name=:rc_circuit))
+    rc_builder = (args...; kwargs...) -> Base.invokelatest(
+        getfield(@__MODULE__, :rc_circuit), args...; kwargs...)
+    rc_circ = MNACircuit(rc_builder)
 
     println("\nComparing solvers on RC circuit (10k steps):")
 

--- a/benchmarks/vacask/rc/cedarsim/profile_allocations.jl
+++ b/benchmarks/vacask/rc/cedarsim/profile_allocations.jl
@@ -16,13 +16,9 @@ using Printf
 using LinearAlgebra
 using SparseArrays
 
-# Load and parse the SPICE netlist from file
+# File-first load: defines `rc_circuit(params, spec, ...)` at top level.
 const spice_file = joinpath(@__DIR__, "runme.sp")
-const spice_code = read(spice_file, String)
-
-# Parse SPICE to code, then evaluate to get the builder function
-const circuit_code = parse_spice_to_mna(spice_code; circuit_name=:rc_circuit)
-eval(circuit_code)
+Base.include(@__MODULE__, SpiceFile(spice_file; name=:rc_circuit))
 
 println("=" ^ 60)
 println("Clean Memory Profiling: VACASK RC Benchmark")

--- a/benchmarks/vacask/rc/cedarsim/runme.jl
+++ b/benchmarks/vacask/rc/cedarsim/runme.jl
@@ -18,13 +18,10 @@ using OrdinaryDiffEq: FBDF, Rodas5P
 using BenchmarkTools
 using Printf
 
-# Load and parse the SPICE netlist from file
+# Load and parse the SPICE netlist from file.
+# File-first load: defines `rc_circuit(params, spec, ...)` at top level.
 const spice_file = joinpath(@__DIR__, "runme.sp")
-const spice_code = read(spice_file, String)
-
-# Parse SPICE to code, then evaluate to get the builder function
-const circuit_code = parse_spice_to_mna(spice_code; circuit_name=:rc_circuit)
-eval(circuit_code)
+Base.include(@__MODULE__, SpiceFile(spice_file; name=:rc_circuit))
 
 """
     setup_simulation()

--- a/benchmarks/vacask/ring/cedarsim/compare_ngspice.jl
+++ b/benchmarks/vacask/ring/cedarsim/compare_ngspice.jl
@@ -19,7 +19,7 @@
 
 using Cadnip
 using Cadnip.MNA
-using Cadnip.MNA: CedarTranOp, MNASolutionAccessor, voltage
+using Cadnip.MNA: CedarTranOp, nameat
 using OrdinaryDiffEq: FBDF
 using SciMLBase
 using Printf
@@ -29,10 +29,10 @@ using DelimitedFiles
 
 # Parse circuit (same netlist as ngspice — no load caps, 10uA pulse)
 const spice_file = joinpath(@__DIR__, "runme.sp")
-const spice_code = read(spice_file, String)
-const circuit_code = parse_spice_to_mna(spice_code; circuit_name=:ring_compare,
-                                         imported_hdl_modules=[VACASKModels])
-eval(circuit_code)
+let ast = Cadnip.NyanSpectreNetlistParser.parsefile(spice_file; start_lang=:spice, implicit_title=true),
+    sema_result = Cadnip.sema(ast; imported_hdl_modules=[VACASKModels])
+    eval(Cadnip._make_mna_circuit_with_sema(sema_result; circuit_name=:ring_compare))
+end
 
 println("Running 1μs transient (matching ngspice settings)...")
 circuit = MNACircuit(ring_compare)
@@ -50,8 +50,8 @@ elapsed = time() - t0
     sol.retcode, length(sol.t), elapsed,
     sol.stats !== nothing ? sol.stats.nnonliniter : 0)
 
-# Extract Cadnip waveforms
-acc = MNASolutionAccessor(sol, sys)
+# Extract Cadnip waveforms. `sol` natively supports name lookup via SII —
+# `nameat(sol, :name, t)` returns the value at `t`.
 n_samples = 10000
 times_cs = range(0.0, 1e-6; length=n_samples)
 println("Extracting Cadnip waveforms...")
@@ -59,7 +59,7 @@ println("Extracting Cadnip waveforms...")
 V_cs = Dict{Int, Vector{Float64}}()
 for node_num in 1:9
     node_sym = Symbol(string(node_num))
-    V_cs[node_num] = [voltage(acc, node_sym, t) for t in times_cs]
+    V_cs[node_num] = [nameat(sol, node_sym, t) for t in times_cs]
 end
 
 # Load ngspice data

--- a/benchmarks/vacask/ring/cedarsim/runme.jl
+++ b/benchmarks/vacask/ring/cedarsim/runme.jl
@@ -20,16 +20,16 @@ using Printf
 # Import precompiled PSP103 builders (nmos_mna_builder, pmos_mna_builder)
 using VACASKModels
 
-# Load and parse the SPICE netlist from file
+# Parse SPICE from file, inject VACASKModels as a Tier-2 scope module (the
+# netlist references `nmos`/`pmos` subckt calls whose builders live in
+# VACASKModels), then codegen via the internal sema-pre-built bridge.
+# Runs at top level so the resulting `ring_circuit` is eval'd into this module
+# without any world-age tax.
 const spice_file = joinpath(@__DIR__, "runme.sp")
-const spice_code = read(spice_file, String)
-
-# Parse SPICE to code, then evaluate to get the builder function
-# VACASKModels provides precompiled nmos_mna_builder/pmos_mna_builder
-# which are resolved via imported_hdl_modules for the exposed subcircuit references
-const circuit_code = parse_spice_to_mna(spice_code; circuit_name=:ring_circuit,
-                                         imported_hdl_modules=[VACASKModels])
-eval(circuit_code)
+let ast = Cadnip.NyanSpectreNetlistParser.parsefile(spice_file; start_lang=:spice, implicit_title=true),
+    sema_result = Cadnip.sema(ast; imported_hdl_modules=[VACASKModels])
+    eval(Cadnip._make_mna_circuit_with_sema(sema_result; circuit_name=:ring_circuit))
+end
 
 """
     setup_simulation()

--- a/doc/api_consolidation_plan.md
+++ b/doc/api_consolidation_plan.md
@@ -1,0 +1,346 @@
+# API Consolidation Plan
+
+**Status:** Draft — iterating.
+
+## Goal
+
+One coherent, robust API for the full workflow:
+
+1. Reference precompiled PDKs and VA device packages from within a netlist via `jlpkg://`.
+2. Load a SPICE/Spectre netlist from a file (primary), string or macro (secondary).
+3. For tests: take an already-compiled builder function directly.
+4. Always initialize via Cedar's `dc_op` / `tran_op` (robust multi-Newton + homotopy).
+5. Return a SciML-compatible solution that supports name-based state lookup.
+
+Today, each of those steps has multiple partial paths that do not compose cleanly. The plan below collapses them.
+
+## Architectural decision: two-tier model resolution
+
+Three parallel mechanisms exist today for resolving a SPICE device name:
+
+1. **`ModelRegistry.getmodel`** — global Julia dispatch. BSIM4.jl, VADistillerModels.jl, PSPModels.jl already register here.
+2. **`imported_hdl_modules` kwarg** — a per-call list of modules, searched by name. Threaded through `make_mna_circuit`, `parse_spice_to_mna`, `parse_spice_file_to_mna`, `load_mna_pdk`, `load_mna_modules`. Cannot be passed through string macros.
+3. **Netlist include graph** — `.hdl "foo.va"`, `.lib "foo.sp" section`, `.include "foo.sp"`, and `jlpkg://Package/path` forms. Sema already handles these; for `jlpkg://` it switches scope to the target package (`src/spc/sema.jl:456-482`).
+
+The second mechanism and much of the third exist because standalone VA loading produced modules that weren't registered anywhere. Users had to route them back in via a kwarg. String macros couldn't. Corner selection on a PDK is fundamentally a namespacing problem that flat registration can't solve (same device name, three different parameterizations per section).
+
+**Decision: two tiers with a clear boundary.**
+
+- **Tier 1 — Builtins (registry).** Everything SPICE simulators are "supposed to know" out of the box: R, C, L, D, V, I, standard MOSFETs dispatched by level (1/2/3/6/9/14/17/...), standard BJTs, diode levels. Resolved via `ModelRegistry.getmodel`. Populated by method addition. Contributed by Cadnip (passives) and stdlib-style packages (VADistillerModels, BSIM4, PSPModels) that claim `(devkind, level, version)` triples via Julia dispatch. `AbstractSimulator` lives here for its original purpose — disambiguating e.g. ngspice's `level=14` from hspice's.
+- **Tier 2 — Scope (netlist include graph).** Everything else: PDK-specific devices, custom VA, photonic models, anything proprietary. Brought into scope at sema time via `.hdl`, `.include`, `.lib`, or `jlpkg://Package/path`. Resolved by a scope walk over the ordered list of included modules; `GlobalRef` baked into the generated builder. No global claim, no cross-package collisions, corners handled naturally because `.lib ... tt` vs `.lib ... ff` push different modules onto the scope.
+
+**`spice_select_device` resolution order** (`src/spc/sema.jl:295`): scope tier first (most-recent include wins); builtin tier as fallback. Users who don't want their custom `d` to shadow the builtin `d` just don't name it `d` — matches how every other language layers local over global.
+
+**`imported_hdl_modules` removed from all public APIs.** The concept survives as internal sema state (the scope walk list), populated only by actual netlist directives. No user-facing kwarg.
+
+## Why VADistillerModels / PSPModels / BSIM4 need no migration
+
+They already register via `Cadnip.ModelRegistry.getmodel` method additions (e.g. `VADistillerModels.jl:109-134`, `PSPModels.jl:71-74`). Under the two-tier model, that IS the correct behavior for Tier-1 contributors. `.model foo d` dispatches through builtins → `sp_diode`. `.model foo nmos level=1` → `sp_mos1`. The `imported_hdl_modules=[sp_diode_module]` kwarg in `benchmarks/vacask/graetz/cedarsim/runme.jl:31` is unnecessary today and just evaporates when the kwarg is deleted. No cross-repo migration.
+
+## Why jlpkg:// is the PDK precedent (and how it generalizes)
+
+`.lib "jlpkg://Sky130PDK/sky130.lib.spice" tt` already causes sema to resolve `Sky130PDK` as a Julia package, switch `imps` and `parse_cache` to the package's, and pick up `Sky130PDK.var"#cedar_parse_cache#"` (the precompiled parse state the package ships). Scope resolution is already package-aware for this case. What's missing is the generalization: the same scope model should drive device-name resolution for all Tier-2 entries (including local `.hdl "foo.va"` files), and Tier-1 should fall out by `getmodel` fallback.
+
+## Netlist directives and what they populate
+
+- **`jlpkg://Package/path`** — resolves to a Julia package; sema switches scope to the package's compiled parse cache. Canonical form for precompiled PDKs and published VA device packages.
+- **`.hdl "foo.va"`** — parses the VA file inline at sema time, creates device types in the netlist's gensym'd scope module. Non-precompiled; re-parsed every compile. For local/in-development VA.
+- **`.include "foo.sp"` / `.lib "foo.sp" section`** — parses the SPICE file inline, brings its subckts/models into scope.
+
+## PDK-authoring API (not for end users)
+
+PDK packages need a Julia-level function to call at package build time: parse the SPICE source, compile device types, bake a parse cache that `jlpkg://` can use later. That function is `Cadnip.precompile_pdk` (renamed from `load_mna_pdk`). It's documented as the thing PDK authors call inside their package; end users never invoke it. Same for VA-only device packages: `Cadnip.precompile_va` (renamed from `load_mna_va_module`) for authors.
+
+End-user code uses `using MyPDK` to bring the package into dependency graph, then references its content from within the netlist via `jlpkg://MyPDK/...`. No Julia-level loading calls in user code.
+
+## Module naming: opaque containers
+
+Generated modules (VA devices compiled inline via `.hdl`, PDK device bundles inside published packages) are gensym'd — never user-visible, never imported by name. Matches how `jlpkg://` already works: users don't reach into `Sky130PDK.var"#something#"`; they reference devices via netlist directives.
+
+The `MODULES = [optical_source_module, ...]` pattern in `neurophos/cadnip/tw_mzm_simulation.jl:33-37` disappears. Under the new model that script's VA files get loaded via `.hdl "optical_source.va"` lines inside the generated netlist (paths resolved against `source_dir`), or by packaging the VA files as a local Julia package and using `jlpkg://`.
+
+## Generated-code hygiene
+
+The baremodule design is intentional and correct: SPICE and Verilog-A have their own `sin`, `log`, `exp`, `max`, etc., and the baremodule is the namespace where those language-level identifiers get the right bindings. Sometimes that binding is `using Base: sin` (Julia's `sin` has the right semantics); sometimes a custom function defined in the module (semantics differ — e.g. a VA operator threading through a `V()` / `I()` access, or a SPICE function with different rounding). Either way, the generated code writes `sin(x)` and the module provides the right meaning.
+
+What's wrong is that the templates have accumulated two kinds of imports that don't belong in the language namespace:
+
+**Type A — language-level (correct to keep).** `sin`, `cos`, `log`, `exp`, `max`, `min`, `abs`, `sqrt`, `pow`, ... Whether backed by `Base` or a custom definition, these map a source-language identifier to the language's semantics. Leave them in the baremodule.
+
+**Type B — Julia-side plumbing (wrong to import; qualify instead).**
+
+- `hasproperty`, `getproperty`, `getfield`, `error`, `!==`, `iszero` — Julia metaprogramming helpers used by the generated builder to unpack parameter NamedTuples, dispatch on types, and throw errors. No SPICE/VA meaning. A VA module with a parameter `error` collides silently with `using Base: error`.
+- `Cadnip.MNA.stamp!`, `va_ddt`, `va_absdelay_V`, `stamp_current_contribution!`, `alloc_internal_node!`, `alloc_current!`, `ZERO_VECTOR`, `va_laplace_nd_dss`, `va_laplace_zp_dss`, `MNAContext`, `MNASpec` — runtime machinery invoked by the generated code. Not language-level.
+- `ForwardDiff.Dual`, `value`, `partials` — autodiff implementation detail. Not language-level.
+- `Cadnip.VerilogAEnvironment` bulk `using` — audit each export; Type-A stays, Type-B gets qualified.
+
+**Deciding rule:** "is this a function with matching semantics in the target language?" Yes → import or define in the baremodule so generated `foo(x)` binds naturally. No → emit fully-qualified `Namespace.foo(x)` at the call site in codegen.
+
+**Hygiene guarantee after the audit:** a Type-B collision can't happen. A VA module with a parameter `error` or a SPICE subckt named `getfield` works. An identifier in user source still binds to a Type-A language function, a Tier-1 builtin, or a Tier-2 scoped device — the intended shadow semantics are preserved.
+
+**Audit findings (scoped):**
+
+- **VA codegen is nearly clean.** `src/vasim.jl` codegen already emits most MNA runtime calls fully qualified (~60 sites already correct). Only **3 bare Type-B emissions** to fix: `va_ddt` at `src/vasim.jl:828`, `error` at `src/vasim.jl:1861`, plus a quick edge check around operators.
+- **SPICE codegen has the bulk of the work.** `src/spc/codegen.jl` emits `stamp!(Device(...), ctx, ...)` as a bare symbol at **~43 sites** (lines 773, 802, 827, 850, 879, 910, 941, 980, 1019, 1239, 1270, 1459, ...). All device-stamp calls plus behavioral-source + VA-module stamping. Mechanical find-replace to `Cadnip.MNA.stamp!(...)`.
+- **VA baremodule preamble** (`src/vasim.jl:3600`) — drop Type-B imports: `va_ddt`, `stamp_current_contribution!`, `MNAContext`, `MNASpec`, `alloc_internal_node!`, `alloc_current!`, `ZERO_VECTOR`, `Dual`, `value`, `partials`. Keep `va_laplace_nd_dss`, `va_laplace_zp_dss` (not shadowing any user identifier).
+- **SPICE baremodule preamble** (`src/spc/codegen.jl:3293`) — drop Type-B imports: `MNAContext`, `MNASpec`, `get_node!`, `stamp!`, `alloc_internal_node!`, `alloc_current!`. Keep device-type imports (`Resistor`, `Capacitor`, `Inductor`, `VoltageSource`, `CurrentSource`) — no user names a parameter `Resistor`.
+- **`src/va_env.jl` and `src/spectre_env.jl` are clean** — all exports are Type-A. No changes.
+
+**Sizing:** 3–4 days of active work (43 `stamp!` rewrites + 3 VA rewrites + 2 preamble changes + a `Resistor`/`Capacitor` usage audit) plus 2–3 days of regression testing. ~1 week total.
+
+Folded into Phase 2 as a prerequisite. Without it, `Base.include(mod, SpiceFile(path))` has to mutate `mod` with Cadnip `using` statements just so the generated code's Type-B references resolve — the exact failure mode this section fixes.
+
+## Target API (file-first)
+
+```julia
+# --- Production: load PDK via using + netlist from file ---
+using Sky130PDK                              # Tier-1 builtins stay unregistered here;
+                                             # Tier-2 content is used via jlpkg:// below
+using VADistillerModels                      # populates Tier-1 diode/MOSFET builtins
+circuit = MNACircuit("amp.sp")               # netlist's .lib "jlpkg://Sky130PDK/..." does the work
+sol = tran!(circuit, (0.0, 1e-3))
+
+# --- Production, with named builder for reuse / perf ---
+Base.include(@__MODULE__, SpiceFile("amp.sp"))   # defines `amp` at top level
+c = MNACircuit(amp; params=(R1=1e3,))
+sol = dc!(c)
+
+# --- Tests, small inline samples ---
+circuit = MNACircuit(sp"""
+  V1 vcc 0 DC 5
+  R1 vcc out 1k
+  R2 out 0 1k
+""")
+circuit = MNACircuit(spc"""...""")           # Spectre, matching old macro name
+
+# --- Programmatic (dynamically-built netlist string) ---
+# Supported but secondary; the netlist itself usually wants to be parameterizable.
+circuit = MNACircuit(build_netlist(); lang=:spectre, source_dir=@__DIR__)
+
+# --- Already-compiled builder (tests, performance-sensitive code) ---
+circuit = MNACircuit(my_builder_fn; params=(R=1e3,))
+
+# --- Parameters, sweeps, analyses ---
+circuit = alter(circuit; R1=150.0)
+sol  = dc!(circuit)                          # CedarRobustNLSolve + homotopy
+sol  = tran!(circuit, (0.0, 1e-3))           # CedarTranOp init
+sol  = ac!(circuit, freqs)
+res  = dc!(CircuitSweep(circuit, sweep))     # SweepResult; iterates (params, sol)
+
+# --- Name-based state lookup, one interface for DC and transient ---
+sol[:vout]           # scalar for DC, full trajectory for transient
+sol[sys.x1.vout]     # hierarchical
+sol(t)[:vout]        # transient at time
+```
+
+Priority: file-first. Macros and runtime strings exist for tests and inline samples. Dynamic-string netlists are supported but not first-class — they typically indicate the netlist should be a parameterized `.subckt` instead.
+
+File loading mirrors the existing VA pattern (`Base.include(mod, VAFile(path))` at `src/vasim.jl:3431`). `SpiceFile` / `SpectreFile` types dispatch to SPICE-specific `Base.include` methods. `MNACircuit(path)` is a one-liner that internally `Base.include`s into an anonymous module.
+
+## Resulting public surface (after refactor)
+
+| Category | Functions |
+|---|---|
+| Netlist loading | `MNACircuit(path)`, `MNACircuit(code; lang)`, `MNACircuit(builder)`, `Base.include(mod, SpiceFile(path))`, `Base.include(mod, SpectreFile(path))` |
+| String macros | `sp"..."` (SPICE), `spc"..."` (Spectre), `va"..."` (Verilog-A) |
+| Parameter modification | `alter`, `CircuitSweep`, `ProductSweep` and friends |
+| Analyses | `dc!`, `tran!`, `ac!` |
+| Solution access | `sol[...]` via SII |
+| MTK interop | `@declare_MSLConnector` |
+| PDK-authoring (not for end users) | `Cadnip.precompile_pdk`, `Cadnip.precompile_va` |
+
+Everything else in the current public surface is deleted.
+
+**Already in the API today, untouched by this plan:** `ac!` (in `src/ac.jl`), `MNACircuit(builder::Function; kwargs...)` (`src/mna/solve.jl:1348`), `@declare_MSLConnector` (MTK extension).
+
+## Resulting internal primitives
+
+Each is shared across multiple entrypoints and cannot be inlined without re-introducing duplication.
+
+- **`make_mna_circuit(ast; circuit_name) -> Expr`** — codegen from parsed AST to a builder `Expr`. Called by `sp"..."`, `spc"..."`, `Base.include(mod, SpiceFile)`, `MNACircuit(path)`, `MNACircuit(code; lang)`, `precompile_pdk`. Genuinely shared. Stays unexported; `imported_hdl_modules` kwarg removed.
+- **One private "eval builder into a module, return the builder function" helper** — shared between `Base.include(mod, SpiceFile(path))` and `MNACircuit(code; lang)`. The four hand-written copies at `test/common.jl:47-76, 95-124, 225-253` and `src/spc/interface.jl:235-258` collapse into this. Returns the builder function **bare, not wrapped in an `invokelatest` closure** — see "Invokelatest policy".
+- **`spice_select_device`** (`src/spc/sema.jl:295`) — post-refactor, walks the sema scope (Tier 2) then falls back to `ModelRegistry.getmodel` (Tier 1). Single dispatch point, handles `UnimplementedDevice` warning.
+
+## Invokelatest policy
+
+**No `invokelatest` on the per-builder-call critical path.** The ODE/DAE solver calls the builder at every Newton iteration at every timestep; an `invokelatest` wrapper is a permanent tax.
+
+`MNACircuit{F,P,S}` already stores the builder as a type parameter (`src/mna/solve.jl:1303`), so `dc!`, `tran!`, `ac!` specialize on the concrete builder type F. When `MNACircuit` is constructed with a freshly-eval'd builder, the specializations of `dc!` / `tran!` / solver callbacks for that new F-type are generated at the call site in the **current** world — after the eval. Standard Julia function-barrier pattern.
+
+Consequences:
+
+- The consolidated private helper evals the builder into an anonymous or caller-supplied module and returns the bare function. No closure wrapping.
+- Users can freely construct `MNACircuit(path)` or `MNACircuit(code; lang)` inside a function body; `dc!(circuit)` crosses the type-dispatch boundary and picks up the new world without `invokelatest`.
+- Only world-age gotcha: directly calling `circuit.builder(...)` in the same function body where `MNACircuit(...)` was constructed bypasses the barrier. Not a normal use case; mention in docs.
+- The four existing test-helper copies (`test/common.jl:249`, `src/spc/interface.jl:250`, etc.) wrap with `(args...; kwargs...) -> Base.invokelatest(circuit_fn, args...; kwargs...)`. This pays `invokelatest` per call. Collapsing into one helper and dropping the wrapper is strictly faster.
+
+## Deleted
+
+- `parse_spice_to_mna` — one-line composition of `make_mna_circuit` + `NyanSpectreNetlistParser.parse`. Users get `Base.include(mod, SpiceFile(path))` or `MNACircuit(code)` instead.
+- `parse_spice_file_to_mna` — replaced by `Base.include(mod, SpiceFile(path))` / `MNACircuit(path)`.
+- `solve_spice_mna` — replaced by `dc!(MNACircuit(code))`.
+- `make_mna_spice_circuit` (test helper) — replaced by `MNACircuit(code; lang=:spice)`.
+- `solve_mna_spice_code`, `solve_mna_spectre_code`, `solve_mna_circuit`, `tran_mna_circuit` (test helpers) — replaced by `dc!(MNACircuit(...))` / `tran!(MNACircuit(...), tspan)`.
+- `load_mna_va_module`, `load_mna_va_modules`, `load_mna_modules`, `load_mna_pdk` as end-user APIs — renamed / merged into PDK-authoring helpers `precompile_va` and `precompile_pdk`. End users don't call these.
+- `imported_hdl_modules` kwarg — removed end-to-end. Concept survives only as internal sema scope-list state, populated by netlist directives only.
+- `MNASolutionAccessor` — subsumed by SII on the solution types. Hard break.
+- `voltage(sol, :x)` / `current(sol, :x)` accessors — deleted. Users write `sol[:x]`.
+
+## Concrete problems being fixed
+
+Cited so future-us can verify the fixes land.
+
+1. **`tran_mna_circuit` bypasses transient init.** `test/common.jl:172-185` builds `ODEProblem` directly via `make_ode_problem`, skipping `tran!` and therefore `CedarTranOp`. Test-side analogue of the robust-Newton DC bypass fixed in PR #169.
+2. **Four copies of the parse → temp-module → eval → `invokelatest` dance** at `test/common.jl:47-76, 95-124, 225-253` and `src/spc/interface.jl:235-258`.
+3. **No Spectre string macro.** `sp"..."` and `va"..."` exist; no `spc"..."`. Spectre netlists can only be consumed via the slow temp-module path today.
+4. **DC and transient have different solution types with different name-lookup APIs.** DC: `voltage(sol, :x)`. Transient: `MNASolutionAccessor(sol, sys)[:x]`. `SymbolicIndexingInterface` is already a dep (`src/circsummary.jl:24`) but only used for `NetRef`.
+5. **`(ctx, sol)` tuple returns.** Exist only because `sol` cannot answer name queries alone. Disappear once SII is on solutions.
+6. **`imported_hdl_modules` leaks into user scripts.** `benchmarks/vacask/graetz/cedarsim/runme.jl:31` passes `[sp_diode_module]` unnecessarily. Under the two-tier model, `.model foo d` dispatches through Tier-1 builtins to `VADistillerModels.sp_diode`; the kwarg is gone and the script stops needing it without any change to VADistillerModels.
+7. **Corner selection is broken by flat registration.** A PDK with `typical`/`fast`/`slow` sections has the same device names across corners. Flat `getmodel` can't represent that. Two-tier resolves via Tier 2: `.lib "jlpkg://Sky130PDK/..." tt` vs `... ff` push different modules onto sema's scope, `getmodel` never sees the conflict.
+8. **Manual stamping in integration tests.** `test/mna/audio_integration.jl`, `photonic.jl`, `vadistiller_integration.jl` build circuits via `MNAContext` + `stamp!` rather than through SPICE/VA.
+9. **Real users reach for `MNA.assemble!` as a pre-warm.** `benchmarks/vacask/graetz/cedarsim/runme.jl:43` calls it outside the timed region to separate setup from solve. Should be an explicit API.
+10. **Sweep result iteration requires `zip(solutions, cs)`** (`neurophos/cadnip/tw_mzm_simulation.jl:145`). `dc!(cs)` returns `Vector{DCSolution}` and loses the sweep-point association.
+
+## Phased work
+
+Ordered so the correctness fix (Phase 2 closes the `tran_mna_circuit` bypass) lands early. Each phase is independently shippable.
+
+### Phase 0 — audit
+
+Grep every Newton / `ODEProblem` / `DAEProblem` / `NonlinearProblem` construction site in `src/` and `test/`. Confirm each goes through `dc!`/`tran!`/`ac!` or has a documented reason. Flag stragglers; no code changes.
+
+### Phase 1 — formalize the two-tier boundary; kill `imported_hdl_modules`
+
+Dramatically smaller than earlier drafts because VADistillerModels / PSPModels / BSIM4 are already doing the right thing (Tier-1 method additions).
+
+- **Establish Tier 2 scope walk in sema.** `spice_select_device` (`src/spc/sema.jl:295`) currently does: registry lookup → HDL-module-list fallback. Reorder to: scope walk (populated from `.hdl` / `.include` / `.lib` / `jlpkg://` directives) → registry fallback. The scope list is sema-internal state, never exposed to users.
+- **`.hdl "foo.va"` sema rewrite.** Parse VA file inline, create device types in the netlist's gensym'd module, push that module onto the sema scope. No global registration. Relative paths resolve against the containing SPICE file.
+- **`jlpkg://` stays as-is** (`src/spc/sema.jl:456-482`). Already does the right scope switch. One cleanup: make sure `.hdl "jlpkg://..."` works symmetrically (today `.lib` and `.include` handle it; check `.hdl`).
+- **Remove `imported_hdl_modules` kwarg** from `make_mna_circuit`, `load_mna_pdk`, and internal sema threading. `parse_spice_to_mna` / `parse_spice_file_to_mna` are deleted outright in Phase 2.
+- **Rename `load_mna_pdk` → `Cadnip.precompile_pdk`** and `load_mna_va_module` → `Cadnip.precompile_va`. Documented as PDK-authoring APIs; package the existing `#cedar_parse_cache#` baking behavior for `jlpkg://` consumption.
+- **Delete `load_mna_modules`, `load_mna_va_modules`.** Multi-module handling collapses into the rename above (auto-detect single vs multi inside `precompile_va`).
+- **Test:** VADistillerModels-using netlists that previously relied on `imported_hdl_modules=[sp_diode_module]` now work with the kwarg removed. Graetz benchmark is the primary case.
+- **Test:** `.hdl "local_dev.va"` followed by a device reference in the same netlist resolves correctly.
+- **Test:** two sibling `.lib "jlpkg://Sky130PDK/..." tt` and `.lib "jlpkg://Sky130PDK/..." ff` compiles produce different builders with different device types, no collision.
+
+### Phase 2 — file-first loading; delete the temp-module duplication
+
+**Prerequisite — codegen hygiene audit.** Before any new entrypoint can cleanly eval into a caller-supplied module, codegen must emit fully-qualified references. Without this, every entrypoint has to mutate the target module with `using` statements, re-introducing the duplication. See "Generated-code hygiene". Start Phase 2 here.
+
+**SpiceFile / SpectreFile types:**
+```julia
+struct SpiceFile
+    path::String
+    name::Symbol       # builder name; defaults to filename stem
+end
+SpiceFile(path; name=Symbol(first(splitext(basename(path))))) = SpiceFile(String(path), Symbol(name))
+# SpectreFile: identical shape
+```
+Default `name` from the filename stem. Explicit `name=` for overrides.
+
+**`Base.include` methods:** `Base.include(mod::Module, f::SpiceFile)` / `Base.include(mod::Module, f::SpectreFile)`, mirroring `Base.include(mod, VAFile)` at `src/vasim.jl:3431`. Each parses, codegens via `make_mna_circuit(ast; circuit_name=f.name)`, evals the builder `Expr` into `mod`. Returns `nothing`; builder accessible as `mod.$(f.name)`. Fully-qualified codegen means `mod` needs no prior `using` statements.
+
+**`MNACircuit(path::AbstractString; lang=infer_from_ext(path), kwargs...)`** — extension rule: `.scs` → Spectre, else SPICE. `lang=` overrides. Creates an anonymous module, `Base.include`s into it, wraps the builder bare.
+
+**`MNACircuit(code::String; lang=:spice, source_dir=nothing, kwargs...)`** — runtime string. Shares the single eval helper with `MNACircuit(path)`. `source_dir` resolves `.hdl` relative paths; error if `.hdl` hits an unresolvable relative path.
+
+**`spc"..."` string macro** — reinstate the old name; symmetric with `sp"..."`. Resolves `.hdl` relative to `__source__.file`.
+
+**Deletions (hard break):**
+- `test/common.jl`: `solve_mna_spice_code`, `solve_mna_spectre_code`, `solve_mna_circuit`, `tran_mna_circuit`, `make_mna_spice_circuit`.
+- `src/spc/interface.jl`: `solve_spice_mna`, `parse_spice_to_mna`, `parse_spice_file_to_mna`.
+- Every call site migrates to `dc!(MNACircuit(...))` / `tran!(MNACircuit(...), tspan)`.
+
+**Byproduct:** fixes the `tran_mna_circuit` transient-init bypass — every test routes through `tran!`, which uses `CedarTranOp` by default.
+
+**Tests to add:**
+
+- `MNACircuit(code; lang=:spice)` inside a function body followed by `dc!` / `tran!` works without `invokelatest` on the per-call path. Regression-proofs the function-barrier story.
+- `Base.include(mod, SpiceFile("amp.sp"))` against a module with no Cadnip `using` succeeds (confirms hygiene prerequisite held).
+- `CircuitSweep` audit: does it accept a bare builder (as `neurophos/cadnip/tw_mzm_simulation.jl:138` does today) or only `MNACircuit`? If both, narrow to `MNACircuit`-input only. Trivial.
+
+### Phase 2b — explicit `prepare!` / eager setup
+
+- Make `MNACircuit(builder)` eagerly run structure discovery (currently `build_with_detection`, `src/mna/solve.jl:1437-1449`). Or expose `prepare!(circuit)` and document the benchmark pattern.
+- Goal: the graetz benchmark's `MNA.assemble!(circuit)` pre-warm becomes `prepare!(circuit)` (or disappears because construction is eager).
+
+### Phase 3 — `SymbolicIndexingInterface` on solutions
+
+Approach: **attach `MNASystem` to the `ODEFunction.sys` field** so SII flows through the native SciML solution (Path A). No wrapper type. If SciMLBase internals turn out to make assumptions `MNASystem` can't satisfy, deal with them when we hit them rather than pre-building a wrapper.
+
+- Implement `SII.is_variable`, `variable_symbols`, `variable_index`, `state_values`, `observed` on `MNASystem`.
+- Thread `sys=circuit.system` through the `ODEFunction` / `DAEFunction` / `DDEFunction` construction in `tran!`.
+- Implement the same SII surface on `DCSolution` (`src/mna/solve.jl:138`) directly — DC has no native SciML analog, so SII on the struct itself.
+- Delete `MNASolutionAccessor` (`src/mna/solve.jl:1127-1174`) once the native-solution path works.
+- Delete `voltage(sol, :x)` / `current(sol, :x)` accessors. Convert call sites.
+
+If Path A hits a wall during implementation, fall back to a `(sol, sys)` wrapper — cost is roughly the same work, just in a different location. Sizing stays at ~2-3 days with the understanding that it might expand if SciMLBase resists.
+
+### Phase 3b — `SweepResult` ergonomics
+
+- `dc!(cs::CircuitSweep)` returns a small `SweepResult{P,S}` that iterates `(params, sol)` pairs and exposes `.points` / `.solutions` aligned.
+- **Not `EnsembleSolution`.** Investigated (SciMLBase): `EnsembleSolution` doesn't carry per-trajectory parameter metadata, its plot recipes assume time-series inners (breaks DC), and its indexing has known issues with threaded solves. Custom `SweepResult`.
+- Apply the same type to `tran!(cs)` once that exists.
+
+### Phase 4 — port integration tests to HDL inputs
+
+- Convert `test/mna/audio_integration.jl`, `photonic.jl`, `vadistiller_integration.jl`, and any `*_integration.jl` file to use `MNACircuit(path)` / `sp"..."` / `MNACircuit(code)` rather than manual `MNAContext` + `stamp!`.
+- Unit tests in `test/mna/core.jl`, `charge_formulation.jl`, etc. keep manual stamping — that's what they test.
+- Rule: tests whose name ends in `_integration.jl` must drive the public API a user drives.
+- `test/common.jl` retains only fixtures (`isapprox_deftol`, etc.), no solver wrappers.
+
+### Phase 5 — documentation
+
+- README table: rows = input forms (SPICE file, Spectre file, VA file, PDK via jlpkg, local .hdl, SPICE string, Spectre string, VA string, builder fn, MTK connector); cols = (loader, example).
+- Document the two-tier model explicitly: Tier 1 for builtins via `using VADistillerModels` / `using BSIM4`, Tier 2 for PDKs via `jlpkg://`.
+- Remove the "Top-Level Eval for SPICE Circuits" section from `CLAUDE.md` — canonical pattern is `MNACircuit(path)` or `Base.include(mod, SpiceFile(path))`.
+- Document `sol[:name]` as the canonical name-lookup.
+
+## Explicit non-goals
+
+- Rewriting `DCSolution` and the transient solution into a single unified struct.
+- Touching the core stamping / `MNAContext` API.
+- Changing how VADistillerModels / PSPModels / BSIM4 register (they're already correct Tier-1 contributors).
+- Converting unit tests that exercise stamping directly.
+- Automating level-specific VA registration (magic comments, annotations). Defer.
+- Fixing the `params.params.x` double-dotting in `ParamLens`. Orthogonal.
+
+## Sizing
+
+Rough, subject to revision once Phase 0 turns up surprises:
+
+| Phase | Size |
+|---|---|
+| 0 — audit | ~0.5 day |
+| 1 — two-tier boundary, sema scope walk, `.hdl` rewrite, kill `imported_hdl_modules`, rename to `precompile_*` | ~1 day (no cross-repo migration; just Cadnip) |
+| 2 — codegen hygiene (3 VA sites + 43 SPICE `stamp!` sites + preamble trim + tests), `SpiceFile`/`SpectreFile` + `Base.include`, `MNACircuit(path)`, `spc"..."`, delete helpers | ~1 week |
+| 2b — eager prepare | ~0.5 day |
+| 3 — SII on solutions (spike risk) | ~2-3 days |
+| 3b — SweepResult | ~0.5 day |
+| 4 — port integration tests | ~1-2 days |
+| 5 — docs | ~0.5 day |
+
+Total: ~2 weeks of focused work. No downstream-package migration needed.
+
+Landing order: 0 → 1 → 2 → 2b → 3 → 3b → 4 → 5. Phase 2 is the fastest route to closing the transient-init bypass; depends on Phase 1 (for sema scope walk and kwarg removal) and on its own codegen-hygiene prerequisite.
+
+## Resolved
+
+- **Model resolution architecture:** two tiers. Tier 1 is the existing `ModelRegistry.getmodel` narrowed to SPICE-standard builtins (R/C/L/D, level-dispatched standard MOSFETs/BJTs), contributed by Cadnip + stdlib packages (VADistillerModels, BSIM4, PSPModels) via Julia dispatch. Tier 2 is the sema scope walk populated by netlist include directives, for PDK-specific and custom devices.
+- **Corner handling:** Tier 2. `.lib "jlpkg://Sky130PDK/..." tt` pushes the tt-section module onto scope; `ff` pushes a different one. Precompiled PDKs can ship all corners in one package; no registry collision.
+- **Downstream model packages:** no migration. They already register correctly as Tier-1 contributors.
+- **Deprecation policy:** hard break. One PR, no aliases.
+- **Spectre macro name:** `spc"..."` — matches the historical name and the `SpectreFile` type prefix.
+- **Extension inference:** `.scs` → Spectre, else SPICE. Override via `lang=`.
+- **File loading style:** `Base.include(mod, SpiceFile(path))` / `Base.include(mod, SpectreFile(path))`, mirroring the existing `VAFile` pattern.
+- **`voltage` / `current` aliases:** deleted.
+- **`SweepResult` vs `EnsembleSolution`:** custom `SweepResult`.
+- **`AbstractSimulator`:** stays in its original role (simulator-variant disambiguation in Tier 1). Not repurposed for corners.
+- **`.hdl` in runtime strings:** error if a relative `.hdl` path is encountered without `source_dir=`; absolute paths and `jlpkg://` forms work unconditionally. Keeps the common inline case zero-ceremony and surfaces missing context clearly for dynamic-string callers.
+- **`precompile_pdk` section handling:** one call per PDK file, not per section. The PDK package ships a single parse cache; section selection is a consumer-side decision via `.lib "jlpkg://..." section`. Matches how `jlpkg://` already works (`test/sky130/scale.spice:3`); no new concept.
+- **`.hdl "jlpkg://..."` symmetry:** implementation verification, not a design question. Folded into Phase 1's task list: verify the existing `.hdl` sema path handles `jlpkg://` the way `.lib` and `.include` do (`src/spc/sema.jl:456-482`); add the handling if it's missing.
+- **Phase 3 SII approach:** Path A — attach `MNASystem` to the `ODEFunction.sys` field so SII flows through the native SciML solution. No wrapper type. If SciMLBase internals resist, fall back to a `(sol, sys)` wrapper as an in-Phase-3 adjustment rather than a pre-emptive design. Sizing stays at ~2-3 days.
+
+## Open questions
+
+None currently open. Plan is ready to execute.

--- a/models/VADistillerModels.jl/src/VADistillerModels.jl
+++ b/models/VADistillerModels.jl/src/VADistillerModels.jl
@@ -179,6 +179,12 @@ Cadnip.ModelRegistry.getparams(::Val{:pjf}, ::Val{1}, ::Nothing, ::Type{<:Abstra
 Cadnip.ModelRegistry.getparams(::Val{:njf}, ::Val{2}, ::Nothing, ::Type{<:AbstractSimulator}) = (type=1,)
 Cadnip.ModelRegistry.getparams(::Val{:pjf}, ::Val{2}, ::Nothing, ::Type{<:AbstractSimulator}) = (type=-1,)
 
+# Diode — `using VADistillerModels` overrides Cadnip's default `MNA.Diode`
+# so `.model foo d <params>` in a SPICE netlist resolves to the full VA diode
+# model. Tier-1 registry contribution per the API consolidation plan.
+Cadnip.ModelRegistry.getmodel(::Val{:d}, ::Nothing, ::Nothing, ::Type{<:AbstractSimulator}) = sp_diode
+Cadnip.ModelRegistry.getparams(::Val{:d}, ::Nothing, ::Nothing, ::Type{<:AbstractSimulator}) = (;)
+
 # Precompile stamp! methods for all three method variants:
 # 1. MNAContext + ZeroVector (default when _mna_x_ not passed)
 # 2. MNAContext + Vector{Float64} (when tests pass _mna_x_=x with x=Float64[])

--- a/src/Cadnip.jl
+++ b/src/Cadnip.jl
@@ -88,11 +88,20 @@ include("spectre.jl")
 # defining additional getmodel/getparams methods.
 #==============================================================================#
 
-# Simple passive devices (no level required)
+# Simple passive devices (no level required) — keep these as defaults.
+# `.model foo r`, `.model foo c`, `.model foo l` resolve to the MNA built-in
+# primitives, which have full parameter coverage for passives.
 ModelRegistry.getmodel(::Val{:r}, ::Nothing, ::Nothing, ::Type{<:ModelRegistry.AbstractSimulator}) = MNA.Resistor
 ModelRegistry.getmodel(::Val{:c}, ::Nothing, ::Nothing, ::Type{<:ModelRegistry.AbstractSimulator}) = MNA.Capacitor
 ModelRegistry.getmodel(::Val{:l}, ::Nothing, ::Nothing, ::Type{<:ModelRegistry.AbstractSimulator}) = MNA.Inductor
-ModelRegistry.getmodel(::Val{:d}, ::Nothing, ::Nothing, ::Type{<:ModelRegistry.AbstractSimulator}) = MNA.Diode
+
+# `:d` is deliberately not registered here. `MNA.Diode` is an incomplete
+# reference implementation (no `cjo`, `m`, `bv`, `tt`, ...). Registering it
+# as a default would block stdlib Tier-1 packages (VADistillerModels) from
+# claiming `(:d, nothing, nothing)` without triggering Julia 1.12's
+# method-overwriting precompile error. Users who need diode `.model` cards
+# load `using VADistillerModels` (or another Tier-1 diode provider). Users
+# who want `MNA.Diode` build it directly via `stamp!(Diode(), ctx, a, k)`.
 
 # Phase 4: New SPC SPICE codegen (used by MNA backend)
 include("spc/cache.jl")  # Must be before sema.jl (CedarParseCache)

--- a/src/Cadnip.jl
+++ b/src/Cadnip.jl
@@ -14,12 +14,10 @@ export DAEProblem
 export @dyn, @requires, @provides, @isckt_or
 export solve
 
-# Phase 4: MNA SPICE codegen exports
-export make_mna_circuit, parse_spice_to_mna, parse_spice_file_to_mna, solve_spice_mna
-export @sp_str
-
-# PDK/VA precompilation exports
-export load_mna_modules, load_mna_pdk, load_mna_va_module, load_mna_va_modules
+# MNA SPICE codegen exports
+export @sp_str, @spc_str
+# make_mna_circuit stays internal (not exported); precompile_pdk / precompile_va are
+# PDK-authoring APIs accessed as Cadnip.precompile_pdk / Cadnip.precompile_va.
 
 
 include("util.jl")

--- a/src/mna/MNA.jl
+++ b/src/mna/MNA.jl
@@ -31,7 +31,7 @@
 #
 # # Solve DC
 # sol = solve_dc(ctx)
-# @assert voltage(sol, :out) ≈ 2.5  # Voltage divider
+# @assert sol[:out] ≈ 2.5  # Voltage divider
 # ```
 #==============================================================================#
 

--- a/src/mna/build.jl
+++ b/src/mna/build.jl
@@ -383,3 +383,46 @@ function show_C(sys::MNAData)
     all_names = vcat(sys.node_names, sys.current_names, sys.charge_names)
     show_matrix(stdout, sys.C, all_names)
 end
+
+#==============================================================================#
+# SymbolicIndexingInterface (SII) on MNAData
+#
+# Wire up the system so that `ODEFunction(f; sys=mna_data)` + solve() gives a
+# solution that supports `sol[:node_name]` and `sol[:current_name]` uniformly
+# for DC and transient analysis. This is Phase 3 of the API consolidation plan.
+#==============================================================================#
+import SymbolicIndexingInterface as SII
+
+function _sii_all_names(sys::MNAData)
+    return vcat(sys.node_names, sys.current_names, sys.charge_names)
+end
+
+# Do NOT define `SII.symbolic_container` — it triggers default recursive
+# forwarding that causes StackOverflowError when paired with ODEFunction's
+# own SII machinery. Define the concrete methods directly.
+SII.is_variable(sys::MNAData, sym::Symbol) = sym in _sii_all_names(sys)
+SII.is_variable(::MNAData, ::Any) = false
+SII.variable_symbols(sys::MNAData) = _sii_all_names(sys)
+
+function SII.variable_index(sys::MNAData, sym::Symbol)
+    (sym === :gnd || sym === Symbol("0")) && return nothing
+    idx = findfirst(==(sym), sys.node_names)
+    idx === nothing || return idx
+    idx = findfirst(==(sym), sys.current_names)
+    idx === nothing || return sys.n_nodes + idx
+    idx = findfirst(==(sym), sys.charge_names)
+    idx === nothing || return sys.n_nodes + sys.n_currents + idx
+    return nothing
+end
+SII.variable_index(::MNAData, ::Any) = nothing
+
+SII.is_independent_variable(::MNAData, sym::Symbol) = sym === :t
+SII.is_independent_variable(::MNAData, ::Any) = false
+SII.independent_variable_symbols(::MNAData) = [:t]
+SII.is_time_dependent(::MNAData) = true
+SII.constant_structure(::MNAData) = true
+SII.parameter_symbols(::MNAData) = Symbol[]
+SII.is_parameter(::MNAData, ::Any) = false
+SII.parameter_index(::MNAData, ::Any) = nothing
+SII.is_observed(::MNAData, ::Any) = false
+SII.all_variable_symbols(sys::MNAData) = _sii_all_names(sys)

--- a/src/mna/solve.jl
+++ b/src/mna/solve.jl
@@ -19,7 +19,8 @@ using Random
 export DCSolution, ACSolution
 export solve_dc, solve_dc!, solve_ac
 export make_ode_problem, make_dae_problem  # For static MNAData
-export voltage, current, magnitude_db, phase_deg
+# voltage / current accessors deleted — use sol[:name]. magnitude_db / phase_deg stay for AC.
+export magnitude_db, phase_deg
 
 #==============================================================================#
 # Simulation Specification
@@ -155,37 +156,47 @@ Base.getindex(sol::DCSolution, i::Int) = sol.x[i]
 Base.length(sol::DCSolution) = length(sol.x)
 
 """
-    voltage(sol::DCSolution, name::Symbol) -> Float64
+    sol[name::Symbol]
 
-Get the voltage at a node by name.
+Name-based solution access. `sol[:vout]` returns the voltage at node `vout`;
+if no such node exists, falls back to searching current variables. Mirrors the
+SymbolicIndexingInterface conventions so that `sol[:x]` works uniformly across
+DC and transient solutions.
 """
-function voltage(sol::DCSolution, name::Symbol)
+function Base.getindex(sol::DCSolution, name::Symbol)
     (name === :gnd || name === Symbol("0")) && return 0.0
     idx = findfirst(==(name), sol.node_names)
-    idx === nothing && error("Unknown node: $name")
-    return sol.x[idx]
-end
-
-"""
-    voltage(sol::DCSolution, idx::Int) -> Float64
-
-Get the voltage at a node by index (0 = ground).
-"""
-function voltage(sol::DCSolution, idx::Int)
-    idx == 0 && return 0.0
-    return sol.x[idx]
-end
-
-"""
-    current(sol::DCSolution, name::Symbol) -> Float64
-
-Get a current variable by name.
-"""
-function current(sol::DCSolution, name::Symbol)
+    idx === nothing || return sol.x[idx]
     idx = findfirst(==(name), sol.current_names)
-    idx === nothing && error("Unknown current: $name")
-    return sol.x[sol.n_nodes + idx]
+    idx === nothing || return sol.x[sol.n_nodes + idx]
+    error("Unknown variable: $name")
 end
+
+"""
+    nameat(sol, name::Symbol, t::Real)
+
+Look up a variable by name at time `t` on a SciML transient solution whose
+`prob.f.sys` carries SymbolicIndexingInterface metadata (i.e., an `MNAData`).
+
+Replaces the old `voltage(MNASolutionAccessor(sol, sys), :x, t)` pattern.
+
+```julia
+sol = tran!(circuit, (0.0, 1e-3))
+v_out_at_0p5ms = nameat(sol, :out, 5e-4)
+```
+"""
+function nameat(sol, name::Symbol, t::Real)
+    (name === :gnd || name === Symbol("0")) && return 0.0
+    sys = sol.prob.f.sys
+    idx = SII.variable_index(sys, name)
+    idx === nothing && error("Unknown variable: $name")
+    return sol(t)[idx]
+end
+export nameat
+
+# `voltage(sol::DCSolution, ...)` and `current(sol::DCSolution, ...)` deleted —
+# use `sol[:name]` (which walks node_names then current_names) or
+# `sol[idx::Int]` for positional access.
 
 function Base.show(io::IO, sol::DCSolution)
     print(io, "DCSolution(")
@@ -239,23 +250,19 @@ struct ACSolution
 end
 
 """
-    voltage(sol::ACSolution, name::Symbol) -> Vector{ComplexF64}
+    sol[name::Symbol]
 
-Get the complex voltage at a node across all frequencies.
+Name-based access to an AC solution — returns the complex trajectory across
+all frequencies. `sol[name, freq_idx]` returns the complex value at one frequency.
 """
-function voltage(sol::ACSolution, name::Symbol)
+function Base.getindex(sol::ACSolution, name::Symbol)
     (name === :gnd || name === Symbol("0")) && return zeros(ComplexF64, length(sol.freqs))
     idx = findfirst(==(name), sol.node_names)
     idx === nothing && error("Unknown node: $name")
     return [x[idx] for x in sol.x]
 end
 
-"""
-    voltage(sol::ACSolution, name::Symbol, freq_idx::Int) -> ComplexF64
-
-Get the complex voltage at a specific frequency index.
-"""
-function voltage(sol::ACSolution, name::Symbol, freq_idx::Int)
+function Base.getindex(sol::ACSolution, name::Symbol, freq_idx::Int)
     (name === :gnd || name === Symbol("0")) && return 0.0 + 0.0im
     idx = findfirst(==(name), sol.node_names)
     idx === nothing && error("Unknown node: $name")
@@ -267,14 +274,14 @@ end
 
 Get the voltage magnitude in dB at a node.
 """
-magnitude_db(sol::ACSolution, name::Symbol) = 20 .* log10.(abs.(voltage(sol, name)))
+magnitude_db(sol::ACSolution, name::Symbol) = 20 .* log10.(abs.(sol[name]))
 
 """
     phase_deg(sol::ACSolution, name::Symbol) -> Vector{Float64}
 
 Get the voltage phase in degrees at a node.
 """
-phase_deg(sol::ACSolution, name::Symbol) = rad2deg.(angle.(voltage(sol, name)))
+phase_deg(sol::ACSolution, name::Symbol) = rad2deg.(angle.(sol[name]))
 
 function Base.show(io::IO, sol::ACSolution)
     print(io, "ACSolution($(length(sol.freqs)) frequencies, ")
@@ -1110,67 +1117,12 @@ end
 # Symbolic Solution Access
 #==============================================================================#
 
-"""
-    MNASolutionAccessor
-
-Provides symbolic access to ODE solution via node names.
-Wraps an ODESolution with the MNAData for name resolution.
-
-# Example
-```julia
-circuit = MNACircuit(build_circuit; Vcc=5.0, R=1000.0)
-sol = tran!(circuit, (0.0, 1e-3))
-acc = MNASolutionAccessor(sol, assemble!(circuit))
-acc[:out]  # Voltage trajectory at node :out
-```
-"""
-struct MNASolutionAccessor{S}
-    sol::S
-    sys::MNAData
-end
-
-export MNASolutionAccessor
-
-# Symbolic indexing: acc[:node_name]
-function Base.getindex(acc::MNASolutionAccessor, name::Symbol)
-    (name === :gnd || name === Symbol("0")) && return zeros(length(acc.sol.t))
-    idx = findfirst(==(name), acc.sys.node_names)
-    if idx !== nothing
-        return [acc.sol(t)[idx] for t in acc.sol.t]
-    end
-    idx = findfirst(==(name), acc.sys.current_names)
-    if idx !== nothing
-        curr_idx = acc.sys.n_nodes + idx
-        return [acc.sol(t)[curr_idx] for t in acc.sol.t]
-    end
-    error("Unknown variable: $name")
-end
-
-# Time access
-Base.getproperty(acc::MNASolutionAccessor, s::Symbol) =
-    s === :t ? acc.sol.t : getfield(acc, s)
-
-# Interpolation
-(acc::MNASolutionAccessor)(t::Real) = acc.sol(t)
-
-"""
-    voltage(acc::MNASolutionAccessor, name::Symbol, t::Real)
-
-Get voltage at node at specific time.
-"""
-function voltage(acc::MNASolutionAccessor, name::Symbol, t::Real)
-    (name === :gnd || name === Symbol("0")) && return 0.0
-    idx = findfirst(==(name), acc.sys.node_names)
-    idx === nothing && error("Unknown node: $name")
-    return acc.sol(t)[idx]
-end
-
-"""
-    voltage(acc::MNASolutionAccessor, name::Symbol)
-
-Get voltage trajectory at node.
-"""
-voltage(acc::MNASolutionAccessor, name::Symbol) = acc[name]
+# `MNASolutionAccessor` deleted — SII on `ODEFunction.sys` / `DAEFunction.sys`
+# (see src/mna/build.jl) means transient solutions natively support `sol[:name]`.
+# For time-indexed access use `nameat(sol, :name, t)`.
+#
+# Hierarchical `sol[ref::NodeRef]` is handled below — delegates to the flat
+# name built by ScopedSystem (e.g., :x1_out).
 
 #==============================================================================#
 # Hierarchical Scope Access (for sol[sys.x1.r1] style)
@@ -1229,16 +1181,20 @@ end
 
 export ScopedSystem
 
-# Allow acc[NodeRef] access
-function Base.getindex(acc::MNASolutionAccessor, ref::NodeRef)
-    full_name = isempty(ref.path) ? ref.name : Symbol(join([ref.path..., ref.name], "_"))
-    return acc[full_name]
-end
+# Flat-name construction from a hierarchical NodeRef. :x1 / :out → :x1_out
+_flat_name(ref::NodeRef) = isempty(ref.path) ? ref.name :
+    Symbol(join([ref.path..., ref.name], "_"))
 
-function voltage(acc::MNASolutionAccessor, ref::NodeRef, t::Real)
-    full_name = isempty(ref.path) ? ref.name : Symbol(join([ref.path..., ref.name], "_"))
-    return voltage(acc, full_name, t)
-end
+# Support sol[NodeRef] on DCSolution and any SciML transient solution whose
+# f.sys supports SII. Delegates to the flat name lookup — `sol[:x1_out]`.
+Base.getindex(sol::DCSolution, ref::NodeRef) = sol[_flat_name(ref)]
+Base.getindex(sol::ACSolution, ref::NodeRef) = sol[_flat_name(ref)]
+# Transient solutions come from SciMLBase; add the NodeRef → flat lookup.
+Base.getindex(sol::SciMLBase.AbstractTimeseriesSolution, ref::NodeRef) =
+    sol[_flat_name(ref)]
+
+# Time-indexed name lookup for NodeRef.
+nameat(sol, ref::NodeRef, t::Real) = nameat(sol, _flat_name(ref), t)
 
 """
     scope(sys::MNAData) -> ScopedSystem
@@ -1414,8 +1370,7 @@ Note that time-dependent sources are evaluated at t=0.
 circuit = MNACircuit(build_rc; R=1000.0, C=1e-6)
 sol = tran!(circuit, (0.0, 1e-3); solver=Rodas5P())
 sys = assemble!(circuit)
-acc = MNASolutionAccessor(sol, sys)
-v_out = voltage(acc, :out, 0.5e-3)
+v_out = nameat(sol, :out, 0.5e-3)   # or sol[:out] for the full trajectory
 ```
 """
 function assemble!(circuit::MNACircuit)
@@ -1620,6 +1575,9 @@ function SciMLBase.DAEProblem(circuit::MNACircuit, tspan::Tuple{<:Real,<:Real};
     # Detection uses random x values to correctly identify voltage-dependent capacitors
     ctx = build_with_detection(circuit)
 
+    # Assemble once to get the MNAData used as SII `sys` on the resulting solution.
+    sys = assemble!(ctx)
+
     # Detect differential variables using the same detection context
     diff_vars = detect_differential_vars(circuit; ctx=ctx)
     n = length(diff_vars)
@@ -1649,9 +1607,9 @@ function SciMLBase.DAEProblem(circuit::MNACircuit, tspan::Tuple{<:Real,<:Real};
         # Do NOT use cs.G + cs.C - numeric cancellation can drop entries and cause
         # dimension mismatch errors with sparse solvers like KLU.
         jac_prototype = copy(cs.G)
-        f = SciMLBase.DAEFunction(residual!; jac=jacobian!, jac_prototype=jac_prototype)
+        f = SciMLBase.DAEFunction(residual!; jac=jacobian!, jac_prototype=jac_prototype, sys=sys)
     else
-        f = SciMLBase.DAEFunction(residual!)
+        f = SciMLBase.DAEFunction(residual!; sys=sys)
     end
 
     # Note: p (workspace) must be positional argument (5th), not keyword
@@ -1751,12 +1709,16 @@ function SciMLBase.ODEProblem(circuit::MNACircuit, tspan::Tuple{<:Real,<:Real}; 
         return nothing
     end
 
+    # Assemble once for SII system metadata (native SciML `sys=` field).
+    sys = assemble!(ctx)
+
     # Mass matrix C is constant - voltage-dependent capacitors use charge formulation
     f = SciMLBase.ODEFunction(
         rhs!;
         mass_matrix = cs.C,
         jac = jac!,
-        jac_prototype = -cs.G
+        jac_prototype = -cs.G,
+        sys = sys,
     )
 
     # Pass workspace as p parameter
@@ -1825,8 +1787,11 @@ function SciMLBase.DDEProblem(circuit::MNACircuit, tspan::Tuple{<:Real,<:Real};
     # History function: DC value for t < t0
     h_init(p, t; idxs=nothing) = idxs === nothing ? u0 : u0[idxs]
 
+    # Assemble once for SII system metadata.
+    sys = assemble!(ctx)
+
     # Mass matrix C is constant (voltage-dependent caps use charge formulation)
-    f = SciMLBase.DDEFunction(rhs!; mass_matrix=cs.C)
+    f = SciMLBase.DDEFunction(rhs!; mass_matrix=cs.C, sys=sys)
     return SciMLBase.DDEProblem(f, u0, h_init, Float64.(tspan), ws;
                                  constant_lags=constant_lags, kwargs...)
 end
@@ -1982,3 +1947,25 @@ function make_workspace_dae_jacobian()
     end
     return dae_jac!
 end
+
+#==============================================================================#
+# prepare!: explicit eager structure-discovery pass
+#
+# Discovers the circuit structure (nodes, current variables, voltage-dependent
+# charges) and caches it on the MNACircuit. This is called automatically by
+# dc!/tran!/ac! but can be invoked explicitly to separate setup from solve for
+# benchmarking. Replaces the `MNA.assemble!(circuit)` pre-warm pattern.
+#==============================================================================#
+"""
+    prepare!(circuit::MNACircuit) -> MNACircuit
+
+Run structure discovery on the circuit so that subsequent `dc!`/`tran!`/`ac!` calls
+reuse the cached structure. Idempotent.
+
+Useful in benchmarks to separate one-time setup cost from per-solve cost.
+"""
+function prepare!(circuit::MNACircuit)
+    build_with_detection(circuit)
+    return circuit
+end
+export prepare!

--- a/src/spc/codegen.jl
+++ b/src/spc/codegen.jl
@@ -770,7 +770,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Resistor})
     return quote
         let r_val = $r_expr, m_val = $m_expr
             # Parallel resistors: R_eff = R / m
-            stamp!($(MNA).Resistor(r_val / m_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
+            $(MNA).stamp!($(MNA).Resistor(r_val / m_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
         end
     end
 end
@@ -799,7 +799,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Capacitor})
     return quote
         let c_val = $c_expr, m_val = $m_expr
             # Parallel capacitors: C_eff = C * m
-            stamp!(Capacitor(c_val * m_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
+            $(MNA).stamp!(Capacitor(c_val * m_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
         end
     end
 end
@@ -824,7 +824,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Inductor})
 
     return quote
         let l_val = $l_expr
-            stamp!(Inductor(l_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
+            $(MNA).stamp!(Inductor(l_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
         end
     end
 end
@@ -847,7 +847,7 @@ function cg_mna_instance!(state::CodegenState, ::Val{:mna}, instance::SNode{SP.V
 
     return quote
         let v = $dc_val
-            stamp!(VoltageSource(v; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
+            $(MNA).stamp!(VoltageSource(v; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
         end
     end
 end
@@ -876,7 +876,7 @@ function cg_mna_instance!(state::CodegenState, ::Val{:mna}, instance::SNode{SP.C
     # Swap nodes: MNA injects into first arg, SPICE injects into neg
     return quote
         let i = $dc_val
-            stamp!(CurrentSource(i; name=$(QuoteNode(Symbol(name)))), ctx, $neg, $pos, t, spec.mode)
+            $(MNA).stamp!(CurrentSource(i; name=$(QuoteNode(Symbol(name)))), ctx, $neg, $pos, t, spec.mode)
         end
     end
 end
@@ -907,7 +907,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.ControlledSour
 
     return quote
         let gain = $gain_expr
-            stamp!(VCVS(gain; name=$(QuoteNode(Symbol(name)))), ctx, $out_p, $out_n, $in_p, $in_n)
+            $(MNA).stamp!(VCVS(gain; name=$(QuoteNode(Symbol(name)))), ctx, $out_p, $out_n, $in_p, $in_n)
         end
     end
 end
@@ -938,7 +938,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.ControlledSour
 
     return quote
         let gm = $gm_expr
-            stamp!(VCCS(gm; name=$(QuoteNode(Symbol(name)))), ctx, $out_p, $out_n, $in_p, $in_n)
+            $(MNA).stamp!(VCCS(gm; name=$(QuoteNode(Symbol(name)))), ctx, $out_p, $out_n, $in_p, $in_n)
         end
     end
 end
@@ -976,8 +976,8 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.ControlledSour
     return quote
         let rm = $rm_expr
             # Get the current index of the referenced voltage source
-            I_in_idx = get_current_idx(ctx, $(QuoteNode(vname_sym)))
-            stamp!(CCVS(rm; name=$(QuoteNode(Symbol(name)))), ctx, $out_p, $out_n, I_in_idx)
+            I_in_idx = $(MNA).get_current_idx(ctx, $(QuoteNode(vname_sym)))
+            $(MNA).stamp!(CCVS(rm; name=$(QuoteNode(Symbol(name)))), ctx, $out_p, $out_n, I_in_idx)
         end
     end
 end
@@ -1015,8 +1015,8 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.ControlledSour
     return quote
         let gain = $gain_expr
             # Get the current index of the referenced voltage source
-            I_in_idx = get_current_idx(ctx, $(QuoteNode(vname_sym)))
-            stamp!(CCCS(gain; name=$(QuoteNode(Symbol(name)))), ctx, $out_p, $out_n, I_in_idx)
+            I_in_idx = $(MNA).get_current_idx(ctx, $(QuoteNode(vname_sym)))
+            $(MNA).stamp!(CCCS(gain; name=$(QuoteNode(Symbol(name)))), ctx, $out_p, $out_n, I_in_idx)
         end
     end
 end
@@ -1236,7 +1236,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Behavioral})
             ctrl_n_expr = ctrl_n === :gnd ? 0 : ctrl_n
             return quote
                 let gain = $gain
-                    stamp!(VCVS(gain; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, $ctrl_p, $ctrl_n_expr)
+                    $(MNA).stamp!(VCVS(gain; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, $ctrl_p, $ctrl_n_expr)
                 end
             end
         else
@@ -1267,7 +1267,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Behavioral})
             # which is opposite to VCCS convention, so swap p and n
             return quote
                 let gm = $gm
-                    stamp!(VCCS(gm; name=$(QuoteNode(Symbol(name)))), ctx, $n, $p, $ctrl_p, $ctrl_n_expr)
+                    $(MNA).stamp!(VCCS(gm; name=$(QuoteNode(Symbol(name)))), ctx, $n, $p, $ctrl_p, $ctrl_n_expr)
                 end
             end
         else
@@ -1698,7 +1698,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
 
         return quote
             let r_val = $r_expr, m_val = $m_expr
-                stamp!(Resistor(r_val / m_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
+                $(MNA).stamp!(Resistor(r_val / m_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
             end
         end
 
@@ -1717,7 +1717,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
 
         return quote
             let c_val = $c_expr, m_val = $m_expr
-                stamp!(Capacitor(c_val * m_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
+                $(MNA).stamp!(Capacitor(c_val * m_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
             end
         end
 
@@ -1736,7 +1736,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
 
         return quote
             let l_val = $l_expr, m_val = $m_expr
-                stamp!(Inductor(l_val / m_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
+                $(MNA).stamp!(Inductor(l_val / m_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
             end
         end
 
@@ -1760,7 +1760,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
             return quote
                 let wave = $wave_expr
                     ts, ys = wave[1:2:end], wave[2:2:end]
-                    stamp!(VoltageSource(ys[1]; tran=_t -> pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
+                    $(MNA).stamp!(VoltageSource(ys[1]; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
                            ctx, $p, $n, t, spec.mode)
                 end
             end
@@ -1771,14 +1771,14 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
             freq = hasparam(instance.params, "freq") ? cg_expr!(state, getparam(instance.params, "freq")) : 1e3
             return quote
                 let vo = $vo, va = $va, freq = $freq
-                    stamp!(VoltageSource(vo; tran=_t -> vo + va * sin(2π * freq * _t), name=$(QuoteNode(Symbol(name)))),
+                    $(MNA).stamp!(VoltageSource(vo; tran=_t -> vo + va * sin(2π * freq * _t), name=$(QuoteNode(Symbol(name)))),
                            ctx, $p, $n, t, spec.mode)
                 end
             end
         else
             # DC source - still use time/mode for consistency (DC sources return dc in all modes)
             return quote
-                stamp!(VoltageSource($dc_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
+                $(MNA).stamp!(VoltageSource($dc_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
             end
         end
 
@@ -1804,14 +1804,14 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
             return quote
                 let wave = $wave_expr
                     ts, ys = wave[1:2:end], wave[2:2:end]
-                    stamp!(CurrentSource(ys[1]; tran=_t -> pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
+                    $(MNA).stamp!(CurrentSource(ys[1]; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
                            ctx, $p, $n, t, spec.mode)
                 end
             end
         else
             # DC source - still use time/mode for consistency
             return quote
-                stamp!(CurrentSource($dc_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
+                $(MNA).stamp!(CurrentSource($dc_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
             end
         end
 
@@ -1826,7 +1826,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
         gain = hasparam(instance.params, "gain") ? cg_expr!(state, getparam(instance.params, "gain")) : 1.0
 
         return quote
-            stamp!(VCVS($gain; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, $cp, $cn)
+            $(MNA).stamp!(VCVS($gain; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, $cp, $cn)
         end
 
     elseif master == "vccs"
@@ -1840,7 +1840,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
         gm = hasparam(instance.params, "gm") ? cg_expr!(state, getparam(instance.params, "gm")) : 1.0
 
         return quote
-            stamp!(VCCS($gm; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, $cp, $cn)
+            $(MNA).stamp!(VCCS($gm; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, $cp, $cn)
         end
 
     else
@@ -2277,7 +2277,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                         let ts = $(StaticArrays).SVector{$n_points,Float64}($(times_exprs...)),
                             ys = $(StaticArrays).SVector{$n_points,Float64}($(values_exprs...)),
                             dc = $dc_value
-                            stamp!(VoltageSource(dc; tran=_t -> pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(VoltageSource(dc; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2286,7 +2286,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                         let ts = $(StaticArrays).SVector{$n_points,Float64}($(times_exprs...)),
                             ys = $(StaticArrays).SVector{$n_points,Float64}($(values_exprs...)),
                             dc = $dc_value
-                            stamp!(CurrentSource(dc; tran=_t -> pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(CurrentSource(dc; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2301,7 +2301,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                             times = vals[1:2:end]
                             values = vals[2:2:end]
                             dc = $dc_expr
-                            stamp!(VoltageSource(dc; tran=_t -> pwl_at_time(times, values, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(VoltageSource(dc; tran=_t -> $(MNA).pwl_at_time(times, values, _t), name=$(QuoteNode(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2311,7 +2311,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                             times = vals[1:2:end]
                             values = vals[2:2:end]
                             dc = $dc_expr
-                            stamp!(CurrentSource(dc; tran=_t -> pwl_at_time(times, values, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(CurrentSource(dc; tran=_t -> $(MNA).pwl_at_time(times, values, _t), name=$(QuoteNode(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2348,7 +2348,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                                 vo + va * exp(-theta * (_t - td)) * sind(360 * freq * (_t - td) + phase)
                             end
                         end
-                        stamp!(VoltageSource(dc; tran=tran_fn, name=$(QuoteNode(Symbol(name)))),
+                        $(MNA).stamp!(VoltageSource(dc; tran=tran_fn, name=$(QuoteNode(Symbol(name)))),
                                ctx, $p, $n, t, spec.mode)
                     end
                 end
@@ -2363,7 +2363,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                                 io + ia * exp(-theta * (_t - td)) * sind(360 * freq * (_t - td) + phase)
                             end
                         end
-                        stamp!(CurrentSource(dc; tran=tran_fn, name=$(QuoteNode(Symbol(name)))),
+                        $(MNA).stamp!(CurrentSource(dc; tran=tran_fn, name=$(QuoteNode(Symbol(name)))),
                                ctx, $p, $n, t, spec.mode)
                     end
                 end
@@ -2403,7 +2403,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                         let ts = $(StaticArrays).SVector{6,Float64}($t0, $t1, $t2, $t3, $t4, $t5),
                             ys = $(StaticArrays).SVector{6,Float64}($v_1, $v_2, $v_3, $v_4, $v_5, $v_6),
                             dc = $dc_value
-                            stamp!(VoltageSource(dc; tran=_t -> pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(VoltageSource(dc; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2412,7 +2412,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                         let ts = $(StaticArrays).SVector{6,Float64}($t0, $t1, $t2, $t3, $t4, $t5),
                             ys = $(StaticArrays).SVector{6,Float64}($v_1, $v_2, $v_3, $v_4, $v_5, $v_6),
                             dc = $dc_value
-                            stamp!(CurrentSource(dc; tran=_t -> pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(CurrentSource(dc; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2427,7 +2427,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                             tr = $tr_expr, tf = $tf_expr, pw = $pw_expr, per = $per_expr, dc = $dc_expr
                             times = [0.0, td, td+tr, td+tr+pw, td+tr+pw+tf, per]
                             values = [v1, v1, v2, v2, v1, v1]
-                            stamp!(VoltageSource(dc; tran=_t -> pwl_at_time(times, values, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(VoltageSource(dc; tran=_t -> $(MNA).pwl_at_time(times, values, _t), name=$(QuoteNode(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2437,7 +2437,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                             tr = $tr_expr, tf = $tf_expr, pw = $pw_expr, per = $per_expr, dc = $dc_expr
                             times = [0.0, td, td+tr, td+tr+pw, td+tr+pw+tf, per]
                             values = [i1, i1, i2, i2, i1, i1]
-                            stamp!(CurrentSource(dc; tran=_t -> pwl_at_time(times, values, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(CurrentSource(dc; tran=_t -> $(MNA).pwl_at_time(times, values, _t), name=$(QuoteNode(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2450,11 +2450,11 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
             dc_val_actual = dc_val !== nothing ? dc_val : 0.0
             if is_voltage
                 return quote
-                    stamp!(VoltageSource($dc_val_actual; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
+                    $(MNA).stamp!(VoltageSource($dc_val_actual; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
                 end
             else
                 return quote
-                    stamp!(CurrentSource($dc_val_actual; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
+                    $(MNA).stamp!(CurrentSource($dc_val_actual; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
                 end
             end
         end
@@ -2465,13 +2465,13 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
     if is_voltage
         return quote
             let v = $dc_val_actual, ac = $ac_expr
-                stamp!(VoltageSource(v; ac=ac, name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
+                $(MNA).stamp!(VoltageSource(v; ac=ac, name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
             end
         end
     else
         return quote
             let i = $dc_val_actual, ac = $ac_expr
-                stamp!(CurrentSource(i; ac=ac, name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
+                $(MNA).stamp!(CurrentSource(i; ac=ac, name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
             end
         end
     end
@@ -2599,7 +2599,7 @@ function codegen_mna!(state::CodegenState; skip_nets::Vector{Symbol}=Symbol[], i
     # Handle temperature option - update spec if temp is set
     if haskey(state.sema.options, :temp)
         temp_expr = cg_expr!(state, state.sema.options[:temp][end][2].val)
-        push!(block.args, :(spec = MNASpec(temp=$temp_expr, mode=spec.mode)))
+        push!(block.args, :(spec = $(MNASpec)(temp=$temp_expr, mode=spec.mode)))
     end
 
     # Import exposed models from HDL modules (VA-generated device types)
@@ -2627,7 +2627,7 @@ function codegen_mna!(state::CodegenState; skip_nets::Vector{Symbol}=Symbol[], i
         if net_name === Symbol("0")
             push!(block.args, :($net_name = 0))
         else
-            push!(block.args, :($net_name = get_node!(ctx, $(QuoteNode(net_name)))))
+            push!(block.args, :($net_name = $(MNA).get_node!(ctx, $(QuoteNode(net_name)))))
         end
     end
 
@@ -3026,9 +3026,16 @@ ctx = circuit_fn((R1=1000.0,), MNASpec())
 sol = MNA.solve_dc(ctx)
 ```
 """
-function make_mna_circuit(ast; circuit_name::Symbol=:circuit, imported_hdl_modules::Vector{Module}=Module[])
+function make_mna_circuit(ast; circuit_name::Symbol=:circuit)
     # Run semantic analysis (use sema() not sema_file_or_section to get parameter_order)
-    sema_result = sema(ast; imported_hdl_modules)
+    # Tier 2 scope walk (imported_hdl_modules) is populated by netlist directives only.
+    sema_result = sema(ast)
+    return _make_mna_circuit_with_sema(sema_result; circuit_name)
+end
+
+# Internal: codegen from a pre-built SemaResult. Separates AST parsing from
+# codegen so test infrastructure can pre-populate `sema_result.imported_hdl_modules`.
+function _make_mna_circuit_with_sema(sema_result; circuit_name::Symbol=:circuit)
     state = CodegenState(sema_result)
 
     # Build a dictionary mapping subcircuit names to their SemaResult
@@ -3089,12 +3096,12 @@ function make_mna_circuit(ast; circuit_name::Symbol=:circuit, imported_hdl_modul
     # Wrap in function definition with necessary imports
     # These imports are needed when the generated code is eval'd directly in Main
     return quote
-        # Import MNA device types needed for stamping
+        # Device type constructors emitted bare in generated code — keep these
+        # in scope. Runtime plumbing (stamp!, MNAContext, get_node!, ZERO_VECTOR,
+        # pwl_at_time, get_current_idx, reset_for_restamping!) is emitted as
+        # fully-qualified `Cadnip.MNA.foo(...)` and needs no using-statement.
         using Cadnip.MNA: Resistor, Capacitor, Inductor, VoltageSource, CurrentSource
         using Cadnip.MNA: VCVS, VCCS, CCVS, CCCS  # Controlled sources
-        using Cadnip.MNA: MNAContext, MNASpec, DirectStampContext, get_node!, stamp!, reset_for_restamping!, ZERO_VECTOR
-        using Cadnip.MNA: get_current_idx  # For CCVS/CCCS current sensing
-        using Cadnip.MNA: pwl_at_time  # For PWL transient functions
         using Cadnip: ParamLens, IdentityLens, StaticArrays
         using Cadnip.SpectreEnvironment
 
@@ -3113,7 +3120,7 @@ function make_mna_circuit(ast; circuit_name::Symbol=:circuit, imported_hdl_modul
         # ctx is optional: if provided, it will be reset and reused (zero-allocation path)
         # ctx can be MNAContext (structure discovery) or DirectStampContext (fast restamping)
         function $(circuit_name)(params, spec::$(MNASpec), t::Real=0.0;
-                                 x::AbstractVector=ZERO_VECTOR,
+                                 x::AbstractVector=$(ZERO_VECTOR),
                                  ctx::Union{$(MNAContext), $(DirectStampContext), Nothing}=nothing,
                                  _mna_h_=nothing, _mna_h_p_=nothing)
             # Default prefix for top-level instances (empty = no prefix)
@@ -3164,10 +3171,10 @@ eval(mod_expr)  # Defines the module
 using .typical: nfet_mna_builder, pfet_mna_builder
 ```
 """
-function make_mna_pdk_module(ast; name::Symbol, exports::Vector{Symbol}=Symbol[],
-                             imported_hdl_modules::Vector{Module}=Module[])
+function make_mna_pdk_module(ast; name::Symbol, exports::Vector{Symbol}=Symbol[])
     # Run semantic analysis
-    sema_result = sema(ast; imported_hdl_modules)
+    # Tier 2 scope walk (imported_hdl_modules) is populated by netlist directives only.
+    sema_result = sema(ast)
 
     # Build subckt_semas dictionary for cross-references
     subckt_semas = Dict{Symbol, SemaResult}()
@@ -3289,9 +3296,9 @@ function make_mna_pdk_module(ast; name::Symbol, exports::Vector{Symbol}=Symbol[]
             # Note: baremodule requires explicit imports for functions used in generated code
             :(using Base: !, ===, !==, getfield, hasfield, typeof, Symbol, Float64, NamedTuple, nothing, ifelse),
             :(import Base),  # Needed for explicit Base.X references in generated code
-            # Import MNA context and stamping functions
-            :(using Cadnip.MNA: MNAContext, MNASpec, get_node!, stamp!, alloc_internal_node!, alloc_current!),
-            # Import device types needed for stamping
+            # Device types emitted bare in generated code — keep in scope.
+            # Runtime plumbing (MNAContext/MNASpec/get_node!/stamp!/alloc_*) is
+            # emitted fully-qualified and needs no using-statement.
             :(using Cadnip.MNA: Resistor, Capacitor, Inductor, VoltageSource, CurrentSource),
             :(using Cadnip: ParamLens, IdentityLens, spicecall, ParsedModel),
             :(using Cadnip.SpectreEnvironment),
@@ -3304,41 +3311,33 @@ function make_mna_pdk_module(ast; name::Symbol, exports::Vector{Symbol}=Symbol[]
 end
 
 """
-    load_mna_modules(into::Module, file::String; names=nothing, pdk_include_paths=[], preload=[])
-    load_mna_modules(file::String; names=nothing, ...)  # Returns expression for manual eval
+    precompile_pdk(into::Module, file::String; names=nothing, preload=[])
 
 Parse a PDK SPICE file and generate MNA builder modules.
 
-When `into` module is provided, evaluates modules directly into that module and returns
-a NamedTuple mapping section names to the created modules. This is the preferred usage
-for PDK packages as it enables precompilation.
+**PDK-authoring API** — not intended for end users. PDK packages call this at package
+build time to bake compiled device modules into the package. End users reference the
+resulting PDK content via `jlpkg://MyPDK/...` directives inside their netlist.
 
-When called without `into`, returns a `:toplevel` expression for manual evaluation.
+Evaluates modules directly into `into` and returns a NamedTuple mapping section names
+to the created modules.
 
 # Arguments
 - `into`: Target module to define submodules in (for precompilation)
 - `file`: Path to the PDK SPICE file
 - `names`: Optional list of library section names to include (default: all)
-- `pdk_include_paths`: Paths to search for `.include` files
 - `preload`: Modules to add as `using` statements in generated code
 
 # Example (PDK package usage - enables precompilation)
 ```julia
 module MyPDK
     using Cadnip
-    const corners = Cadnip.load_mna_modules(@__MODULE__, joinpath(@__DIR__, "pdk.spice"))
+    const corners = Cadnip.precompile_pdk(@__MODULE__, joinpath(@__DIR__, "pdk.spice"))
     # corners.typical, corners.fast, corners.slow are now available
 end
 ```
-
-# Example (manual eval)
-```julia
-path = joinpath(@__DIR__, "pdk.spice")
-eval(load_mna_modules(path; names=["typical", "fast"]))
-# Now you can use: typical.nfet_03v3_mna_builder, fast.nfet_03v3_mna_builder, etc.
-```
 """
-function load_mna_modules end  # Forward declaration for docstring
+function precompile_pdk end  # Forward declaration for docstring
 
 """
     collect_lib_statements(node) -> Vector
@@ -3370,7 +3369,7 @@ function collect_lib_statements(node)
 end
 
 # Internal helper to generate module expressions from parsed PDK
-function _generate_mna_module_exprs(sa, names, preload, imported_hdl_modules)
+function _generate_mna_module_exprs(sa, names, preload)
     modules = Pair{Symbol, Expr}[]
 
     # Collect all LibStatements from the parsed tree
@@ -3385,7 +3384,7 @@ function _generate_mna_module_exprs(sa, names, preload, imported_hdl_modules)
 
         # Generate MNA module for this library section
         mod_name = Symbol(lib_name)
-        mod_expr = make_mna_pdk_module(node; name=mod_name, imported_hdl_modules=imported_hdl_modules)
+        mod_expr = make_mna_pdk_module(node; name=mod_name)
 
         # Add preload usings if needed
         if !isempty(preload)
@@ -3409,97 +3408,24 @@ function _generate_mna_module_exprs(sa, names, preload, imported_hdl_modules)
     return modules
 end
 
-# Version that evals into a target module (preferred for precompilation)
-function load_mna_modules(into::Module, file::String; names=nothing,
-                          pdk_include_paths::Vector{String}=String[],
-                          preload::Vector{Module}=Module[],
-                          imported_hdl_modules::Vector{Module}=Module[])
+function precompile_pdk(into::Module, file::String; names=nothing,
+                        preload::Vector{Module}=Module[])
     # Parse the file
     sa = NyanSpectreNetlistParser.parsefile(file; implicit_title=false)
     if sa.ps.errored
         throw(LoadError(file, 0, SpectreParseError(sa)))
     end
 
-    module_exprs = _generate_mna_module_exprs(sa, names, preload, imported_hdl_modules)
+    module_exprs = _generate_mna_module_exprs(sa, names, preload)
 
     # Eval each module into the target module and collect results
     result_modules = Dict{Symbol, Module}()
     for (mod_name, mod_expr) in module_exprs
-        # Eval the module definition in the target module
         Core.eval(into, mod_expr)
-        # Get the created module
         result_modules[mod_name] = getfield(into, mod_name)
     end
 
-    # Return as NamedTuple for convenient access
     return NamedTuple(result_modules)
-end
-
-# Version that returns expression for manual eval (backward compatible)
-function load_mna_modules(file::String; names=nothing, pdk_include_paths::Vector{String}=String[],
-                          preload::Vector{Module}=Module[],
-                          imported_hdl_modules::Vector{Module}=Module[])
-    # Parse the file
-    sa = NyanSpectreNetlistParser.parsefile(file; implicit_title=false)
-    if sa.ps.errored
-        throw(LoadError(file, 0, SpectreParseError(sa)))
-    end
-
-    module_exprs = _generate_mna_module_exprs(sa, names, preload, imported_hdl_modules)
-
-    res = Expr(:toplevel)
-    for (_, mod_expr) in module_exprs
-        push!(res.args, mod_expr)
-    end
-
-    return res
-end
-
-"""
-    load_mna_pdk(into::Module, file::String; section::String, ...)
-    load_mna_pdk(file::String; section::String, ...)
-
-Load a single library section from a PDK file as an MNA module.
-
-When `into` module is provided, evaluates the module directly into that module
-and returns the created module. This is the preferred usage for precompilation.
-
-When called without `into`, returns the module expression for manual evaluation.
-
-# Example (PDK package usage - enables precompilation)
-```julia
-module MyPDK
-    using Cadnip
-    const typical = Cadnip.load_mna_pdk(@__MODULE__, joinpath(@__DIR__, "pdk.spice"); section="typical")
-end
-```
-
-# Example (manual eval)
-```julia
-mod_expr = load_mna_pdk("pdk.spice"; section="typical")
-eval(mod_expr)
-using .typical: nfet_mna_builder
-```
-"""
-function load_mna_pdk(into::Module, file::String; section::String,
-                      pdk_include_paths::Vector{String}=String[],
-                      preload::Vector{Module}=Module[],
-                      imported_hdl_modules::Vector{Module}=Module[])
-    result = load_mna_modules(into, file; names=[section], pdk_include_paths, preload, imported_hdl_modules)
-    if isempty(result)
-        error("Section '$section' not found in $file")
-    end
-    return only(values(result))
-end
-
-function load_mna_pdk(file::String; section::String, pdk_include_paths::Vector{String}=String[],
-                      preload::Vector{Module}=Module[],
-                      imported_hdl_modules::Vector{Module}=Module[])
-    expr = load_mna_modules(file; names=[section], pdk_include_paths, preload, imported_hdl_modules)
-    if isempty(expr.args)
-        error("Section '$section' not found in $file")
-    end
-    return only(expr.args)
 end
 
 #==============================================================================#

--- a/src/spc/codegen.jl
+++ b/src/spc/codegen.jl
@@ -640,6 +640,22 @@ using ..MNA: MNAContext, MNASpec, get_node!, stamp!
 using ..MNA: Resistor, Capacitor, Inductor, VoltageSource, CurrentSource
 using ..MNA: VCVS, VCCS, CCVS, CCCS
 
+"""
+    _scoped_sym_expr(local_name::Symbol) -> Expr
+
+Emit a Julia expression that evaluates, at runtime inside a generated
+builder, to `_mna_prefix_ == Symbol("") ? local_name : Symbol(_mna_prefix_, "_", local_name)`.
+
+Used to prefix subckt-internal node names (in `get_node!` calls), device
+`name=` kwargs (which feed `alloc_current!`), and the callee's `_mna_prefix_`
+when chaining nested subckt calls. Top-level circuits have
+`_mna_prefix_ == Symbol("")` so the bare `local_name` is used — backwards
+compatible.
+"""
+_scoped_sym_expr(local_name::Symbol) =
+    :(_mna_prefix_ == Symbol("") ? $(QuoteNode(local_name)) :
+                                   Symbol(_mna_prefix_, "_", $(QuoteNode(local_name))))
+
 # Helper to get a param value
 function getparam(params, name, default=nothing)
     for p in params
@@ -770,7 +786,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Resistor})
     return quote
         let r_val = $r_expr, m_val = $m_expr
             # Parallel resistors: R_eff = R / m
-            $(MNA).stamp!($(MNA).Resistor(r_val / m_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
+            $(MNA).stamp!($(MNA).Resistor(r_val / m_val; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n)
         end
     end
 end
@@ -799,7 +815,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Capacitor})
     return quote
         let c_val = $c_expr, m_val = $m_expr
             # Parallel capacitors: C_eff = C * m
-            $(MNA).stamp!(Capacitor(c_val * m_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
+            $(MNA).stamp!(Capacitor(c_val * m_val; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n)
         end
     end
 end
@@ -824,7 +840,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Inductor})
 
     return quote
         let l_val = $l_expr
-            $(MNA).stamp!(Inductor(l_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
+            $(MNA).stamp!(Inductor(l_val; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n)
         end
     end
 end
@@ -847,7 +863,7 @@ function cg_mna_instance!(state::CodegenState, ::Val{:mna}, instance::SNode{SP.V
 
     return quote
         let v = $dc_val
-            $(MNA).stamp!(VoltageSource(v; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
+            $(MNA).stamp!(VoltageSource(v; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n, t, spec.mode)
         end
     end
 end
@@ -876,7 +892,7 @@ function cg_mna_instance!(state::CodegenState, ::Val{:mna}, instance::SNode{SP.C
     # Swap nodes: MNA injects into first arg, SPICE injects into neg
     return quote
         let i = $dc_val
-            $(MNA).stamp!(CurrentSource(i; name=$(QuoteNode(Symbol(name)))), ctx, $neg, $pos, t, spec.mode)
+            $(MNA).stamp!(CurrentSource(i; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $neg, $pos, t, spec.mode)
         end
     end
 end
@@ -907,7 +923,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.ControlledSour
 
     return quote
         let gain = $gain_expr
-            $(MNA).stamp!(VCVS(gain; name=$(QuoteNode(Symbol(name)))), ctx, $out_p, $out_n, $in_p, $in_n)
+            $(MNA).stamp!(VCVS(gain; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $out_p, $out_n, $in_p, $in_n)
         end
     end
 end
@@ -938,7 +954,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.ControlledSour
 
     return quote
         let gm = $gm_expr
-            $(MNA).stamp!(VCCS(gm; name=$(QuoteNode(Symbol(name)))), ctx, $out_p, $out_n, $in_p, $in_n)
+            $(MNA).stamp!(VCCS(gm; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $out_p, $out_n, $in_p, $in_n)
         end
     end
 end
@@ -977,7 +993,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.ControlledSour
         let rm = $rm_expr
             # Get the current index of the referenced voltage source
             I_in_idx = $(MNA).get_current_idx(ctx, $(QuoteNode(vname_sym)))
-            $(MNA).stamp!(CCVS(rm; name=$(QuoteNode(Symbol(name)))), ctx, $out_p, $out_n, I_in_idx)
+            $(MNA).stamp!(CCVS(rm; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $out_p, $out_n, I_in_idx)
         end
     end
 end
@@ -1016,7 +1032,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.ControlledSour
         let gain = $gain_expr
             # Get the current index of the referenced voltage source
             I_in_idx = $(MNA).get_current_idx(ctx, $(QuoteNode(vname_sym)))
-            $(MNA).stamp!(CCCS(gain; name=$(QuoteNode(Symbol(name)))), ctx, $out_p, $out_n, I_in_idx)
+            $(MNA).stamp!(CCCS(gain; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $out_p, $out_n, I_in_idx)
         end
     end
 end
@@ -1236,7 +1252,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Behavioral})
             ctrl_n_expr = ctrl_n === :gnd ? 0 : ctrl_n
             return quote
                 let gain = $gain
-                    $(MNA).stamp!(VCVS(gain; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, $ctrl_p, $ctrl_n_expr)
+                    $(MNA).stamp!(VCVS(gain; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n, $ctrl_p, $ctrl_n_expr)
                 end
             end
         else
@@ -1267,7 +1283,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Behavioral})
             # which is opposite to VCCS convention, so swap p and n
             return quote
                 let gm = $gm
-                    $(MNA).stamp!(VCCS(gm; name=$(QuoteNode(Symbol(name)))), ctx, $n, $p, $ctrl_p, $ctrl_n_expr)
+                    $(MNA).stamp!(VCCS(gm; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $n, $p, $ctrl_p, $ctrl_n_expr)
                 end
             end
         else
@@ -1518,11 +1534,14 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.SubcktCall}, s
     # Generate code that:
     # 1. Navigates to subcircuit's portion of the lens via getproperty
     # 2. Calls builder with navigated lens, parent_params as positional arg, and explicit params as kwargs
-    # 3. Passes instance_name as _mna_prefix_ for hierarchical naming
+    # 3. Passes instance_name as _mna_prefix_ for hierarchical naming — chained
+    #    with the caller's own _mna_prefix_ so nested subckts get unique flat
+    #    names like :arma_x1_mid.
     # Note: lens_var is captured from the enclosing scope (var"*lens#" or lens)
+    chained_prefix_expr = _scoped_sym_expr(instance_name)
     return quote
         let subckt_lens = Base.getproperty(var"*lens#", $(QuoteNode(instance_name)))
-            $builder_name(subckt_lens, spec, t, ctx, $(port_exprs...), $parent_params_expr, x, $(QuoteNode(instance_name)); _mna_h_=_mna_h_, _mna_h_p_=_mna_h_p_, $(explicit_kwargs...))
+            $builder_name(subckt_lens, spec, t, ctx, $(port_exprs...), $parent_params_expr, x, $chained_prefix_expr; _mna_h_=_mna_h_, _mna_h_p_=_mna_h_p_, $(explicit_kwargs...))
         end
     end
 end
@@ -1679,6 +1698,11 @@ Supported masters:
 - isource: dc=value, type=pwl/pulse/sine
 """
 function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
+    return cg_mna_instance!(state, instance, Dict{Symbol, SemaResult}())
+end
+
+function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance},
+                          subckt_semas::Dict{Symbol, SemaResult})
     master = lowercase(String(instance.master))
     nets = sema_nets(instance)
     name = LString(instance.name)
@@ -1698,7 +1722,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
 
         return quote
             let r_val = $r_expr, m_val = $m_expr
-                $(MNA).stamp!(Resistor(r_val / m_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
+                $(MNA).stamp!(Resistor(r_val / m_val; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n)
             end
         end
 
@@ -1717,7 +1741,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
 
         return quote
             let c_val = $c_expr, m_val = $m_expr
-                $(MNA).stamp!(Capacitor(c_val * m_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
+                $(MNA).stamp!(Capacitor(c_val * m_val; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n)
             end
         end
 
@@ -1736,7 +1760,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
 
         return quote
             let l_val = $l_expr, m_val = $m_expr
-                $(MNA).stamp!(Inductor(l_val / m_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n)
+                $(MNA).stamp!(Inductor(l_val / m_val; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n)
             end
         end
 
@@ -1760,7 +1784,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
             return quote
                 let wave = $wave_expr
                     ts, ys = wave[1:2:end], wave[2:2:end]
-                    $(MNA).stamp!(VoltageSource(ys[1]; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
+                    $(MNA).stamp!(VoltageSource(ys[1]; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(_scoped_sym_expr(Symbol(name)))),
                            ctx, $p, $n, t, spec.mode)
                 end
             end
@@ -1771,14 +1795,14 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
             freq = hasparam(instance.params, "freq") ? cg_expr!(state, getparam(instance.params, "freq")) : 1e3
             return quote
                 let vo = $vo, va = $va, freq = $freq
-                    $(MNA).stamp!(VoltageSource(vo; tran=_t -> vo + va * sin(2π * freq * _t), name=$(QuoteNode(Symbol(name)))),
+                    $(MNA).stamp!(VoltageSource(vo; tran=_t -> vo + va * sin(2π * freq * _t), name=$(_scoped_sym_expr(Symbol(name)))),
                            ctx, $p, $n, t, spec.mode)
                 end
             end
         else
             # DC source - still use time/mode for consistency (DC sources return dc in all modes)
             return quote
-                $(MNA).stamp!(VoltageSource($dc_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
+                $(MNA).stamp!(VoltageSource($dc_val; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n, t, spec.mode)
             end
         end
 
@@ -1804,14 +1828,14 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
             return quote
                 let wave = $wave_expr
                     ts, ys = wave[1:2:end], wave[2:2:end]
-                    $(MNA).stamp!(CurrentSource(ys[1]; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
+                    $(MNA).stamp!(CurrentSource(ys[1]; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(_scoped_sym_expr(Symbol(name)))),
                            ctx, $p, $n, t, spec.mode)
                 end
             end
         else
             # DC source - still use time/mode for consistency
             return quote
-                $(MNA).stamp!(CurrentSource($dc_val; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
+                $(MNA).stamp!(CurrentSource($dc_val; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n, t, spec.mode)
             end
         end
 
@@ -1826,7 +1850,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
         gain = hasparam(instance.params, "gain") ? cg_expr!(state, getparam(instance.params, "gain")) : 1.0
 
         return quote
-            $(MNA).stamp!(VCVS($gain; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, $cp, $cn)
+            $(MNA).stamp!(VCVS($gain; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n, $cp, $cn)
         end
 
     elseif master == "vccs"
@@ -1840,7 +1864,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
         gm = hasparam(instance.params, "gm") ? cg_expr!(state, getparam(instance.params, "gm")) : 1.0
 
         return quote
-            $(MNA).stamp!(VCCS($gm; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, $cp, $cn)
+            $(MNA).stamp!(VCCS($gm; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n, $cp, $cn)
         end
 
     else
@@ -1911,8 +1935,11 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
                     end
                 end
             end
-        elseif haskey(state.sema.subckts, master_sym)
-            # User-defined subcircuit - generate call to subcircuit builder
+        elseif haskey(state.sema.subckts, master_sym) || haskey(subckt_semas, master_sym)
+            # User-defined subcircuit - generate call to subcircuit builder.
+            # The subckt may be defined in a parent scope (passed in
+            # `subckt_semas` when this instance lives inside a subckt body)
+            # or in the current sema's own subckts table (top-level).
             instance_name = Symbol(LString(instance.name))
             builder_name = Symbol(master_sym, "_mna_builder")
 
@@ -1927,12 +1954,28 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
                 push!(explicit_kwargs, Expr(:kw, param_name, param_val))
             end
 
-            # Build parent_params NamedTuple with exposed parameters from caller's scope
-            ssema = resolve_subckt(state.sema, master_sym)
-            all_exposed = collect_exposed_parameters_recursively(state.sema, ssema)
+            # Resolve callee sema: local first, then parent-scope dict.
+            ssema = haskey(state.sema.subckts, master_sym) ?
+                resolve_subckt(state.sema, master_sym) :
+                subckt_semas[master_sym]
+
+            # Build parent_params NamedTuple with exposed parameters from caller's scope.
+            # Use the dict-based transitive collector when available, otherwise
+            # fall back to the local-sema one.
+            all_exposed = if !isempty(subckt_semas)
+                collect_exposed_parameters_from_dict(subckt_semas, ssema)
+            else
+                collect_exposed_parameters_recursively(state.sema, ssema)
+            end
+            locally_defined = Set{Symbol}(keys(state.sema.params))
             parent_param_pairs = Expr[]
             for name in all_exposed
-                push!(parent_param_pairs, Expr(:(=), name, cg_expr!(state, name)))
+                if isempty(subckt_semas) || name in locally_defined
+                    push!(parent_param_pairs, Expr(:(=), name, cg_expr!(state, name)))
+                else
+                    # Forward from caller's parent_params when we're inside a subckt.
+                    push!(parent_param_pairs, Expr(:(=), name, :(parent_params.$name)))
+                end
             end
             parent_params_expr = if isempty(parent_param_pairs)
                 :((;))
@@ -1940,11 +1983,16 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance})
                 Expr(:tuple, Expr(:parameters, parent_param_pairs...))
             end
 
-            # Generate subcircuit call similar to SPICE SubcktCall
-            # Pass instance_name as _mna_prefix_ for hierarchical naming
+            # Chain `_mna_prefix_` with this instance's name so nested subckt
+            # internals get uniquely scoped flat names (:outer_inner_mid etc).
+            # Pick the lens variable name based on is_subcircuit context: when
+            # codegen runs inside a subckt body, `lens` is the parameter;
+            # at top level, `var"*lens#"` is the gensym'd lens variable.
+            chained_prefix_expr = _scoped_sym_expr(instance_name)
+            lens_var = isempty(subckt_semas) ? Symbol("*lens#") : :lens
             return quote
-                let subckt_lens = Base.getproperty(var"*lens#", $(QuoteNode(instance_name)))
-                    $builder_name(subckt_lens, spec, t, ctx, $(port_exprs...), $parent_params_expr, x, $(QuoteNode(instance_name)); _mna_h_=_mna_h_, _mna_h_p_=_mna_h_p_, $(explicit_kwargs...))
+                let subckt_lens = Base.getproperty($lens_var, $(QuoteNode(instance_name)))
+                    $builder_name(subckt_lens, spec, t, ctx, $(port_exprs...), $parent_params_expr, x, $chained_prefix_expr; _mna_h_=_mna_h_, _mna_h_p_=_mna_h_p_, $(explicit_kwargs...))
                 end
             end
         else
@@ -2277,7 +2325,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                         let ts = $(StaticArrays).SVector{$n_points,Float64}($(times_exprs...)),
                             ys = $(StaticArrays).SVector{$n_points,Float64}($(values_exprs...)),
                             dc = $dc_value
-                            $(MNA).stamp!(VoltageSource(dc; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(VoltageSource(dc; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(_scoped_sym_expr(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2286,7 +2334,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                         let ts = $(StaticArrays).SVector{$n_points,Float64}($(times_exprs...)),
                             ys = $(StaticArrays).SVector{$n_points,Float64}($(values_exprs...)),
                             dc = $dc_value
-                            $(MNA).stamp!(CurrentSource(dc; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(CurrentSource(dc; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(_scoped_sym_expr(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2301,7 +2349,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                             times = vals[1:2:end]
                             values = vals[2:2:end]
                             dc = $dc_expr
-                            $(MNA).stamp!(VoltageSource(dc; tran=_t -> $(MNA).pwl_at_time(times, values, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(VoltageSource(dc; tran=_t -> $(MNA).pwl_at_time(times, values, _t), name=$(_scoped_sym_expr(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2311,7 +2359,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                             times = vals[1:2:end]
                             values = vals[2:2:end]
                             dc = $dc_expr
-                            $(MNA).stamp!(CurrentSource(dc; tran=_t -> $(MNA).pwl_at_time(times, values, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(CurrentSource(dc; tran=_t -> $(MNA).pwl_at_time(times, values, _t), name=$(_scoped_sym_expr(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2348,7 +2396,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                                 vo + va * exp(-theta * (_t - td)) * sind(360 * freq * (_t - td) + phase)
                             end
                         end
-                        $(MNA).stamp!(VoltageSource(dc; tran=tran_fn, name=$(QuoteNode(Symbol(name)))),
+                        $(MNA).stamp!(VoltageSource(dc; tran=tran_fn, name=$(_scoped_sym_expr(Symbol(name)))),
                                ctx, $p, $n, t, spec.mode)
                     end
                 end
@@ -2363,7 +2411,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                                 io + ia * exp(-theta * (_t - td)) * sind(360 * freq * (_t - td) + phase)
                             end
                         end
-                        $(MNA).stamp!(CurrentSource(dc; tran=tran_fn, name=$(QuoteNode(Symbol(name)))),
+                        $(MNA).stamp!(CurrentSource(dc; tran=tran_fn, name=$(_scoped_sym_expr(Symbol(name)))),
                                ctx, $p, $n, t, spec.mode)
                     end
                 end
@@ -2403,7 +2451,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                         let ts = $(StaticArrays).SVector{6,Float64}($t0, $t1, $t2, $t3, $t4, $t5),
                             ys = $(StaticArrays).SVector{6,Float64}($v_1, $v_2, $v_3, $v_4, $v_5, $v_6),
                             dc = $dc_value
-                            $(MNA).stamp!(VoltageSource(dc; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(VoltageSource(dc; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(_scoped_sym_expr(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2412,7 +2460,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                         let ts = $(StaticArrays).SVector{6,Float64}($t0, $t1, $t2, $t3, $t4, $t5),
                             ys = $(StaticArrays).SVector{6,Float64}($v_1, $v_2, $v_3, $v_4, $v_5, $v_6),
                             dc = $dc_value
-                            $(MNA).stamp!(CurrentSource(dc; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(CurrentSource(dc; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(_scoped_sym_expr(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2427,7 +2475,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                             tr = $tr_expr, tf = $tf_expr, pw = $pw_expr, per = $per_expr, dc = $dc_expr
                             times = [0.0, td, td+tr, td+tr+pw, td+tr+pw+tf, per]
                             values = [v1, v1, v2, v2, v1, v1]
-                            $(MNA).stamp!(VoltageSource(dc; tran=_t -> $(MNA).pwl_at_time(times, values, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(VoltageSource(dc; tran=_t -> $(MNA).pwl_at_time(times, values, _t), name=$(_scoped_sym_expr(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2437,7 +2485,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
                             tr = $tr_expr, tf = $tf_expr, pw = $pw_expr, per = $per_expr, dc = $dc_expr
                             times = [0.0, td, td+tr, td+tr+pw, td+tr+pw+tf, per]
                             values = [i1, i1, i2, i2, i1, i1]
-                            $(MNA).stamp!(CurrentSource(dc; tran=_t -> $(MNA).pwl_at_time(times, values, _t), name=$(QuoteNode(Symbol(name)))),
+                            $(MNA).stamp!(CurrentSource(dc; tran=_t -> $(MNA).pwl_at_time(times, values, _t), name=$(_scoped_sym_expr(Symbol(name)))),
                                    ctx, $p, $n, t, spec.mode)
                         end
                     end
@@ -2450,11 +2498,11 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
             dc_val_actual = dc_val !== nothing ? dc_val : 0.0
             if is_voltage
                 return quote
-                    $(MNA).stamp!(VoltageSource($dc_val_actual; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
+                    $(MNA).stamp!(VoltageSource($dc_val_actual; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n, t, spec.mode)
                 end
             else
                 return quote
-                    $(MNA).stamp!(CurrentSource($dc_val_actual; name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
+                    $(MNA).stamp!(CurrentSource($dc_val_actual; name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n, t, spec.mode)
                 end
             end
         end
@@ -2465,13 +2513,13 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
     if is_voltage
         return quote
             let v = $dc_val_actual, ac = $ac_expr
-                $(MNA).stamp!(VoltageSource(v; ac=ac, name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
+                $(MNA).stamp!(VoltageSource(v; ac=ac, name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n, t, spec.mode)
             end
         end
     else
         return quote
             let i = $dc_val_actual, ac = $ac_expr
-                $(MNA).stamp!(CurrentSource(i; ac=ac, name=$(QuoteNode(Symbol(name)))), ctx, $p, $n, t, spec.mode)
+                $(MNA).stamp!(CurrentSource(i; ac=ac, name=$(_scoped_sym_expr(Symbol(name)))), ctx, $p, $n, t, spec.mode)
             end
         end
     end
@@ -2616,7 +2664,9 @@ function codegen_mna!(state::CodegenState; skip_nets::Vector{Symbol}=Symbol[], i
         end
     end
 
-    # Codegen nets - get_node! for each net (except ports passed as arguments)
+    # Codegen nets - get_node! for each net (except ports passed as arguments).
+    # Internal nets are name-scoped by the caller's `_mna_prefix_` so each
+    # subckt instance allocates distinct nodes in the flat MNAContext map.
     for (net, _) in state.sema.nets
         net_name = cg_net_name!(state, net)
         # Skip nets that are subcircuit ports - they're passed as function args
@@ -2627,7 +2677,7 @@ function codegen_mna!(state::CodegenState; skip_nets::Vector{Symbol}=Symbol[], i
         if net_name === Symbol("0")
             push!(block.args, :($net_name = 0))
         else
-            push!(block.args, :($net_name = $(MNA).get_node!(ctx, $(QuoteNode(net_name)))))
+            push!(block.args, :($net_name = $(MNA).get_node!(ctx, $(_scoped_sym_expr(net_name)))))
         end
     end
 
@@ -2809,10 +2859,14 @@ function codegen_mna!(state::CodegenState; skip_nets::Vector{Symbol}=Symbol[], i
     end
 
     # Codegen device instances using MNA stamps
-    # For SubcktCall, we need to use the appropriate function based on context
+    # For SubcktCall (SPICE) and Instance (Spectre) calls to user-defined
+    # subckts, when inside a subckt body pass subckt_semas through so the
+    # callee can be resolved from a parent scope.
     function codegen_instance(inst)
         if inst isa SNode{SP.SubcktCall} && is_subcircuit
             cg_mna_instance_subcircuit!(state, inst, Dict{Symbol, Symbol}(), subckt_semas)
+        elseif inst isa SNode{SC.Instance} && is_subcircuit
+            cg_mna_instance!(state, inst, subckt_semas)
         else
             cg_mna_instance!(state, inst)
         end

--- a/src/spc/interface.jl
+++ b/src/spc/interface.jl
@@ -173,88 +173,19 @@ function codegen_hdl_imports!(mod::Module, hdl_imports)
     end
 end
 
-# MNA-based parsing: returns MNA builder function instead of DAECompiler code
-"""
-    parse_spice_to_mna(spice_code::String; circuit_name=:circuit)
-
-Parse SPICE code and return an MNA builder function.
-
-The returned function has signature:
-    function circuit_name(params, spec::MNASpec) -> MNAContext
-
-# Example
-```julia
-code = \"\"\"
-V1 vcc 0 5
-R1 vcc out 1k
-R2 out 0 1k
-\"\"\"
-build_fn = parse_spice_to_mna(code)
-ctx = build_fn((;), MNASpec())
-sol = MNA.solve_dc(ctx)
-voltage(sol, :out)  # Returns 2.5
-```
-"""
-function parse_spice_to_mna(spice_code::String; circuit_name::Symbol=:circuit,
-                            imported_hdl_modules::Vector{Module}=Module[])
-    ast = NyanSpectreNetlistParser.parse(IOBuffer(spice_code); start_lang=:spice, implicit_title=true)
-    return make_mna_circuit(ast; circuit_name, imported_hdl_modules)
-end
-
-"""
-    parse_spice_file_to_mna(filepath::AbstractString; circuit_name=:circuit, imported_hdl_modules=Module[])
-
-Parse a SPICE netlist file and generate an MNA builder function.
-This variant preserves the file path context for resolving relative includes.
-
-# Example
-```julia
-circuit_code = parse_spice_file_to_mna("circuit.sp"; circuit_name=:my_circuit)
-eval(circuit_code)
-```
-"""
-function parse_spice_file_to_mna(filepath::AbstractString; circuit_name::Symbol=:circuit,
-                                  imported_hdl_modules::Vector{Module}=Module[])
-    ast = NyanSpectreNetlistParser.parsefile(filepath; start_lang=:spice, implicit_title=true)
-    return make_mna_circuit(ast; circuit_name, imported_hdl_modules)
-end
-
-"""
-    solve_spice_mna(spice_code::String; temp=27.0)
-
-Parse SPICE code, build MNA circuit, and solve DC operating point.
-Returns (MNAData, DCSolution).
-
-# Example
-```julia
-code = \"\"\"
-V1 vcc 0 5
-R1 vcc out 1k
-R2 out 0 1k
-\"\"\"
-sys, sol = solve_spice_mna(code)
-voltage(sol, :out)  # Returns 2.5
-```
-"""
-function solve_spice_mna(spice_code::String; temp::Real=27.0)
-    ast = NyanSpectreNetlistParser.parse(IOBuffer(spice_code); start_lang=:spice, implicit_title=true)
-    code = make_mna_circuit(ast)
-    # We need to evaluate the code in a temporary module
-    m = Module()
-    Base.eval(m, :(using Cadnip.MNA))
-    Base.eval(m, :(using Cadnip: ParamLens))
-    Base.eval(m, :(using Cadnip.SpectreEnvironment))
-    circuit_fn = Base.eval(m, code)
-
-    spec = MNA.MNASpec(temp=Float64(temp), mode=:dcop)
-    ctx = Base.invokelatest(circuit_fn, (;), spec)
-    sol = MNA.solve_dc(ctx)
-
-    # Also return assembled system for inspection
-    ctx2 = Base.invokelatest(circuit_fn, (;), spec)
-    sys = MNA.assemble!(ctx2)
-
-    return sys, sol
+#==============================================================================#
+# Internal helper: eval a builder expression into a module
+#
+# Shared by Base.include(mod, SpiceFile/SpectreFile), MNACircuit(path), and
+# MNACircuit(code; lang). Returns the builder function bare (no invokelatest
+# wrapper) — MNACircuit{F,...} specializes on F, and dc!/tran!/ac! cross the
+# function-barrier boundary in the current world. See docs on Invokelatest policy.
+#==============================================================================#
+function _eval_builder_into_module(mod::Module, code::Expr, circuit_name::Symbol)
+    # After codegen hygiene pass, `mod` does not need any Cadnip `using` statements —
+    # generated code emits fully-qualified references.
+    Base.eval(mod, code)
+    return getfield(mod, circuit_name)
 end
 
 """
@@ -280,7 +211,7 @@ R2 out 0 1k
 \"\"\"
 ctx = circuit((;), MNASpec())
 sol = solve_dc(ctx)
-voltage(sol, :out)  # Returns 2.5
+sol[:out]  # Returns 2.5
 
 # Inline mode (i flag) - no title line needed
 circuit2 = sp\"\"\"
@@ -305,4 +236,205 @@ macro sp_str(str, flag="")
         $code
         $circuit_name
     end)
+end
+
+"""
+    spc"..."
+
+Parse Spectre code and generate an MNA builder function. Symmetric with `sp"..."`.
+
+# Example
+```julia
+circuit = spc\"\"\"
+v1 (vcc 0) vsource type=dc dc=5
+r1 (vcc out) resistor r=1k
+r2 (out 0) resistor r=1k
+\"\"\"
+sol = dc!(MNACircuit(circuit))
+```
+"""
+macro spc_str(str, flag="")
+    enable_julia_escape = 'e' in flag
+    sa = NyanSpectreNetlistParser.parse(IOBuffer(str); start_lang=:spectre, enable_julia_escape,
+        fname=String(__source__.file), srcline=__source__.line)
+
+    circuit_name = gensym(:circuit)
+    code = make_mna_circuit(sa; circuit_name)
+
+    return esc(quote
+        $code
+        $circuit_name
+    end)
+end
+
+#==============================================================================#
+# SpiceFile / SpectreFile + Base.include — file-first loading API
+#
+# Mirrors the existing VAFile pattern (src/vasim.jl:3431). Preserves file path
+# for relative .hdl / .include resolution.
+#==============================================================================#
+
+"""
+    SpiceFile(path; name=<stem>)
+
+File-loading wrapper for SPICE netlists. Used with `Base.include(mod, SpiceFile(path))`
+to define a builder function named `name` in `mod`.
+
+Default `name` is the filename stem (e.g. `SpiceFile("amp.sp").name === :amp`).
+
+See also: `SpectreFile`, `MNACircuit(path)`.
+"""
+struct SpiceFile
+    path::String
+    name::Symbol
+end
+SpiceFile(path::AbstractString; name=Symbol(first(splitext(basename(String(path)))))) =
+    SpiceFile(String(path), Symbol(name))
+
+"""
+    SpectreFile(path; name=<stem>)
+
+File-loading wrapper for Spectre netlists. Symmetric with `SpiceFile`.
+"""
+struct SpectreFile
+    path::String
+    name::Symbol
+end
+SpectreFile(path::AbstractString; name=Symbol(first(splitext(basename(String(path)))))) =
+    SpectreFile(String(path), Symbol(name))
+
+export SpiceFile, SpectreFile
+
+function _parse_netlist_file(path::String, lang::Symbol)
+    if lang === :spice
+        sa = NyanSpectreNetlistParser.parsefile(path; start_lang=:spice, implicit_title=true)
+    elseif lang === :spectre
+        sa = NyanSpectreNetlistParser.parsefile(path; start_lang=:spectre)
+    else
+        error("Unknown netlist language: $lang (expected :spice or :spectre)")
+    end
+    if sa.ps.errored
+        throw(LoadError(path, 0, SpectreParseError(sa)))
+    end
+    return sa
+end
+
+function _parse_netlist_string(code::AbstractString, lang::Symbol; source_dir=nothing)
+    fname = source_dir === nothing ? "<string>" : joinpath(source_dir, "<string>")
+    if lang === :spice
+        sa = NyanSpectreNetlistParser.parse(IOBuffer(code); start_lang=:spice,
+            implicit_title=true, fname=String(fname))
+    elseif lang === :spectre
+        sa = NyanSpectreNetlistParser.parse(IOBuffer(code); start_lang=:spectre,
+            fname=String(fname))
+    else
+        error("Unknown netlist language: $lang (expected :spice or :spectre)")
+    end
+    if sa.ps.errored
+        throw(LoadError(fname, 0, SpectreParseError(sa)))
+    end
+    return sa
+end
+
+function Base.include(mod::Module, f::SpiceFile)
+    sa = _parse_netlist_file(f.path, :spice)
+    code = make_mna_circuit(sa; circuit_name=f.name)
+    Base.eval(mod, code)
+    return nothing
+end
+
+function Base.include(mod::Module, f::SpectreFile)
+    sa = _parse_netlist_file(f.path, :spectre)
+    code = make_mna_circuit(sa; circuit_name=f.name)
+    Base.eval(mod, code)
+    return nothing
+end
+
+"""
+    infer_lang_from_ext(path) -> Symbol
+
+Infer netlist language from file extension. `.scs` → `:spectre`, else `:spice`.
+"""
+function infer_lang_from_ext(path::AbstractString)
+    _, ext = splitext(String(path))
+    return lowercase(ext) == ".scs" ? :spectre : :spice
+end
+
+#==============================================================================#
+# MNACircuit(path) and MNACircuit(code; lang) — file-first entry points
+#
+# One AbstractString method: if the argument names an existing file, treat it as
+# a path (extension-inferred language); otherwise treat it as inline netlist code
+# (language defaults to :spice, override with lang=).
+#==============================================================================#
+
+"""
+    MNACircuit(path_or_code::AbstractString; lang=nothing, source_dir=nothing,
+               name=<stem>, kwargs...) -> MNACircuit
+
+If `path_or_code` names an existing file, loads the netlist from disk and infers
+language from the extension (`.scs` → Spectre, else SPICE). Otherwise treats the
+string as an inline netlist (default `:spice`, override with `lang=`).
+
+`source_dir` is used to resolve relative `.hdl` / `.include` paths for inline
+netlists; absent, relative paths fail.
+
+!!! note "Top-level use only"
+    This constructor calls `Base.eval` internally to install the generated
+    builder. Julia captures the caller's world age at function entry, so when
+    called *inside a function body* the subsequent `dc!`/`tran!`/`ac!` will
+    error with _"method too new"_. Use this form at the REPL or module top
+    level.
+
+    For loads inside a function body, bring the circuit into scope at top
+    level first:
+    ```julia
+    Base.include(@__MODULE__, SpiceFile("amp.sp"))  # top level — defines `amp`
+
+    function run_sim()
+        c = MNACircuit(amp; R1=1e3)                 # no eval, no world-age
+        dc!(c)
+    end
+    ```
+
+```julia
+# Top level:
+circuit = MNACircuit("amp.sp")              # file
+circuit = MNACircuit("V1 vcc 0 5\\nR1 vcc 0 1k"; lang=:spice)  # inline
+sol = dc!(circuit)
+```
+"""
+function MNA.MNACircuit(path_or_code::AbstractString;
+                        lang::Union{Symbol,Nothing}=nothing,
+                        source_dir=nothing,
+                        name::Union{Symbol,Nothing}=nothing,
+                        spec::MNA.MNASpec=MNA.MNASpec(), kwargs...)
+    is_file = lang === nothing && source_dir === nothing && isfile(path_or_code)
+    if is_file
+        path = String(path_or_code)
+        eff_lang = infer_lang_from_ext(path)
+        eff_name = name === nothing ?
+            Symbol(first(splitext(basename(path)))) : name
+        mod = Module(gensym(eff_name))
+        if eff_lang === :spice
+            Base.include(mod, SpiceFile(path; name=eff_name))
+        else
+            Base.include(mod, SpectreFile(path; name=eff_name))
+        end
+        builder = getfield(mod, eff_name)
+    else
+        eff_lang = something(lang, :spice)
+        sa = _parse_netlist_string(path_or_code, eff_lang; source_dir=source_dir)
+        eff_name = name === nothing ? gensym(:circuit) : name
+        builder_code = make_mna_circuit(sa; circuit_name=eff_name)
+        mod = Module(gensym(:netlist))
+        Base.eval(mod, builder_code)
+        builder = getfield(mod, eff_name)
+    end
+    # Return the bare builder. This constructor is documented as top-level-only;
+    # the call to `Base.eval` has advanced the world so a following top-level
+    # `dc!(circuit)` sees the fresh methods. Inside a function body it errors,
+    # which is a clear signal to move the load to top level.
+    params = NamedTuple(kwargs)
+    return MNA.MNACircuit(builder, params, spec)
 end

--- a/src/spc/sema.jl
+++ b/src/spc/sema.jl
@@ -281,39 +281,34 @@ end
 
 Select the appropriate model type for a SPICE device declaration.
 
-Uses the ModelRegistry dispatch system to find registered models. Falls back to
-searching imported HDL modules (Verilog-A `.hdl` includes) if no registered model
-is found.
+Resolution order (two-tier model):
+1. **Tier 2 (scope walk)** — netlist-included modules (via `.hdl`, `.include`, `.lib`,
+   `jlpkg://`). Most-recent include wins. Used for PDK-specific and custom devices.
+2. **Tier 1 (registry)** — `ModelRegistry.getmodel` fallback. Used for SPICE-standard
+   builtins (R, C, L, D, level-dispatched MOSFETs/BJTs) populated by method addition
+   from Cadnip + stdlib packages (VADistillerModels, BSIM4, PSPModels).
 
 Returns a GlobalRef to the model type, or GlobalRef(Cadnip, :UnimplementedDevice)
 if no suitable model is found.
-
-Note: For VA models to be resolved, they must either:
-1. Be registered with Cadnip.ModelRegistry (preferred for standard device types)
-2. Be included via `.hdl` directive in the SPICE netlist
 """
 function spice_select_device(sema::SemaResult, devkind::Symbol, level, version, stmt; dialect=:ngspice)
-    # Convert version to string for registry lookup
-    version_str = version === nothing ? nothing : string(Int(version))
-    level_int = level === nothing ? nothing : Int(level)
-
-    # Try the model registry first (preferred path)
-    model_type = Cadnip.getmodel(devkind, level_int, version_str)
-
-    if model_type !== nothing
-        # Found in registry - convert type to GlobalRef
-        return GlobalRef(parentmodule(model_type), nameof(model_type))
-    end
-
-    # Search for this model in HDL modules included via .hdl directive
+    # Tier 2: scope walk. Most-recent include wins — reverse iteration.
     # SPICE is case-insensitive, so try both exact match and uppercase
     devkind_upper = Symbol(uppercase(String(devkind)))
-    for hdl_mod in sema.imported_hdl_modules
+    for hdl_mod in Iterators.reverse(sema.imported_hdl_modules)
         if isdefined(hdl_mod, devkind)
             return GlobalRef(hdl_mod, devkind)
         elseif isdefined(hdl_mod, devkind_upper)
             return GlobalRef(hdl_mod, devkind_upper)
         end
+    end
+
+    # Tier 1: registry fallback.
+    version_str = version === nothing ? nothing : string(Int(version))
+    level_int = level === nothing ? nothing : Int(level)
+    model_type = Cadnip.getmodel(devkind, level_int, version_str)
+    if model_type !== nothing
+        return GlobalRef(parentmodule(model_type), nameof(model_type))
     end
 
     # No model found - warn and return UnimplementedDevice
@@ -606,6 +601,10 @@ function sema_file_or_section(n::SNode; imps=nothing, parse_cache=nothing, impor
     scope
 end
 
+# `imported_hdl_modules` is INTERNAL. Public callers should use netlist directives
+# (.hdl, .include, .lib, jlpkg://) to populate the Tier-2 scope walk list. The
+# kwarg is retained for test-infrastructure use only — do not add it to new
+# public APIs.
 function sema(n::SNode; imps = nothing, parse_cache=nothing, imported_hdl_modules::Vector{Module}=Module[])
     scope = SemaResult(n)
     if imps !== nothing

--- a/src/sweeps.jl
+++ b/src/sweeps.jl
@@ -430,7 +430,7 @@ Returns a `DCSolution` with voltage/current accessors.
 ```julia
 circuit = MNACircuit(build_divider, (R1=1k, R2=1k), MNASpec())
 sol = dc!(circuit)
-voltage(sol, :out)  # Voltage at output node
+sol[:out]  # Voltage at output node
 ```
 """
 function dc!(circuit::MNA.MNACircuit)
@@ -441,13 +441,61 @@ function dc!(circuit::MNA.MNACircuit)
 end
 
 """
-    dc!(cs::CircuitSweep)
+    SweepResult{P,S}
 
-DC operating point analysis for a circuit sweep.
-Returns a vector of `DCSolution` objects.
+Result of running `dc!` or `tran!` over a `CircuitSweep`. Carries parameter tuples
+and corresponding solutions, aligned by index. Iterates as `(params, sol)` pairs.
+
+```julia
+cs = CircuitSweep(builder, ProductSweep(R=1:3:10))
+result = dc!(cs)
+for (p, sol) in result
+    @show p.R, sol[:vout]
+end
+result.points[1]      # first parameter set
+result.solutions[1]   # corresponding solution
+```
+
+Chosen over SciML's `EnsembleSolution`: that type doesn't carry per-trajectory
+parameter metadata and its plot recipes assume time-series inners, which breaks
+for DC.
+"""
+struct SweepResult{P,S}
+    points::Vector{P}
+    solutions::Vector{S}
+end
+
+Base.length(r::SweepResult) = length(r.solutions)
+Base.size(r::SweepResult) = (length(r),)
+Base.iterate(r::SweepResult, state=1) = state > length(r) ? nothing :
+    ((r.points[state], r.solutions[state]), state + 1)
+Base.getindex(r::SweepResult, i::Integer) = (r.points[i], r.solutions[i])
+Base.eltype(::Type{SweepResult{P,S}}) where {P,S} = Tuple{P,S}
+
+export SweepResult
+
+"""
+    dc!(cs::CircuitSweep) -> SweepResult
+
+DC operating point analysis over a circuit sweep. Returns a `SweepResult` that
+pairs each parameter point with its `DCSolution`.
 """
 function dc!(cs::CircuitSweep; kwargs...)
-    return [dc!(circuit; kwargs...) for circuit in cs]
+    points = Any[]
+    solutions = Any[]
+    state = nothing
+    it_state = iterate(cs.iterator)
+    while it_state !== nothing
+        params_nt, next_state = it_state
+        circuit = MNA.alter(cs.circuit; params_nt...)
+        sol = dc!(circuit; kwargs...)
+        push!(points, NamedTuple(params_nt))
+        push!(solutions, sol)
+        it_state = iterate(cs.iterator, next_state)
+    end
+    P = isempty(points) ? NamedTuple : typeof(first(points))
+    S = isempty(solutions) ? Any : typeof(first(solutions))
+    return SweepResult{P,S}(Vector{P}(points), Vector{S}(solutions))
 end
 
 #==============================================================================#
@@ -566,7 +614,20 @@ Returns a vector of solution objects.
 - `solver`: Solver algorithm (default: IDA from Sundials.jl)
 """
 function tran!(cs::CircuitSweep, tspan::Tuple{<:Real,<:Real}; kwargs...)
-    return [tran!(circuit, tspan; kwargs...) for circuit in cs]
+    points = Any[]
+    solutions = Any[]
+    it_state = iterate(cs.iterator)
+    while it_state !== nothing
+        params_nt, next_state = it_state
+        circuit = MNA.alter(cs.circuit; params_nt...)
+        sol = tran!(circuit, tspan; kwargs...)
+        push!(points, NamedTuple(params_nt))
+        push!(solutions, sol)
+        it_state = iterate(cs.iterator, next_state)
+    end
+    P = isempty(points) ? NamedTuple : typeof(first(points))
+    S = isempty(solutions) ? Any : typeof(first(solutions))
+    return SweepResult{P,S}(Vector{P}(points), Vector{S}(solutions))
 end
 
 # Base case; a single parameter mapped on certain values:

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -824,8 +824,8 @@ function (to_julia::MNAScope)(stmt::VANode{FunctionCall})
     end
 
     if fname == :ddt
-        # Time derivative - use va_ddt
-        return Expr(:call, :va_ddt, to_julia(stmt.args[1].item))
+        # Time derivative - use va_ddt (fully-qualified to avoid target-module scope pollution)
+        return Expr(:call, GlobalRef(Cadnip.MNA, :va_ddt), to_julia(stmt.args[1].item))
     elseif fname == :absdelay
         # Transport delay - absdelay(expr, tdelay [, maxdelay])
         # Create a delayed scope so V/I calls generate h-based lookups
@@ -913,7 +913,7 @@ function (to_julia::MNAScope)(stmt::VANode{FunctionCall})
             # Use node_order for partial index (duals indexed by port position)
             id_idx = findfirst(==(probe), to_julia.node_order)
             return :(let x = $(to_julia(stmt.args[1].item))
-                isa(x, Dual) ? @inbounds(ForwardDiff.partials(x, $id_idx)) : 0.0
+                isa(x, ForwardDiff.Dual) ? @inbounds(ForwardDiff.partials(x, $id_idx)) : 0.0
             end)
         else
             probe1 = Symbol(item.args[1].item)
@@ -924,8 +924,8 @@ function (to_julia::MNAScope)(stmt::VANode{FunctionCall})
             # This works because V(a,b) = V_a - V_b, so:
             # ∂expr/∂V_a = ∂expr/∂V(a,b) and ∂expr/∂V_b = -∂expr/∂V(a,b)
             return :(let x = $(to_julia(stmt.args[1].item)),
-                        dx1 = isa(x, Dual) ? @inbounds(ForwardDiff.partials(x, $id1_idx)) : 0.0,
-                        dx2 = isa(x, Dual) ? @inbounds(ForwardDiff.partials(x, $id2_idx)) : 0.0
+                        dx1 = isa(x, ForwardDiff.Dual) ? @inbounds(ForwardDiff.partials(x, $id1_idx)) : 0.0,
+                        dx2 = isa(x, ForwardDiff.Dual) ? @inbounds(ForwardDiff.partials(x, $id2_idx)) : 0.0
                 (dx1 - dx2) / 2
             end)
         end
@@ -1858,7 +1858,8 @@ function (to_julia::MNAScope)(stmt::VANode{AnalogSystemTaskEnable})
         elseif fname == Symbol("\$strobe")
             return nothing
         elseif fname == Symbol("\$error")
-            return Expr(:call, :error, args...)
+            # Fully qualified to avoid collision with a user parameter named `error`.
+            return Expr(:call, GlobalRef(Base, :error), args...)
         elseif fname == Symbol("\$discontinuity")
             # Discontinuity markers are no-ops in MNA
             return nothing
@@ -2975,7 +2976,7 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
         # Create JacobianTag dual with identity partials for ddx() support
         partials = Expr(:tuple, [k == i ? 1.0 : 0.0 for k in 1:n_all_nodes]...)
         push!(dual_creation.args,
-            :($node_sym = Dual{Cadnip.MNA.JacobianTag}($(Symbol("V_", i)), $partials...)))
+            :($node_sym = ForwardDiff.Dual{Cadnip.MNA.JacobianTag}($(Symbol("V_", i)), $partials...)))
     end
 
     # Generate branch current extraction for named branches
@@ -3392,13 +3393,18 @@ function make_mna_module(va::VANode; deps::Vector{Symbol}=Symbol[])
 
     Expr(:toplevel, :(baremodule $s
         using Base: AbstractVector, Real, Symbol, Float64, Int, String, isempty, max, zeros, zero, length
-        using Base: hasproperty, getproperty, getfield, error, !==, iszero, abs
+        # Drop `error` — emitted as `Base.error` to avoid collision with user params
+        using Base: hasproperty, getproperty, getfield, !==, iszero, abs
         import Base  # For getproperty override in aliasparam
         import ..Cadnip
         using ..Cadnip.VerilogAEnvironment
-        using ..Cadnip.MNA: va_ddt, va_absdelay_V, stamp_current_contribution!, MNAContext, MNASpec, alloc_internal_node!, alloc_current!, ZERO_VECTOR, va_laplace_nd_dss, va_laplace_zp_dss
-        using ..Cadnip.MNA: AnyMNAContext, get_is_vdep, reset_detection_counter!  # For DirectStampContext support
-        using ForwardDiff: Dual, value, partials
+        # Type-A VA operators (language-level) — keep in scope
+        using ..Cadnip.MNA: va_absdelay_V, va_laplace_nd_dss, va_laplace_zp_dss
+        # Type-B runtime plumbing (va_ddt, MNAContext, MNASpec, alloc_*,
+        # ZERO_VECTOR, AnyMNAContext, get_is_vdep, reset_detection_counter!,
+        # stamp_current_contribution!) is emitted fully-qualified and needs no
+        # using-statement. Dual/value/partials from ForwardDiff likewise
+        # emitted via `ForwardDiff.Dual` / `ForwardDiff.partials` / `ForwardDiff.value`.
         import ForwardDiff
         $(dep_usings...)
         $([:( export $e) for e in all_exports]...)
@@ -3456,160 +3462,78 @@ Base.show(io::IO, vap::VAParseError) = NyanVerilogAParser.VerilogACSTParser.visi
 #==============================================================================#
 
 """
-    load_mna_va_module(into::Module, file::String)
-    load_mna_va_module(file::String)
+    precompile_va(into::Module, file::String)
 
-Load a Verilog-A file and generate MNA device module(s).
+Load a Verilog-A file and generate MNA device module(s) into `into`.
 
-When `into` module is provided, evaluates the module directly into that module
-and returns the created module. This is the preferred usage for device packages
-as it enables precompilation.
+**PDK/device-authoring API** — not intended for end users. Device packages call this
+at package build time to bake compiled device types into the package.
 
-When called without `into`, returns the expression for manual evaluation.
+Auto-detects single vs. multi-module files. For a single-module file, the resulting
+submodule is brought into scope with a top-level `using`. For multi-module files,
+each module is placed in its own submodule.
 
-# Arguments
-- `into`: Target module to define the device module in (for precompilation)
-- `file`: Path to the Verilog-A file
+Returns the created module (single-module case) or a NamedTuple mapping module names
+to the created Julia modules (multi-module case).
 
-# Alternative: VAFile + Base.include
-
-The existing pattern also works and is equivalent:
-```julia
-using RelocatableFolders
-const device_va = @path joinpath(@__DIR__, "device.va")
-Base.include(@__MODULE__, VAFile(device_va))
-```
-
-This is what packages like BSIM4.jl use. The difference is that `load_mna_va_module`
-returns the created module for convenience.
-
-# Example (Device package usage - enables precompilation)
+# Example (device package)
 ```julia
 module BSIM4
     using Cadnip
-    const bsim4_module = Cadnip.load_mna_va_module(@__MODULE__,
+    const bsim4_module = Cadnip.precompile_va(@__MODULE__,
         joinpath(@__DIR__, "bsim4.va"))
     using .bsim4_module: bsim4
     export bsim4
 end
 ```
-
-# Example (manual eval)
-```julia
-expr = Cadnip.load_mna_va_module("bsim4.va")
-eval(expr)
-using .bsim4_module: bsim4
-```
-
-# Generated Module Structure
-
-For a VA file containing `module bsim4(d, g, s, b); ... endmodule`, generates:
-- A submodule named `bsim4_module`
-- Exports the device type `bsim4`
-- Device has `stamp!(dev::bsim4, ctx, d, g, s, b; ...)` method
 """
-function load_mna_va_module end
-
-# Version that evals into target module (preferred for precompilation)
-function load_mna_va_module(into::Module, file::String)
-    # Parse the VA file
+function precompile_va(into::Module, file::String)
     va = NyanVerilogAParser.parsefile(file)
     if va.ps.errored
         throw(LoadError(file, 0, VAParseError(va)))
     end
 
-    # Generate the module expression
-    expr = make_mna_module(va)
+    # Count top-level VerilogModules to decide single vs multi-module
+    va_modules = [stmt for stmt in va.stmts if stmt isa VANode{VerilogModule}]
 
-    # expr is (:toplevel, module_def, using_stmt)
-    # We need to eval both parts
-    @assert expr.head == :toplevel
-    module_def = expr.args[1]
-    using_stmt = expr.args[2]
-
-    # Eval the module definition
-    Core.eval(into, module_def)
-
-    # Also eval the using statement to bring the module into scope
-    Core.eval(into, using_stmt)
-
-    # Get the created module name from the module definition
-    # module_def is :(baremodule modname ... end)
-    mod_name = module_def.args[2]  # The module name symbol
-
-    # Return the created module
-    return getfield(into, mod_name)
-end
-
-# Version that returns expression for manual eval
-function load_mna_va_module(file::String)
-    # Parse the VA file
-    va = NyanVerilogAParser.parsefile(file)
-    if va.ps.errored
-        throw(LoadError(file, 0, VAParseError(va)))
+    if length(va_modules) <= 1
+        # Single-module (or zero): use make_mna_module which produces (:toplevel, baremodule, using)
+        expr = make_mna_module(va)
+        @assert expr.head == :toplevel
+        module_def = expr.args[1]
+        using_stmt = expr.args[2]
+        Core.eval(into, module_def)
+        Core.eval(into, using_stmt)
+        mod_name = module_def.args[2]
+        return getfield(into, mod_name)
     end
 
-    # Return the expression for manual evaluation
-    return make_mna_module(va)
-end
-
-"""
-    load_mna_va_modules(into::Module, file::String)
-
-Load all Verilog-A modules from a file.
-
-Similar to `load_mna_va_module` but handles files with multiple modules,
-returning a NamedTuple mapping module names to the created Julia modules.
-
-# Example
-```julia
-module MyDevices
-    using Cadnip
-    const devices = Cadnip.load_mna_va_modules(@__MODULE__,
-        joinpath(@__DIR__, "devices.va"))
-    # devices.resistor_module, devices.capacitor_module, etc.
-end
-```
-"""
-function load_mna_va_modules(into::Module, file::String)
-    # Parse the VA file
-    va = NyanVerilogAParser.parsefile(file)
-    if va.ps.errored
-        throw(LoadError(file, 0, VAParseError(va)))
-    end
-
-    # Collect all VerilogModule nodes
+    # Multi-module: create one submodule per VA module
     result_modules = Dict{Symbol, Module}()
+    for vamod in va_modules
+        typename = Symbol(vamod.id)
+        mod_name = Symbol(String(vamod.id), "_module")
 
-    for stmt in va.stmts
-        if stmt isa VANode{VerilogModule}
-            vamod = stmt
-            typename = Symbol(vamod.id)
-            mod_name = Symbol(String(vamod.id), "_module")
+        device_expr = make_mna_device(vamod)
 
-            # Generate device expression
-            device_expr = make_mna_device(vamod)
+        module_expr = :(baremodule $mod_name
+            using Base: AbstractVector, Real, Symbol, Float64, Int, String, isempty, max, zeros, zero, length
+            # Drop `error` — emitted as `Base.error` to avoid collision with user params
+            using Base: hasproperty, getproperty, getfield, !==, iszero, abs
+            import Base
+            import ..Cadnip
+            using ..Cadnip.VerilogAEnvironment
+            # Type-A VA operators only; Type-B plumbing is emitted fully-qualified
+            using ..Cadnip.MNA: va_absdelay_V, va_laplace_nd_dss, va_laplace_zp_dss
+            import ForwardDiff
+            export $typename
+            $(device_expr.args...)
+        end)
 
-            # Create module expression
-            module_expr = :(baremodule $mod_name
-                using Base: AbstractVector, Real, Symbol, Float64, Int, String, isempty, max, zeros, zero, length
-                using Base: hasproperty, getproperty, getfield, error, !==, iszero, abs
-                import Base
-                import ..Cadnip
-                using ..Cadnip.VerilogAEnvironment
-                using ..Cadnip.MNA: va_ddt, va_absdelay_V, stamp_current_contribution!, MNAContext, MNASpec, alloc_internal_node!, alloc_current!, ZERO_VECTOR, va_laplace_nd_dss, va_laplace_zp_dss
-                using ForwardDiff: Dual, value, partials
-                import ForwardDiff
-                export $typename
-                $(device_expr.args...)
-            end)
+        Core.eval(into, module_expr)
+        Core.eval(into, :(using .$mod_name))
 
-            # Eval into target module
-            Core.eval(into, module_expr)
-            Core.eval(into, :(using .$mod_name))
-
-            result_modules[mod_name] = getfield(into, mod_name)
-        end
+        result_modules[mod_name] = getfield(into, mod_name)
     end
 
     return NamedTuple(result_modules)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -4,7 +4,7 @@ include("common.jl")
 
 using Cadnip.MNA: MNAContext, MNASpec, get_node!, stamp!, assemble!, solve_dc
 using Cadnip.MNA: Resistor, Capacitor, Inductor, VoltageSource, CurrentSource
-using Cadnip.MNA: voltage, current, make_ode_problem
+using Cadnip.MNA: make_ode_problem
 
 #=
 NOTE: Tests that require DAECompiler are skipped:
@@ -41,8 +41,8 @@ end
     sol = dc!(circuit)
 
     # I = V/R = 5/2 = 2.5A
-    R_v = voltage(sol, :vcc)
-    R_i = -current(sol, :I_v1)  # Voltage source current is negative when sourcing (SPICE is case-insensitive)
+    R_v = sol[:vcc]
+    R_i = -sol[:I_v1]  # Voltage source current is negative when sourcing (SPICE is case-insensitive)
     @test isapprox_deftol(R_v, 5.0)
     @test isapprox_deftol(R_i, 2.5)
 end
@@ -83,7 +83,7 @@ end
     """i)
     sol = dc!(circuit)
 
-    R_v = voltage(sol, :icc)
+    R_v = sol[:icc]
     @test isapprox_deftol(R_v, 10.0)
 end
 
@@ -177,8 +177,8 @@ end
 
     ctx, sol = solve_mna_spectre_code(spectre_code)
     # Voltage divider: 5V * (1k / (1k + 1k)) = 2.5V
-    @test isapprox_deftol(voltage(sol, :out), 2.5)
-    @test isapprox_deftol(voltage(sol, :vcc), 5.0)
+    @test isapprox_deftol(sol[:out], 2.5)
+    @test isapprox_deftol(sol[:vcc], 5.0)
 end
 
 @testset "Spectre current source" begin
@@ -191,7 +191,7 @@ end
 
     ctx, sol = solve_mna_spectre_code(spectre_code)
     # V = I * R = 1mA * 1kΩ = 1V
-    @test isapprox_deftol(voltage(sol, :vcc), 1.0)
+    @test isapprox_deftol(sol[:vcc], 1.0)
 end
 
 # TODO: Full Spectre sources test with PWL and B-source (requires transient simulation)
@@ -249,8 +249,8 @@ end
     """
     ctx, sol = solve_mna_spectre_code(spectre_code)
     # I = V/R = 1V/2kΩ = 0.5mA
-    @test isapprox_deftol(voltage(sol, :vcc), 1.0)
-    @test isapprox_deftol(current(sol, :I_v1), -0.5e-3)
+    @test isapprox_deftol(sol[:vcc], 1.0)
+    @test isapprox_deftol(sol[:I_v1], -0.5e-3)
 end
 
 @testset "Simple SPICE sources" begin
@@ -265,7 +265,7 @@ end
     # Original: @test all(isapprox.(sol[sys.node_1], -1.0))
     # V1 has + at 0, - at 1, so node 1 = -1V
     # Note: SPICE numeric nodes become Symbol("1"), not :node_1
-    @test isapprox_deftol(voltage(sol, Symbol("1")), -1.0)
+    @test isapprox_deftol(sol[Symbol("1")], -1.0)
 end
 
 @testset "Simple SPICE controlled sources" begin
@@ -286,12 +286,12 @@ end
     # V1 makes node 1 = -1V (+ at 0, - at 1)
     # E6: VCVS with gain=2, Vout = 2 * V(0,1) = 2 * 1 = 2V at node 6 relative to 0
     # Since E6 has + at 0 and - at 6, node 6 = -2V
-    @test isapprox_deftol(voltage(sol, Symbol("1")), -1.0)
-    @test isapprox(voltage(sol, Symbol("6")), -2.0; atol=deftol*10)
+    @test isapprox_deftol(sol[Symbol("1")], -1.0)
+    @test isapprox(sol[Symbol("6")], -2.0; atol=deftol*10)
     # G7: VCCS with gm=2, I = 2 * V(0,1) = 2A into node 7
     # With R7=1k to ground: V = I*R = 2*1000 = 2000V (but sign depends on convention)
     # G7 outputs current from 0 to 7, so 2A flows into 7, V7 = -2000V
-    @test isapprox(voltage(sol, Symbol("7")), -2000.0; atol=deftol*10)
+    @test isapprox(sol[Symbol("7")], -2000.0; atol=deftol*10)
 end
 
 @testset "SPICE B-source" begin
@@ -307,7 +307,7 @@ end
     ctx, sol = solve_mna_spice_code(spice_code)
     # V1 makes node 1 = -1V
     # B5: v = V(1)*2 = -1*2 = -2V, but B5 has + at 0, - at 5, so node 5 = 2V
-    @test isapprox(voltage(sol, Symbol("5")), 2.0; atol=deftol*10)
+    @test isapprox(sol[Symbol("5")], 2.0; atol=deftol*10)
 end
 
 @testset "SPICE B-source (nonlinear current)" begin
@@ -336,9 +336,9 @@ end
     sol = Cadnip.MNA.solve_dc(circuit_fn, (;), spec)
 
     # Node 1 should be 1V (the positive solution to V^2 + V - 2 = 0)
-    @test isapprox(voltage(sol, Symbol("1")), 1.0; atol=1e-6)
+    @test isapprox(sol[Symbol("1")], 1.0; atol=1e-6)
     # V_vcc = 2V
-    @test isapprox(voltage(sol, :vcc), 2.0; atol=1e-6)
+    @test isapprox(sol[:vcc], 2.0; atol=1e-6)
 end
 
 # TODO: Alternate E/G forms with vol=/cur= syntax
@@ -359,8 +359,8 @@ end
     ctx, sol = solve_mna_spice_code(spice_code)
     # E8: vol=V(0,1)*2 = 1*2 = 2V, since + at 0, - at 8, node 8 = -2V
     # G9: cur=V(0,1)*2 = 1*2 = 2A into node 9, V = 2*1000 = 2000V
-    @test isapprox(voltage(sol, Symbol("8")), -2.0; atol=deftol*10)
-    @test isapprox(voltage(sol, Symbol("9")), -2000.0; atol=deftol*10)
+    @test isapprox(sol[Symbol("8")], -2.0; atol=deftol*10)
+    @test isapprox(sol[Symbol("9")], -2000.0; atol=deftol*10)
 end
 =#
 
@@ -379,8 +379,8 @@ end
 
     ctx, sol = solve_mna_spice_code(spice_code)
     # Original: @test all(isapprox.(sol[sys.x1.r1.I], 0.5e-3))
-    @test isapprox_deftol(voltage(sol, :vcc), 1.0)
-    @test isapprox_deftol(current(sol, :I_v1), -0.5e-3)  # 1V / 2kΩ
+    @test isapprox_deftol(sol[:vcc], 1.0)
+    @test isapprox_deftol(sol[:I_v1], -0.5e-3)  # 1V / 2kΩ
 end
 
 @testset "SPICE include .LIB" begin
@@ -415,7 +415,7 @@ end
         sol = dc!(circuit)
 
         # I = V / R = 1V / 1337Ω
-        @test isapprox_deftol(current(sol, :I_v1), -1/1337)
+        @test isapprox_deftol(sol[:I_v1], -1/1337)
     end
 end
 
@@ -466,7 +466,7 @@ end
     ctx, sol = solve_mna_spice_code(spice_code)
     # R = l - par_l = 11 - 1 = 10Ω
     # I = V/R = 1/10 = 0.1A
-    @test isapprox_deftol(current(sol, :I_v1), -0.1)
+    @test isapprox_deftol(sol[:I_v1], -0.1)
 end
 
 # TODO: Extended parameter scope tests - nested dynamic scoping
@@ -491,7 +491,7 @@ end
     ctx, sol = solve_mna_spice_code(spice_code)
     # foo=1 at top level, inner sees foo+2000 = 2001
     # V = I * R = 1 * 2001 = 2001V
-    @test isapprox_deftol(voltage(sol, :vcc), -2001.0)
+    @test isapprox_deftol(sol[:vcc], -2001.0)
 end
 =#
 
@@ -507,7 +507,7 @@ end
     """
     ctx, sol = solve_mna_spice_code(spice_code)
     # foo = temper = 10 (from .option temp)
-    @test_broken isapprox_deftol(voltage(sol, :vcc), -10.0)
+    @test_broken isapprox_deftol(sol[:vcc], -10.0)
 end
 
 # Currently errors at sema stage - .temp directive handling calls error()
@@ -523,7 +523,7 @@ end
     """
     ctx, sol = solve_mna_spice_code(spice_code)
     # foo = temper = 10 (from .temp)
-    @test isapprox_deftol(voltage(sol, :vcc), -10.0)
+    @test isapprox_deftol(sol[:vcc], -10.0)
 end
 =#
 
@@ -537,7 +537,7 @@ end
     """
     ctx, sol = solve_mna_spice_code(spice_code)
     # Default temper = 27
-    @test isapprox_deftol(voltage(sol, :vcc), -27.0)
+    @test isapprox_deftol(sol[:vcc], -27.0)
 end
 
 # Currently errors at runtime - instance param referencing other params not scoped correctly
@@ -557,7 +557,7 @@ end
     ctx, sol = solve_mna_spice_code(spice_code)
     # nrd='w/2' where w=4, so nrd=2, R = rsh*nrd = 1*2 = 2
     # I = V/R = 1/2 = 0.5A
-    @test isapprox_deftol(current(sol, :I_v1), -0.5)
+    @test isapprox_deftol(sol[:I_v1], -0.5)
 end
 =#
 
@@ -602,7 +602,7 @@ end
     # With m=10, r1a is effectively 0.1Ω
     # Total R = 0.1 + 1 = 1.1Ω
     # V at node 1 = 1 * (1/1.1) = 0.909V (voltage divider)
-    @test isapprox(voltage(sol, Symbol("1")), 10/11; atol=deftol*10)
+    @test isapprox(sol[Symbol("1")], 10/11; atol=deftol*10)
 end
 
 # TODO: Extended multiplicities tests with subcircuits
@@ -619,7 +619,7 @@ end
     """
     ctx, sol = solve_mna_spice_code(spice_code)
     # Subcircuit with m=10 divides resistance by 10
-    @test_broken isapprox(voltage(sol, Symbol("2")), 10/11; atol=deftol*10)
+    @test_broken isapprox(sol[Symbol("2")], 10/11; atol=deftol*10)
 end
 
 # Currently errors at codegen - nested subcircuits not resolved
@@ -642,7 +642,7 @@ end
     """
     ctx, sol = solve_mna_spice_code(spice_code)
     # Two x5 each with m=5 on r10 (which has m=10)
-    @test isapprox(voltage(sol, Symbol("4")), 10/11; atol=deftol*10)
+    @test isapprox(sol[Symbol("4")], 10/11; atol=deftol*10)
 end
 =#
 
@@ -661,7 +661,7 @@ end
     """
     ctx, sol = solve_mna_spice_code(spice_code)
     # r2 has m=2 internally, x5a has m=5, so effective m=10
-    @test isapprox(voltage(sol, Symbol("5")), 10/11; atol=deftol*10)
+    @test isapprox(sol[Symbol("5")], 10/11; atol=deftol*10)
 end
 =#
 
@@ -675,7 +675,7 @@ end
     r6b 6 0 1
     """
     ctx, sol = solve_mna_spice_code(spice_code)
-    @test isapprox(voltage(sol, Symbol("6")), 10/11; atol=deftol*10)
+    @test isapprox(sol[Symbol("6")], 10/11; atol=deftol*10)
 end
 
 @testset ".model case sensitivity" begin
@@ -689,7 +689,7 @@ end
     ctx, sol = solve_mna_spice_code(spice_code)
     # r1 uses model rr with R=1, r2 overrides R=2
     # Total resistance = 1 + 2 = 3, V at node 1 = 1 * 2/3
-    @test isapprox(voltage(sol, Symbol("1")), 2/3; atol=deftol*10)
+    @test isapprox(sol[Symbol("1")], 2/3; atol=deftol*10)
 end
 
 @testset "units and magnitudes" begin
@@ -702,7 +702,7 @@ end
 
     ctx, sol = solve_mna_spice_code(spice_code)
     # V = I*R = 1e-3 * 1e6 = 1000V
-    @test isapprox(voltage(sol, :vcc), 1000.0; atol=deftol*10)
+    @test isapprox(sol[:vcc], 1000.0; atol=deftol*10)
 
     spice_code2 = """
     * units and magnitudes 2
@@ -712,7 +712,7 @@ end
 
     ctx, sol = solve_mna_spice_code(spice_code2)
     # 1 mil = 25.4e-6 (25.4 micrometers)
-    @test isapprox(voltage(sol, :vcc), 2.54e-5; atol=1e-8)
+    @test isapprox(sol[:vcc], 2.54e-5; atol=1e-8)
 end
 
 # TODO: Test that magnitudes don't introduce floating point errors
@@ -775,7 +775,7 @@ end
     """
     ctx, sol = solve_mna_spice_code(spice_ckt)
     # intp=1, intn=-1, floorp=1 -> V = 1 + (-1) + 1 = 1V
-    @test isapprox(voltage(sol, :vcc), 1.0; atol=deftol)
+    @test isapprox(sol[:vcc], 1.0; atol=deftol)
 end
 
 # TODO: Extended functions test - verify all function results via ParamObserver
@@ -878,7 +878,7 @@ end
     # I = 1A (from current source), V = I*R
     # Current source I1: -1A means extracting 1A from vcc, injecting into 0
     # V_vcc = I * R = 1 * 2000 = 2000V
-    @test isapprox(voltage(sol, :vcc), 2000.0; rtol=1e-6)
+    @test isapprox(sol[:vcc], 2000.0; rtol=1e-6)
 end
 
 # TODO: Extended device == param tests
@@ -944,7 +944,7 @@ end
     # R1 = rsh * l / w = 500 * 2m / 1m = 1000Ω
     # R2 = res = 1000Ω
     # Parallel: R_eq = 500Ω, I = 1/500 = 2mA
-    @test_broken isapprox(current(sol, :I_v1), -2e-3; atol=deftol*10)
+    @test_broken isapprox(sol[:I_v1], -2e-3; atol=deftol*10)
     =#
 end
 
@@ -962,7 +962,7 @@ end
     """
     ctx, sol = solve_mna_spice_code(spice_code)
     # With switch=1, R1=1Ω, I = V/R = 1A
-    @test isapprox(current(sol, :I_v1), -1.0; atol=deftol*10)
+    @test isapprox(sol[:I_v1], -1.0; atol=deftol*10)
 end
 
 @testset "SPICE CCVS (H element)" begin
@@ -980,9 +980,9 @@ end
 
     # Current through Vsense = 5V/1kΩ = 5mA
     # Vout = rm * I = 200 * 5mA = 1V
-    @test isapprox(voltage(sol, :vcc), 5.0; atol=deftol)
-    @test isapprox(voltage(sol, :sense), 0.0; atol=deftol)
-    @test isapprox(voltage(sol, :out), 1.0; atol=deftol)
+    @test isapprox(sol[:vcc], 5.0; atol=deftol)
+    @test isapprox(sol[:sense], 0.0; atol=deftol)
+    @test isapprox(sol[:out], 1.0; atol=deftol)
 end
 
 @testset "SPICE CCCS (F element)" begin
@@ -1001,9 +1001,9 @@ end
     # Current through Vsense = 5V/1kΩ = 5mA
     # I_out = gain * I = 2 * 5mA = 10mA
     # V_out = I_out * R = 10mA * 100Ω = 1V
-    @test isapprox(voltage(sol, :vcc), 5.0; atol=deftol)
-    @test isapprox(voltage(sol, :sense), 0.0; atol=deftol)
-    @test isapprox(voltage(sol, :out), 1.0; atol=deftol)
+    @test isapprox(sol[:vcc], 5.0; atol=deftol)
+    @test isapprox(sol[:sense], 0.0; atol=deftol)
+    @test isapprox(sol[:out], 1.0; atol=deftol)
 end
 
 end # basic_tests

--- a/test/common.jl
+++ b/test/common.jl
@@ -10,6 +10,12 @@ using SciMLBase
 using Sundials
 using LinearSolve: KLUFactorization
 
+using Cadnip.MNA: MNAContext, MNASpec, assemble!, solve_dc, solve_ac
+using Cadnip.MNA: MNACircuit
+using Cadnip.MNA: get_node!, stamp!
+using Cadnip.MNA: Resistor, Capacitor, Inductor, VoltageSource, CurrentSource
+using Cadnip.MNA: make_ode_problem, ZERO_VECTOR
+
 const deftol = 1e-8
 
 # Our default tolerances are one order of magnitude above our default solve tolerances
@@ -19,235 +25,85 @@ isapprox_deftol(x) = y->isapprox(x, y; atol=deftol*10, rtol=deftol*10)
 allapprox_deftol(itr) = isempty(itr) ? true : all(isapprox_deftol(first(itr)), itr)
 
 #==============================================================================#
-# MNA-based solve functions (Phase 4+, no DAECompiler required)
+# Compat shims for test files — thin wrappers around the new MNACircuit API.
+#
+# Tests that still return `(ctx, sol)` tuples are supported here; the idiomatic
+# call is `dc!(MNACircuit(code; lang=...))`, which returns just the solution.
+# These shims make old test code compile while Phase 4 migration is in progress.
 #==============================================================================#
 
-using Cadnip.MNA: MNAContext, MNASpec, assemble!, solve_dc, solve_ac
-using Cadnip.MNA: voltage, current, get_node!, stamp!
-using Cadnip.MNA: Resistor, Capacitor, Inductor, VoltageSource, CurrentSource
-using Cadnip.MNA: make_ode_problem, ZERO_VECTOR
-
-"""
-    solve_mna_spice_code(spice_code::String; temp=27.0) -> (ctx, sol)
-
-Parse SPICE code and solve DC operating point using MNA backend.
-Returns (MNAContext, DCSolution).
-
-# Example
-```julia
-code = \"\"\"
-V1 vcc 0 DC 5
-R1 vcc out 1k
-R2 out 0 1k
-\"\"\"
-ctx, sol = solve_mna_spice_code(code)
-voltage(sol, :out)  # Returns 2.5
-```
-"""
-function solve_mna_spice_code(spice_code::String; temp::Real=27.0, imported_hdl_modules::Vector{Module}=Module[], maxiters::Int=100)
-    ast = Cadnip.NyanSpectreNetlistParser.parse(IOBuffer(spice_code); start_lang=:spice, implicit_title=true)
-    code = Cadnip.make_mna_circuit(ast; imported_hdl_modules)
-
-    # Evaluate in temporary module
+# These shims eval the builder inside a function body (we're called from an
+# `@testset`). `MNACircuit(code; lang=...)` from production would error with
+# "method too new" here (by design), so we wrap the builder in an explicit
+# invokelatest closure ourselves — same pattern tests have always used for
+# runtime-parsed circuits.
+function _eval_spice_builder(spice_code, imported_hdl_modules)
+    code = parse_spice_to_mna(spice_code; circuit_name=:circuit, imported_hdl_modules)
     m = Module()
-    Base.eval(m, :(using Cadnip.MNA))
-    Base.eval(m, :(using Cadnip: ParamLens))
-    Base.eval(m, :(using Cadnip.SpectreEnvironment))
-    # Import VA device types
-    for hdl_mod in imported_hdl_modules
-        for name in names(hdl_mod; all=true, imported=false)
-            if !startswith(String(name), "#") && isdefined(hdl_mod, name)
-                val = getfield(hdl_mod, name)
-                isa(val, Type) && Base.eval(m, :(const $name = $val))
-            end
-        end
-    end
-    circuit_fn = Base.eval(m, code)
-
-    # Use solve_dc(builder, params, spec) which properly handles Newton iteration
-    # for nonlinear devices (VA BJTs, diodes, etc.)
-    spec = MNASpec(temp=Float64(temp), mode=:dcop)
-    sol = Base.invokelatest(solve_dc, circuit_fn, (;), spec; maxiters)
-
-    # Build context for returning (at the solved operating point)
-    ctx = Base.invokelatest(circuit_fn, (;), spec, 0.0; x=sol.x)
-
-    return ctx, sol
+    Base.eval(m, code)
+    builder = getfield(m, :circuit)
+    return (args...; kwargs...) -> Base.invokelatest(builder, args...; kwargs...)
 end
 
-"""
-    solve_mna_spectre_code(spectre_code::String; temp=27.0) -> (ctx, sol)
-
-Parse Spectre code and solve DC operating point using MNA backend.
-Returns (MNAContext, DCSolution).
-
-# Example
-```julia
-code = \"\"\"
-v1 (vcc 0) vsource dc=5
-r1 (vcc out) resistor r=1k
-r2 (out 0) resistor r=1k
-\"\"\"
-ctx, sol = solve_mna_spectre_code(code)
-voltage(sol, :out)  # Returns 2.5
-```
-"""
-function solve_mna_spectre_code(spectre_code::String; temp::Real=27.0, imported_hdl_modules::Vector{Module}=Module[], maxiters::Int=100)
+function _eval_spectre_builder(spectre_code, imported_hdl_modules)
     ast = Cadnip.NyanSpectreNetlistParser.parse(IOBuffer(spectre_code); start_lang=:spectre)
-    code = Cadnip.make_mna_circuit(ast; imported_hdl_modules)
-
-    # Evaluate in temporary module
+    sema_result = Cadnip.sema(ast; imported_hdl_modules)
+    code = Cadnip._make_mna_circuit_with_sema(sema_result; circuit_name=:circuit)
     m = Module()
-    Base.eval(m, :(using Cadnip.MNA))
-    Base.eval(m, :(using Cadnip: ParamLens))
-    Base.eval(m, :(using Cadnip.SpectreEnvironment))
-    # Import VA device types
-    for hdl_mod in imported_hdl_modules
-        for name in names(hdl_mod; all=true, imported=false)
-            if !startswith(String(name), "#") && isdefined(hdl_mod, name)
-                val = getfield(hdl_mod, name)
-                isa(val, Type) && Base.eval(m, :(const $name = $val))
-            end
-        end
-    end
-    circuit_fn = Base.eval(m, code)
+    Base.eval(m, code)
+    builder = getfield(m, :circuit)
+    return (args...; kwargs...) -> Base.invokelatest(builder, args...; kwargs...)
+end
 
-    # Use solve_dc(builder, params, spec) which properly handles Newton iteration
-    # for nonlinear devices (VA BJTs, diodes, etc.)
-    spec = MNASpec(temp=Float64(temp), mode=:dcop)
-    sol = Base.invokelatest(solve_dc, circuit_fn, (;), spec; maxiters)
-
-    # Build context for returning (at the solved operating point)
-    ctx = Base.invokelatest(circuit_fn, (;), spec, 0.0; x=sol.x)
-
+function solve_mna_spice_code(spice_code::AbstractString; temp::Real=27.0, maxiters::Int=100,
+                              imported_hdl_modules::Vector{Module}=Module[])
+    wrapped = _eval_spice_builder(spice_code, imported_hdl_modules)
+    circuit = MNACircuit(wrapped, (;), MNASpec(temp=Float64(temp), mode=:dcop))
+    sol = solve_dc(circuit)
+    ctx = circuit.builder(circuit.params, circuit.spec, 0.0; x=sol.x)
     return ctx, sol
 end
 
-"""
-    solve_mna_circuit(builder; params=(;), temp=27.0) -> (ctx, sol)
-
-Build and solve a circuit using MNA backend.
-`builder` should be a function (params, spec, t; x=...) -> MNAContext.
-
-# Example
-```julia
-function my_circuit(params, spec, t::Real=0.0; x=Float64[])
-    ctx = MNAContext()
-    vcc = get_node!(ctx, :vcc)
-    stamp!(VoltageSource(5.0), ctx, vcc, 0)
-    stamp!(Resistor(params.R), ctx, vcc, 0)
-    return ctx
-end
-ctx, sol = solve_mna_circuit(my_circuit; params=(R=1000.0,))
-```
-"""
-function solve_mna_circuit(builder; params=(;), temp::Real=27.0)
-    # Use solve_dc(builder, params, spec) which properly handles Newton iteration
-    # for nonlinear devices (VA BJTs, diodes, etc.)
-    spec = MNASpec(temp=Float64(temp), mode=:dcop)
-    sol = solve_dc(builder, params, spec)
-    ctx = builder(params, spec, 0.0; x=sol.x)
+function solve_mna_spectre_code(spectre_code::AbstractString; temp::Real=27.0, maxiters::Int=100,
+                                imported_hdl_modules::Vector{Module}=Module[])
+    wrapped = _eval_spectre_builder(spectre_code, imported_hdl_modules)
+    circuit = MNACircuit(wrapped, (;), MNASpec(temp=Float64(temp), mode=:dcop))
+    sol = solve_dc(circuit)
+    ctx = circuit.builder(circuit.params, circuit.spec, 0.0; x=sol.x)
     return ctx, sol
 end
 
-"""
-    tran_mna_circuit(builder, tspan; params=(;), temp=27.0, solver=Rodas5P(linsolve=KLUFactorization())) -> (ctx, sol)
+# `solve_mna_circuit`, `tran_mna_circuit`, and `make_mna_spice_circuit` were
+# compat shims for old test code; no current test calls them. Deleted.
 
-Build and solve a transient simulation using MNA backend.
-
-# Example
-```julia
-function rc_circuit(params, spec, t::Real=0.0)
-    ctx = MNAContext()
-    vcc = get_node!(ctx, :vcc)
-    out = get_node!(ctx, :out)
-    stamp!(VoltageSource(params.V), ctx, vcc, 0)
-    stamp!(Resistor(params.R), ctx, vcc, out)
-    stamp!(Capacitor(params.C), ctx, out, 0)
-    return ctx
-end
-ctx, sol = tran_mna_circuit(rc_circuit, (0.0, 1e-3); params=(V=5.0, R=1000.0, C=1e-6))
-```
-"""
-function tran_mna_circuit(builder, tspan::Tuple; params=(;), temp::Real=27.0, solver=Rodas5P(linsolve=KLUFactorization()))
-    spec = MNASpec(temp=Float64(temp), mode=:tran)
-    ctx = builder(params, spec)
-    sys = assemble!(ctx)
-
-    # Create and solve ODE problem
-    prob_data = make_ode_problem(sys, tspan)
-    f = ODEFunction(prob_data.f; mass_matrix=prob_data.mass_matrix,
-                    jac=prob_data.jac, jac_prototype=prob_data.jac_prototype)
-    prob = ODEProblem(f, prob_data.u0, prob_data.tspan)
-    sol = solve(prob, solver; reltol=deftol, abstol=deftol)
-
-    return ctx, sol
+#==============================================================================#
+# Test-only shim: `parse_spice_to_mna` returns a builder Expr and accepts an
+# internal `imported_hdl_modules` list for test code that defines VA devices via
+# the `va"""..."""` macro. Not a public API.
+#==============================================================================#
+function parse_spice_to_mna(spice_code::AbstractString;
+                            circuit_name::Symbol=:circuit,
+                            imported_hdl_modules::Vector{Module}=Module[])
+    ast = Cadnip.NyanSpectreNetlistParser.parse(IOBuffer(spice_code);
+        start_lang=:spice, implicit_title=true)
+    sema_result = Cadnip.sema(ast; imported_hdl_modules)
+    return _make_mna_circuit_from_sema(sema_result, circuit_name)
 end
 
-using Cadnip.MNA: MNACircuit
+function parse_spice_file_to_mna(filepath::AbstractString;
+                                  circuit_name::Symbol=:circuit,
+                                  imported_hdl_modules::Vector{Module}=Module[])
+    ast = Cadnip.NyanSpectreNetlistParser.parsefile(filepath;
+        start_lang=:spice, implicit_title=true)
+    sema_result = Cadnip.sema(ast; imported_hdl_modules)
+    return _make_mna_circuit_from_sema(sema_result, circuit_name)
+end
 
-"""
-    make_mna_spice_circuit(spice_code::String; temp=27.0, imported_hdl_modules=Module[]) -> MNACircuit
-
-Parse SPICE code and return an MNACircuit ready for simulation.
-
-This is a convenience function for test code. It uses `invokelatest` internally
-to handle world age issues with runtime-parsed code.
-
-For production code loading SPICE from files, use the top-level eval pattern:
-
-```julia
-# At module/file load time (top level)
-using Cadnip: parse_spice_to_mna
-const circuit_code = parse_spice_to_mna(read("circuit.sp", String);
-                                        imported_hdl_modules=[MyVA_module])
-eval(circuit_code)  # Defines `circuit` function, advances world
-
-# Now can use normally without invokelatest
-circuit = MNACircuit(circuit)
-sol = tran!(circuit, (0.0, 1e-3))
-```
-
-# Example (test code)
-```julia
-spice = \"\"\"
-* BJT amplifier
-V1 vcc 0 DC 12
-Vb base 0 DC 0.65
-Rc vcc coll 4.7k
-X1 base 0 coll npnbjt
-\"\"\"
-
-circuit = make_mna_spice_circuit(spice; imported_hdl_modules=[npnbjt_module])
-sol = tran!(circuit, (0.0, 1e-3))
-```
-"""
-function make_mna_spice_circuit(spice_code::String; temp::Real=27.0, imported_hdl_modules::Vector{Module}=Module[])
-    ast = Cadnip.NyanSpectreNetlistParser.parse(IOBuffer(spice_code); start_lang=:spice, implicit_title=true)
-    code = Cadnip.make_mna_circuit(ast; imported_hdl_modules)
-
-    # Evaluate in temporary module
-    m = Module()
-    Base.eval(m, :(using Cadnip.MNA))
-    Base.eval(m, :(using Cadnip: ParamLens))
-    Base.eval(m, :(using Cadnip.SpectreEnvironment))
-    # Import VA device types
-    for hdl_mod in imported_hdl_modules
-        for name in names(hdl_mod; all=true, imported=false)
-            if !startswith(String(name), "#") && isdefined(hdl_mod, name)
-                val = getfield(hdl_mod, name)
-                isa(val, Type) && Base.eval(m, :(const $name = $val))
-            end
-        end
-    end
-    circuit_fn = Base.eval(m, code)
-
-    # Wrap in invokelatest to handle world age issues.
-    # This is needed because circuit_fn was defined via eval and is called from
-    # ODE solver callbacks which are in an older world.
-    # For production performance, use the sp"..." macro instead.
-    wrapped_fn = (args...; kwargs...) -> Base.invokelatest(circuit_fn, args...; kwargs...)
-
-    spec = MNASpec(temp=Float64(temp), mode=:tran)
-    return MNACircuit(wrapped_fn, (;), spec)
+# Reuse codegen with a pre-built sema result. Duplicates a bit of codegen.jl
+# logic but avoids surfacing imported_hdl_modules on a public API.
+function _make_mna_circuit_from_sema(sema_result, circuit_name::Symbol)
+    # Reach into Cadnip's codegen — this is an internal/test-only bridge.
+    # We assemble the same expression make_mna_circuit would, but with a sema
+    # that already has imported_hdl_modules populated.
+    Cadnip._make_mna_circuit_with_sema(sema_result; circuit_name)
 end

--- a/test/ddx.jl
+++ b/test/ddx.jl
@@ -3,7 +3,7 @@ module ddx_tests
 using Cadnip
 using Cadnip.MNA
 using Cadnip.MNA: MNAContext, MNASpec, get_node!, stamp!, assemble!, solve_dc
-using Cadnip.MNA: voltage, current
+
 using Cadnip.MNA: VoltageSource
 using Test
 
@@ -59,14 +59,14 @@ endmodule
     sol = solve_dc(VRcircuit, (;), MNASpec(mode=:dcop))
 
     # Verify voltages
-    @test isapprox(voltage(sol, :vcc), 5.0; atol=1e-10)
-    @test isapprox(voltage(sol, :vg), 3.0; atol=1e-10)
+    @test isapprox(sol[:vcc], 5.0; atol=1e-10)
+    @test isapprox(sol[:vg], 3.0; atol=1e-10)
 
     # Verify current:
     # I(d,s) = 2*R*V(d,s)*V(g,s) = 2*2*5*3 = 60A flows from d(vcc) to s(gnd)
     # V1 sources this current (pushing out of positive terminal), so I_V1 = -60A
     expected_I = 5.0 * 2.0 * 2.0 * 3.0
-    @test isapprox(current(sol, :I_V1), -expected_I; atol=1e-6)
+    @test isapprox(sol[:I_V1], -expected_I; atol=1e-6)
 end
 
 end # module ddx_tests

--- a/test/mna/astable_bjt_test.jl
+++ b/test/mna/astable_bjt_test.jl
@@ -22,12 +22,15 @@
 using Test
 using Cadnip
 using Cadnip.MNA
-using Cadnip.MNA: MNACircuit, MNASolutionAccessor, MNASpec
-using Cadnip.MNA: voltage, assemble!, CedarDCOp, CedarUICOp, solve_dc
+using Cadnip.MNA: nameat
+using Cadnip.MNA: MNACircuit, MNASpec
+using Cadnip.MNA: assemble!, CedarDCOp, CedarUICOp, solve_dc
 using SciMLBase
-using Cadnip: tran!, parse_spice_to_mna
+using Cadnip: tran!
 using OrdinaryDiffEq: Rodas5P
 using LinearSolve: KLUFactorization
+
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 #==============================================================================#
 # Helper functions
@@ -142,12 +145,12 @@ eval(astable_code)
         @test sol.retcode == SciMLBase.ReturnCode.Success
 
         sys = assemble!(circuit)
-        acc = MNASolutionAccessor(sol, sys)
+        acc = sol  # MNASolutionAccessor removed — sol supports SII directly
 
         # Verify we can read voltages without NaN/Inf
-        V_q1 = voltage(acc, :q1_coll, 50e-3)
-        V_q2 = voltage(acc, :q2_coll, 50e-3)
-        V_vcc = voltage(acc, :vcc, 50e-3)
+        V_q1 = nameat(acc, :q1_coll, 50e-3)
+        V_q2 = nameat(acc, :q2_coll, 50e-3)
+        V_vcc = nameat(acc, :vcc, 50e-3)
 
         @test isfinite(V_q1)
         @test isfinite(V_q2)
@@ -169,14 +172,14 @@ eval(astable_code)
         @test sol.retcode == SciMLBase.ReturnCode.Success
 
         sys = assemble!(circuit)
-        acc = MNASolutionAccessor(sol, sys)
+        acc = sol  # MNASolutionAccessor removed — sol supports SII directly
 
         # Sample collector voltages after startup transient
         t_start = 20e-3
         t_end = 100e-3
         n_samples = 2000
         times = range(t_start, t_end; length=n_samples)
-        V_q1 = [voltage(acc, :q1_coll, t) for t in times]
+        V_q1 = [nameat(acc, :q1_coll, t) for t in times]
 
         q1_min, q1_max = extrema(V_q1)
         midpoint = (q1_max + q1_min) / 2
@@ -220,13 +223,13 @@ eval(astable_code)
         @test sol.retcode == SciMLBase.ReturnCode.Success
 
         sys = assemble!(circuit)
-        acc = MNASolutionAccessor(sol, sys)
+        acc = sol  # MNASolutionAccessor removed — sol supports SII directly
 
         # Check voltages at a few time points
         for t in [1e-3, 5e-3, 10e-3]
-            V_q1 = voltage(acc, :q1_coll, t)
-            V_q2 = voltage(acc, :q2_coll, t)
-            V_vcc = voltage(acc, :vcc, t)
+            V_q1 = nameat(acc, :q1_coll, t)
+            V_q2 = nameat(acc, :q2_coll, t)
+            V_vcc = nameat(acc, :vcc, t)
 
             # Collector voltages should be between 0 and Vcc
             @test V_q1 >= -0.1

--- a/test/mna/audio_integration.jl
+++ b/test/mna/audio_integration.jl
@@ -20,9 +20,10 @@
 using Test
 using Cadnip
 using Cadnip.MNA
-using Cadnip.MNA: MNACircuit, MNASolutionAccessor
-using Cadnip.MNA: voltage, current, assemble!
-using Cadnip: tran!, parse_spice_to_mna, CircuitSweep, Sweep
+using Cadnip.MNA: nameat
+using Cadnip.MNA: MNACircuit
+using Cadnip.MNA: assemble!
+using Cadnip: tran!, CircuitSweep, Sweep
 using OrdinaryDiffEq
 using SciMLBase
 using LinearSolve: KLUFactorization
@@ -112,12 +113,12 @@ eval(ce_amplifier_code)
         sol = MNA.solve_dc(bjt_fixed_voltages, (;), spec)
 
         # Check voltages are as expected
-        @test isapprox(voltage(sol, :base), 0.65; atol=1e-6)
-        @test isapprox(voltage(sol, :coll), 5.0; atol=1e-6)
+        @test isapprox(sol[:base], 0.65; atol=1e-6)
+        @test isapprox(sol[:coll], 5.0; atol=1e-6)
 
         # The voltage source currents tell us the terminal currents
-        I_Vbe = current(sol, :I_vbe)  # Current into base
-        I_Vce = current(sol, :I_vce)  # Current into collector
+        I_Vbe = sol[:I_vbe]  # Current into base
+        I_Vce = sol[:I_vce]  # Current into collector
 
         # Base current should be small (μA range), collector current larger (mA range)
         @test abs(I_Vbe) > 1e-6   # Base current exists
@@ -138,8 +139,8 @@ eval(ce_amplifier_code)
         spec = MNA.MNASpec(mode=:dcop)
         sol = MNA.solve_dc(bjt_with_rc, (;), spec)
 
-        V_coll = voltage(sol, :coll)
-        V_base = voltage(sol, :base)
+        V_coll = sol[:coll]
+        V_base = sol[:base]
 
         # Base should be at Vb
         @test isapprox(V_base, 0.65; atol=1e-6)
@@ -167,8 +168,8 @@ eval(ce_amplifier_code)
         # First verify DC operating point
         spec = MNA.MNASpec(mode=:dcop)
         dc_sol = MNA.solve_dc(ce_amplifier, (;), spec)
-        V_coll_dc = voltage(dc_sol, :coll)
-        V_base_dc = voltage(dc_sol, :base)
+        V_coll_dc = dc_sol[:coll]
+        V_base_dc = dc_sol[:base]
 
         # Verify BJT is biased properly
         @test isapprox(V_base_dc, Vbias; atol=0.01)
@@ -186,14 +187,14 @@ eval(ce_amplifier_code)
 
         # Access results
         sys = assemble!(circuit)
-        acc = MNASolutionAccessor(sol, sys)
+        acc = sol  # MNASolutionAccessor removed — sol supports SII directly
 
         # Measure output after initial transient (last 2 periods)
         t_start = 3 * period
         times = range(t_start, 5*period; length=100)
 
-        V_coll = [voltage(acc, :coll, t) for t in times]
-        V_base = [voltage(acc, :base, t) for t in times]
+        V_coll = [nameat(acc, :coll, t) for t in times]
+        V_base = [nameat(acc, :base, t) for t in times]
 
         # Calculate peak-to-peak voltages
         Vout_pp = maximum(V_coll) - minimum(V_coll)
@@ -211,7 +212,7 @@ eval(ce_amplifier_code)
 
         # Verify phase inversion (input peak → output trough)
         t_max_inp = times[argmax(V_base)]
-        V_out_at_inp_max = voltage(acc, :coll, t_max_inp)
+        V_out_at_inp_max = nameat(acc, :coll, t_max_inp)
 
         # At input maximum, output should be below DC level (inverted)
         @test V_out_at_inp_max < V_coll_dc
@@ -232,20 +233,17 @@ eval(ce_amplifier_code)
         sweep = Sweep(vac = [0.0005, 0.001, 0.002])
         cs = CircuitSweep(ce_amplifier, sweep; vac=0.001, freq=freq)
 
-        # Run transient sweep - returns vector of solutions
-        solutions = tran!(cs, tspan; solver=Rodas5P(linsolve=KLUFactorization()), abstol=1e-9, reltol=1e-7)
+        # Run transient sweep - returns a SweepResult that iterates (params, sol) pairs
+        result = tran!(cs, tspan; solver=Rodas5P(linsolve=KLUFactorization()), abstol=1e-9, reltol=1e-7)
 
         gains = Float64[]
-        for (sol, circuit) in zip(solutions, cs)
+        for (params, sol) in result
             if sol.retcode == ReturnCode.Success
-                sys = assemble!(circuit)
-                acc = MNASolutionAccessor(sol, sys)
-
                 t_start = 3 * period
                 times = range(t_start, 5*period; length=100)
 
-                V_coll = [voltage(acc, :coll, t) for t in times]
-                V_base = [voltage(acc, :base, t) for t in times]
+                V_coll = [nameat(sol, :coll, t) for t in times]
+                V_base = [nameat(sol, :base, t) for t in times]
 
                 Vout_pp = maximum(V_coll) - minimum(V_coll)
                 Vin_pp = maximum(V_base) - minimum(V_base)
@@ -291,15 +289,15 @@ eval(ce_amplifier_code)
 
             if sol.retcode == ReturnCode.Success
                 sys = assemble!(circuit)
-                acc = MNASolutionAccessor(sol, sys)
+                acc = sol  # MNASolutionAccessor removed — sol supports SII directly
 
                 # Measure last 3 periods
                 t_start = 7 * period
                 t_end = 10 * period
                 times = range(t_start, t_end; length=100)
 
-                V_coll = [voltage(acc, :coll, t) for t in times]
-                V_base = [voltage(acc, :base, t) for t in times]
+                V_coll = [nameat(acc, :coll, t) for t in times]
+                V_base = [nameat(acc, :base, t) for t in times]
 
                 Vout_pp = maximum(V_coll) - minimum(V_coll)
                 Vin_pp = maximum(V_base) - minimum(V_base)
@@ -359,10 +357,10 @@ eval(ce_amplifier_code)
         sol = MNA.solve_dc(ce_amplifier_builder, (;), spec)
 
         # Check that BJT is properly biased
-        V_vin = voltage(sol, :vin)
-        V_vcc = voltage(sol, :vcc)
-        V_emitter = voltage(sol, :emitter)
-        V_collector = voltage(sol, :collector)
+        V_vin = sol[:vin]
+        V_vcc = sol[:vcc]
+        V_emitter = sol[:emitter]
+        V_collector = sol[:collector]
 
         @test isapprox(V_vin, 3.0; atol=1e-6)
         @test isapprox(V_vcc, 6.0; atol=1e-6)
@@ -405,10 +403,10 @@ eval(ce_amplifier_code)
         spec = MNA.MNASpec(mode=:dcop)
         sol_high = MNA.solve_dc(ce_high_voltage_builder, (;), spec)
 
-        V_vin_h = voltage(sol_high, :vin)
-        V_vcc_h = voltage(sol_high, :vcc)
-        V_emitter_h = voltage(sol_high, :emitter)
-        V_collector_h = voltage(sol_high, :collector)
+        V_vin_h = sol_high[:vin]
+        V_vcc_h = sol_high[:vcc]
+        V_emitter_h = sol_high[:emitter]
+        V_collector_h = sol_high[:collector]
 
         @test isapprox(V_vin_h, 6.0; atol=1e-6)
         @test isapprox(V_vcc_h, 12.0; atol=1e-6)

--- a/test/mna/charge_formulation.jl
+++ b/test/mna/charge_formulation.jl
@@ -448,7 +448,7 @@ end
     using Cadnip: dc!, tran!, MNACircuit, MNASpec
     using Cadnip.MNA: MNAContext, get_node!, stamp!, assemble!, reset_for_restamping!
     using Cadnip.MNA: stamp_charge_state!, VoltageSource, Resistor, Capacitor, resolve_index
-    using Cadnip.MNA: MNASolutionAccessor, voltage
+    
     using OrdinaryDiffEq: Rodas5P
     using LinearSolve: KLUFactorization
     using SciMLBase: ReturnCode
@@ -510,7 +510,7 @@ end
 
         # Get the assembled system to find variable indices
         sys = assemble!(circuit)
-        acc = MNASolutionAccessor(sol, sys)
+        acc = sol  # MNASolutionAccessor removed — sol supports SII directly
 
         # Variable layout: [vcc, cap, I_Vsource, q_scaled]
         # vcc = index 1, cap = index 2, I_V = index 3, q_scaled = index 4

--- a/test/mna/codegen_hygiene.jl
+++ b/test/mna/codegen_hygiene.jl
@@ -1,0 +1,66 @@
+module codegen_hygiene_tests
+
+include(joinpath(@__DIR__, "..", "common.jl"))
+
+using Test
+using Cadnip
+using Cadnip.MNA: MNACircuit, MNASpec
+
+# Regression test: generated SPICE/VA code must not leak Cadnip-internal identifiers
+# into the target module's namespace. A SPICE subckt parameter named `stamp` would
+# previously shadow the bare `stamp!(...)` emission inside generated code.
+#
+# After the codegen hygiene pass, Type-B references are emitted fully-qualified
+# (`Cadnip.MNA.stamp!(...)`, `Cadnip.MNA.get_node!(...)`, `Base.error(...)`, etc.),
+# so user identifiers are free to use those names.
+
+@testset "Codegen hygiene: structural — no bare Type-B emissions" begin
+
+    @testset "SPICE generated code contains no bare stamp!" begin
+        ast = Cadnip.NyanSpectreNetlistParser.parse(IOBuffer("""
+        * test
+        V1 vcc 0 DC 5
+        R1 vcc 0 1k
+        C1 vcc 0 1p
+        """); start_lang=:spice, implicit_title=true)
+        code = Cadnip.make_mna_circuit(ast; circuit_name=:hygiene_test)
+        code_str = string(code)
+        # After hygiene: no unqualified `stamp!(`, `get_node!(`, `pwl_at_time(`,
+        # `get_current_idx(`. All must appear as `Cadnip.MNA.xxx` or via GlobalRef.
+        @test !occursin(r"(?<![.A-Za-z])stamp!\(", code_str)
+        @test !occursin(r"(?<![.A-Za-z])get_node!\(", code_str)
+    end
+
+    @testset "SPICE subckt with parameter named `stamp` resolves correctly" begin
+        # Regression: if `stamp!` were emitted bare, this subckt would fail
+        # because the parameter `stamp` would shadow the function at call time.
+        circuit = MNACircuit(sp"""
+        * param-name-collision regression
+        .subckt myres a b stamp=2000.0
+        R1 a b 'stamp'
+        .ends
+        V1 vcc 0 DC 1.0
+        X1 vcc 0 myres stamp=1500.0
+        """)
+        sol = dc!(circuit)
+        # I = V/R = 1V / 1500Ω
+        @test isapprox(sol[:I_v1], -1.0/1500.0; atol=1e-8)
+    end
+
+    @testset "SPICE subckt with parameter named `get_node`" begin
+        # Additional regression — `get_node!` emitted bare would collide here.
+        circuit = MNACircuit(sp"""
+        * another collision regression
+        .subckt myres2 a b get_node=3000.0
+        R1 a b 'get_node'
+        .ends
+        V1 vcc 0 DC 1.0
+        X1 vcc 0 myres2 get_node=2500.0
+        """)
+        sol = dc!(circuit)
+        @test isapprox(sol[:I_v1], -1.0/2500.0; atol=1e-8)
+    end
+
+end
+
+end # module

--- a/test/mna/core.jl
+++ b/test/mna/core.jl
@@ -27,10 +27,11 @@ using Cadnip.MNA: get_source_value, pwl_at_time
 using Cadnip.MNA: VCVS, VCCS, CCVS, CCCS
 using Cadnip.MNA: assemble!, assemble_G, assemble_C, get_rhs
 using Cadnip.MNA: DCSolution, ACSolution, solve_dc, solve_ac
-using Cadnip.MNA: voltage, current, magnitude_db, phase_deg
+using Cadnip.MNA: magnitude_db, phase_deg
 using Cadnip.MNA: make_ode_problem, make_ode_function
 using Cadnip.MNA: make_dae_problem, make_dae_function
 using Cadnip.MNA: reset_for_restamping!
+using Cadnip.MNA: nameat
 
 # Import Cadnip for macros and dc!/tran!
 using Cadnip
@@ -183,12 +184,12 @@ using NyanVerilogAParser
         # Verify voltages using voltage divider
         # V(anode) = 5.0 (forced by voltage source)
         # V(a_int) = 5.0 * 1000 / (10 + 1000) ≈ 4.9505
-        @test voltage(sol, :anode) ≈ 5.0
+        @test sol[:anode] ≈ 5.0
         @test isapprox(sol.x[a_int], 5.0 * 1000 / 1010; rtol=1e-6)
 
         # Current through circuit
         # I = 5.0 / (10 + 1000) = 5.0 / 1010 ≈ 4.95mA
-        @test isapprox(-current(sol, :I_V1), 5.0 / 1010; rtol=1e-6)
+        @test isapprox(-sol[:I_V1], 5.0 / 1010; rtol=1e-6)
     end
 
     @testset "Stamping primitives" begin
@@ -512,8 +513,8 @@ using NyanVerilogAParser
         R2 out 0 1k
         """i)
         sol = dc!(circuit)
-        @test voltage(sol, :vcc) ≈ 5.0
-        @test voltage(sol, :out) ≈ 2.5 atol=1e-10
+        @test sol[:vcc] ≈ 5.0
+        @test sol[:out] ≈ 2.5 atol=1e-10
     end
 
     @testset "DC: Voltage divider (unequal)" begin
@@ -525,7 +526,7 @@ using NyanVerilogAParser
         R2 out 0 1k
         """i)
         sol = dc!(circuit)
-        @test voltage(sol, :out) ≈ 5.0 / 3.0 atol=1e-10
+        @test sol[:out] ≈ 5.0 / 3.0 atol=1e-10
     end
 
     @testset "DC: Current source into resistor" begin
@@ -536,7 +537,7 @@ using NyanVerilogAParser
         R1 n1 0 1k
         """i)
         sol = dc!(circuit)
-        @test voltage(sol, :n1) ≈ 1.0 atol=1e-10
+        @test sol[:n1] ≈ 1.0 atol=1e-10
     end
 
     @testset "DC: Two voltage sources" begin
@@ -549,8 +550,8 @@ using NyanVerilogAParser
         R2 mid 0 1k
         """i)
         sol = dc!(circuit)
-        @test voltage(sol, :vcc) ≈ 5.0
-        @test voltage(sol, :mid) ≈ 3.0
+        @test sol[:vcc] ≈ 5.0
+        @test sol[:mid] ≈ 3.0
     end
 
     @testset "DC: VCCS amplifier" begin
@@ -564,8 +565,8 @@ using NyanVerilogAParser
         R1 out 0 1k
         """i)
         sol = dc!(circuit)
-        @test voltage(sol, :inp) ≈ 1.0
-        @test voltage(sol, :out) ≈ 10.0 atol=1e-10
+        @test sol[:inp] ≈ 1.0
+        @test sol[:out] ≈ 10.0 atol=1e-10
     end
 
     @testset "DC: Inverting amplifier with VCVS" begin
@@ -576,8 +577,8 @@ using NyanVerilogAParser
         E1 out 0 inp 0 -10.0
         """i)
         sol = dc!(circuit)
-        @test voltage(sol, :inp) ≈ 0.5
-        @test voltage(sol, :out) ≈ -5.0 atol=1e-10
+        @test sol[:inp] ≈ 0.5
+        @test sol[:out] ≈ -5.0 atol=1e-10
     end
 
     @testset "DC: Transresistance amplifier with CCVS" begin
@@ -592,7 +593,7 @@ using NyanVerilogAParser
         R1 out 0 1Meg
         """i)
         sol = dc!(circuit)
-        @test voltage(sol, :out) ≈ 1.0 atol=1e-6
+        @test sol[:out] ≈ 1.0 atol=1e-6
     end
 
     @testset "DC: Current mirror with CCCS" begin
@@ -608,7 +609,7 @@ using NyanVerilogAParser
         R1 out 0 1k
         """i)
         sol = dc!(circuit)
-        @test voltage(sol, :out) ≈ 2.0 atol=1e-10
+        @test sol[:out] ≈ 2.0 atol=1e-10
     end
 
     @testset "DC: Multi-node network" begin
@@ -626,7 +627,7 @@ using NyanVerilogAParser
         """i)
         sol = dc!(circuit)
         expected = 9.0 / (1.0 + 0.5 + 1.0/3.0)
-        @test voltage(sol, :center) ≈ expected atol=1e-10
+        @test sol[:center] ≈ expected atol=1e-10
     end
 
     #==========================================================================#
@@ -657,15 +658,15 @@ using NyanVerilogAParser
         ac_sol = solve_ac(sys, freqs)
 
         # At low frequency: Vout ≈ Vin
-        Vout_low = abs(voltage(ac_sol, :out, 1))
+        Vout_low = abs(ac_sol[:out, 1])
         @test Vout_low > 0.99
 
         # At cutoff: |Vout/Vin| ≈ 0.707
-        Vout_fc = abs(voltage(ac_sol, :out, 2))
+        Vout_fc = abs(ac_sol[:out, 2])
         @test Vout_fc ≈ 1.0/sqrt(2) atol=0.01
 
         # At high frequency: Vout << Vin
-        Vout_high = abs(voltage(ac_sol, :out, 3))
+        Vout_high = abs(ac_sol[:out, 3])
         @test Vout_high < 0.15
     end
 
@@ -693,15 +694,15 @@ using NyanVerilogAParser
         ac_sol = solve_ac(sys, freqs)
 
         # At low frequency: Vout << Vin (inductor is short)
-        Vout_low = abs(voltage(ac_sol, :out, 1))
+        Vout_low = abs(ac_sol[:out, 1])
         @test Vout_low < 0.15
 
         # At cutoff: |Vout/Vin| ≈ 0.707
-        Vout_fc = abs(voltage(ac_sol, :out, 2))
+        Vout_fc = abs(ac_sol[:out, 2])
         @test Vout_fc ≈ 1.0/sqrt(2) atol=0.01
 
         # At high frequency: Vout ≈ Vin (inductor is open)
-        Vout_high = abs(voltage(ac_sol, :out, 3))
+        Vout_high = abs(ac_sol[:out, 3])
         @test Vout_high > 0.99
     end
 
@@ -757,7 +758,7 @@ using NyanVerilogAParser
         R1 n1 0 1T
         """i)
         sol3 = dc!(circuit3)
-        @test voltage(sol3, :n1) ≈ 1.0
+        @test sol3[:n1] ≈ 1.0
 
         # Very small resistance
         circuit4 = MNACircuit(sp"""
@@ -766,7 +767,7 @@ using NyanVerilogAParser
         R2 n2 0 1u
         """i)
         sol4 = dc!(circuit4)
-        @test voltage(sol4, :n2) ≈ 2.5 atol=1e-6
+        @test sol4[:n2] ≈ 2.5 atol=1e-6
     end
 
     #==========================================================================#
@@ -1164,7 +1165,7 @@ using NyanVerilogAParser
 
         # Build and solve
         sol = solve_dc(circuit)
-        @test voltage(sol, :out) ≈ 5.0  # Voltage divider: Vcc * R2/(R1+R2)
+        @test sol[:out] ≈ 5.0  # Voltage divider: Vcc * R2/(R1+R2)
 
         # Alter parameters
         circuit2 = alter(circuit; R2=3000.0)
@@ -1172,7 +1173,7 @@ using NyanVerilogAParser
         @test circuit2.params.R1 == 1000.0  # Unchanged
 
         sol2 = solve_dc(circuit2)
-        @test voltage(sol2, :out) ≈ 7.5  # 10 * 3000/4000
+        @test sol2[:out] ≈ 7.5  # 10 * 3000/4000
 
         # Change mode
         circuit3 = with_mode(circuit, :dcop)
@@ -1205,7 +1206,7 @@ using NyanVerilogAParser
 
         # DC solution (capacitor is open circuit)
         sol = solve_dc(circuit)
-        @test voltage(sol, :out) ≈ 5.0  # At DC, capacitor is open
+        @test sol[:out] ≈ 5.0  # At DC, capacitor is open
 
         # AC sweep - cutoff fc = 1/(2πRC) ≈ 159Hz for R=1kΩ, C=1μF
         # At 10Hz (well below cutoff), gain should be ~1
@@ -1213,9 +1214,9 @@ using NyanVerilogAParser
         ac_sol = solve_ac(circuit, freqs)
 
         # At 10Hz (f << fc), gain ≈ 1 (within 1%)
-        @test abs(voltage(ac_sol, :out)[1]) > 0.99 * circuit.params.Vcc
+        @test abs(ac_sol[:out][1]) > 0.99 * circuit.params.Vcc
         # At 1000Hz (f >> fc), gain should be < 0.2 (rolloff)
-        @test abs(voltage(ac_sol, :out)[3]) < 0.2 * circuit.params.Vcc
+        @test abs(ac_sol[:out][3]) < 0.2 * circuit.params.Vcc
     end
 
     @testset "DC-initialized transient (ODE)" begin
@@ -1334,14 +1335,14 @@ using NyanVerilogAParser
 
         # Test 1: DC analysis with default mode (:tran)
         sol_dc = solve_dc(circuit)
-        @test voltage(sol_dc, :vcc) ≈ 5.0
-        @test voltage(sol_dc, :out) ≈ 5.0  # steady state
+        @test sol_dc[:vcc] ≈ 5.0
+        @test sol_dc[:out] ≈ 5.0  # steady state
 
         # Test 2: Change parameters using alter()
         circuit_modified = alter(circuit; R=2000.0, C=2e-6)
         sol_mod = solve_dc(circuit_modified)
-        @test voltage(sol_mod, :vcc) ≈ 5.0
-        @test voltage(sol_mod, :out) ≈ 5.0  # same DC, different dynamics
+        @test sol_mod[:vcc] ≈ 5.0
+        @test sol_mod[:out] ≈ 5.0  # same DC, different dynamics
 
         # Verify time constant changed: τ = R*C
         τ_original = 1000.0 * 1e-6   # 1ms
@@ -1351,13 +1352,13 @@ using NyanVerilogAParser
         # Test 3: Change Vcc parameter and verify DC changes
         circuit_highv = alter(circuit; Vcc=10.0)
         sol_highv = solve_dc(circuit_highv)
-        @test voltage(sol_highv, :out) ≈ 10.0
+        @test sol_highv[:out] ≈ 10.0
 
         # Test 4: Mode switching with with_mode()
         circuit_dcop = with_mode(circuit, :dcop)
         @test circuit_dcop.spec.mode == :dcop
         sol_dcop = solve_dc(circuit_dcop)
-        @test voltage(sol_dcop, :out) ≈ 5.0
+        @test sol_dcop[:out] ≈ 5.0
 
         # Test 5: Transient simulation with different parameters
         # Compare τ=1ms circuit vs τ=4ms circuit using high-level tran! API
@@ -1378,8 +1379,8 @@ using NyanVerilogAParser
         # Test 6: Chain multiple alterations
         circuit_chain = alter(alter(circuit; Vcc=3.3); R=4700.0)
         sol_chain = solve_dc(circuit_chain)
-        @test voltage(sol_chain, :vcc) ≈ 3.3
-        @test voltage(sol_chain, :out) ≈ 3.3
+        @test sol_chain[:vcc] ≈ 3.3
+        @test sol_chain[:out] ≈ 3.3
         @test circuit_chain.params.R == 4700.0
         @test circuit_chain.params.Vcc == 3.3
         @test circuit_chain.params.C == 1e-6  # unchanged from original
@@ -1452,14 +1453,14 @@ using NyanVerilogAParser
         # Test DC mode gives Vdc
         circuit_dcop = with_mode(circuit, :dcop)
         sol_dcop = solve_dc(circuit_dcop)
-        @test voltage(sol_dcop, :vcc) ≈ 0.0
-        @test voltage(sol_dcop, :out) ≈ 0.0
+        @test sol_dcop[:vcc] ≈ 0.0
+        @test sol_dcop[:out] ≈ 0.0
 
         # Test transient mode gives Vss
         circuit_tran = with_mode(circuit, :tran)
         sol_tran = solve_dc(circuit_tran)
-        @test voltage(sol_tran, :vcc) ≈ 5.0
-        @test voltage(sol_tran, :out) ≈ 5.0
+        @test sol_tran[:vcc] ≈ 5.0
+        @test sol_tran[:out] ≈ 5.0
 
         # Run transient from DC operating point
         # This simulates the typical SPICE flow:
@@ -1468,7 +1469,7 @@ using NyanVerilogAParser
 
         # First, get DC operating point (cap starts at 0V)
         dc_sol = dc!(circuit_dcop)
-        V_cap_dc = voltage(dc_sol, :out)
+        V_cap_dc = dc_sol[:out]
         @test V_cap_dc ≈ 0.0  # Cap at 0V in DC mode
 
         # Now run transient with source at 5V, cap starting at 0V
@@ -1549,20 +1550,20 @@ using NyanVerilogAParser
         # With identity lens: all defaults
         circuit_default = MNACircuit(build_with_lens; lens=IdentityLens())
         sol_default = dc!(circuit_default)
-        @test voltage(sol_default, :out) ≈ 2.5  # 5V * 1k/(1k+1k)
+        @test sol_default[:out] ≈ 2.5  # 5V * 1k/(1k+1k)
 
         # With partial override: only R1 changed
         override_lens = ParamLens((params=(R1=3000.0,),))
         circuit_override = MNACircuit(build_with_lens; lens=override_lens)
         sol_override = dc!(circuit_override)
         # Vout = 5V * R2/(R1+R2) = 5 * 1000/4000 = 1.25V
-        @test voltage(sol_override, :out) ≈ 1.25 rtol=1e-6
+        @test sol_override[:out] ≈ 1.25 rtol=1e-6
 
         # Verify R2 and Vcc still at defaults (unmodified)
         # We can check by computing what voltage would be with different values
         # If R2=2000: Vout = 5 * 2000/5000 = 2.0V (not what we see)
         # So R2 must be at default 1000
-        @test voltage(sol_override, :vcc) ≈ 5.0  # Vcc at default
+        @test sol_override[:vcc] ≈ 5.0  # Vcc at default
 
         # Test 5: Hierarchical lens traversal
         # lens.subcircuit returns a new lens for that subcircuit
@@ -1623,20 +1624,20 @@ using NyanVerilogAParser
                         spec=MNASpec(temp=27.0),
                         Vcc=10.0, R0=1000.0, tc=0.004, R2=1000.0)
         sol_27 = solve_dc(circuit_27)
-        @test voltage(sol_27, :out) ≈ 5.0  # Equal resistors
+        @test sol_27[:out] ≈ 5.0  # Equal resistors
 
         # At 127°C, R_temp = 1000 * (1 + 0.004*100) = 1400 Ω
         circuit_127 = with_temp(circuit_27, 127.0)
         @test circuit_127.spec.temp == 127.0
         sol_127 = solve_dc(circuit_127)
         # Voltage divider: Vout = Vcc * R2/(R_temp + R2) = 10 * 1000/2400 ≈ 4.167V
-        @test voltage(sol_127, :out) ≈ 10.0 * 1000.0 / 2400.0 rtol=1e-6
+        @test sol_127[:out] ≈ 10.0 * 1000.0 / 2400.0 rtol=1e-6
 
         # At -73°C, R_temp = 1000 * (1 + 0.004*(-100)) = 600 Ω
         circuit_m73 = with_temp(circuit_27, -73.0)
         sol_m73 = solve_dc(circuit_m73)
         # Voltage divider: Vout = 10 * 1000/1600 = 6.25V
-        @test voltage(sol_m73, :out) ≈ 10.0 * 1000.0 / 1600.0 rtol=1e-6
+        @test sol_m73[:out] ≈ 10.0 * 1000.0 / 1600.0 rtol=1e-6
 
         # Test with_spec
         new_spec = MNASpec(temp=85.0, mode=:dcop)
@@ -1657,7 +1658,7 @@ using NyanVerilogAParser
     #==========================================================================#
 
     # dc!/tran! are already imported at the top of this file from Cadnip
-    using Cadnip.MNA: MNASolutionAccessor, scope, NodeRef, ScopedSystem
+    using Cadnip.MNA:scope, NodeRef, ScopedSystem
 
     @testset "dc! and tran! API with MNACircuit" begin
         # Define a simple RC circuit
@@ -1683,7 +1684,7 @@ using NyanVerilogAParser
         # Test dc!(circuit) - matches Cadnip API
         dc_sol = dc!(circuit)
         @test dc_sol isa DCSolution
-        @test voltage(dc_sol, :out) ≈ 5.0  # DC steady state
+        @test dc_sol[:out] ≈ 5.0  # DC steady state
 
         # Test tran!(circuit, tspan) with ODE solver (Rodas5P)
         ode_sol = tran!(circuit, (0.0, 5τ); solver=Rodas5P(linsolve=KLUFactorization()))
@@ -1691,14 +1692,14 @@ using NyanVerilogAParser
 
         # Wrap for symbolic access
         sys = assemble!(circuit)
-        acc = MNASolutionAccessor(ode_sol, sys)
+        acc = ode_sol  # MNASolutionAccessor removed
 
         # Test voltage access by name
-        v_out_final = voltage(acc, :out, 5τ)
+        v_out_final = nameat(acc, :out, 5τ)
         @test v_out_final ≈ 5.0 rtol=1e-2  # Should stay at DC steady state
 
         # Test voltage trajectory
-        v_trajectory = voltage(acc, :out)
+        v_trajectory = acc[:out]
         @test length(v_trajectory) == length(acc.t)
 
         # Test acc[:name] syntax
@@ -1750,7 +1751,7 @@ using NyanVerilogAParser
 
         # Test with tran! using ODE solver
         ode_sol = tran!(circuit, (0.0, 1e-3); solver=Rodas5P(linsolve=KLUFactorization()))
-        acc = MNASolutionAccessor(ode_sol, sys)
+        acc = ode_sol  # MNASolutionAccessor removed
 
         # Access via NodeRef
         v_x1_out = acc[s.x1.out]
@@ -1761,7 +1762,7 @@ using NyanVerilogAParser
         @test v_x1_out == v_direct
 
         # Test voltage with NodeRef
-        v_at_t = voltage(acc, s.x1.out, 0.0)
+        v_at_t = nameat(acc, s.x1.out, 0.0)
         @test v_at_t isa Float64
     end
 
@@ -1855,7 +1856,7 @@ using NyanVerilogAParser
         circuit = MNACircuit(pwl_circuit)
         sol = dc!(circuit)
         # At t=0.5ms, PWL value = 2.5V
-        @test voltage(sol, :vcc) ≈ 2.5 atol=1e-10
+        @test sol[:vcc] ≈ 2.5 atol=1e-10
 
         # Test SIN voltage source stamping via builder pattern
         # At t=0.25ms (1/4 period of 1kHz), sin = 5*sin(90°) = 5
@@ -1873,7 +1874,7 @@ using NyanVerilogAParser
 
         circuit2 = MNACircuit(sin_circuit)
         sol2 = dc!(circuit2)
-        @test voltage(sol2, :vcc) ≈ 5.0 atol=1e-10
+        @test sol2[:vcc] ≈ 5.0 atol=1e-10
     end
 
     @testset "Time-dependent ODE with builder" begin

--- a/test/mna/laplace.jl
+++ b/test/mna/laplace.jl
@@ -93,7 +93,7 @@ end
     # Through 1Ω: V(out) = 1V
     # I(out) <+ 1.0 means 1A flowing out of 'out' node
     # With 1Ω to ground: V(out) = -1.0 (current leaves node)
-    @test abs(voltage(sol, :out)) ≈ 1.0 atol=0.01
+    @test abs(sol[:out]) ≈ 1.0 atol=0.01
 end
 
 @testset "idt() DC with non-zero initial condition" begin
@@ -125,7 +125,7 @@ end
     sol = dc!(circuit)
     # At DC, idt(0.0, 5.0) should return ic = 5.0
     # V(out) <+ 5.0 means V(out) - V(gnd) is constrained to 5.0
-    @test voltage(sol, :out) ≈ 5.0 atol=0.01
+    @test sol[:out] ≈ 5.0 atol=0.01
 end
 
 @testset "laplace_nd() AC frequency response" begin

--- a/test/mna/monostable_test.jl
+++ b/test/mna/monostable_test.jl
@@ -30,12 +30,15 @@
 using Test
 using Cadnip
 using Cadnip.MNA
-using Cadnip.MNA: MNACircuit, MNASolutionAccessor
-using Cadnip.MNA: voltage, assemble!, CedarDCOp, CedarUICOp
+using Cadnip.MNA: nameat
+using Cadnip.MNA: MNACircuit
+using Cadnip.MNA: assemble!, CedarDCOp, CedarUICOp
 using SciMLBase
-using Cadnip: tran!, parse_spice_to_mna
+using Cadnip: tran!
 using OrdinaryDiffEq: Rodas5P
 using LinearSolve: KLUFactorization
+
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 #==============================================================================#
 # Define simplified Ebers-Moll BJT (no internal nodes)
@@ -132,11 +135,11 @@ eval(monostable_code)
         @test sol.retcode == SciMLBase.ReturnCode.Success
 
         sys = assemble!(circuit)
-        acc = MNASolutionAccessor(sol, sys)
+        acc = sol  # MNASolutionAccessor removed — sol supports SII directly
 
         # Check stable state before trigger (t < 1ms)
-        v_q1_coll_before = voltage(acc, :q1_coll, 0.5e-3)
-        v_q2_coll_before = voltage(acc, :q2_coll, 0.5e-3)
+        v_q1_coll_before = nameat(acc, :q1_coll, 0.5e-3)
+        v_q2_coll_before = nameat(acc, :q2_coll, 0.5e-3)
 
         @info "Before trigger" v_q1_coll_before v_q2_coll_before
 
@@ -155,11 +158,11 @@ eval(monostable_code)
         try
             dc_sol = MNA.solve_dc(monostable_simple, (;), spec)
 
-            v_vcc = voltage(dc_sol, :vcc)
-            v_q1_base = voltage(dc_sol, :q1_base)
-            v_q1_coll = voltage(dc_sol, :q1_coll)
-            v_q2_base = voltage(dc_sol, :q2_base)
-            v_q2_coll = voltage(dc_sol, :q2_coll)
+            v_vcc = dc_sol[:vcc]
+            v_q1_base = dc_sol[:q1_base]
+            v_q1_coll = dc_sol[:q1_coll]
+            v_q2_base = dc_sol[:q2_base]
+            v_q2_coll = dc_sol[:q2_coll]
 
             @info "DC Operating Point" v_vcc v_q1_base v_q1_coll v_q2_base v_q2_coll
 

--- a/test/mna/oscillator_test.jl
+++ b/test/mna/oscillator_test.jl
@@ -9,10 +9,11 @@
 using Test
 using Cadnip
 using Cadnip.MNA
+using Cadnip.MNA: nameat
 using Cadnip.MNA: MNAContext, MNASpec, get_node!, stamp!, assemble!
-using Cadnip.MNA: voltage, current
+
 using Cadnip.MNA: VoltageSource, Resistor, Capacitor
-using Cadnip.MNA: MNACircuit, MNASolutionAccessor
+using Cadnip.MNA: MNACircuit
 using Cadnip.MNA: reset_for_restamping!, CedarUICOp
 using SciMLBase
 using Cadnip: tran!
@@ -98,7 +99,7 @@ C3 in1 0 10f
         @test sol.retcode == SciMLBase.ReturnCode.Success
 
         sys = assemble!(circuit)
-        acc = MNASolutionAccessor(sol, sys)
+        acc = sol  # MNASolutionAccessor removed — sol supports SII directly
 
         # Sample output voltages in the last half of simulation (after startup transient)
         t_start = 100e-9
@@ -106,9 +107,9 @@ C3 in1 0 10f
         n_samples = 1000
         times = range(t_start, t_end; length=n_samples)
 
-        V_out1 = [voltage(acc, :out1, t) for t in times]
-        V_out2 = [voltage(acc, :out2, t) for t in times]
-        V_in1 = [voltage(acc, :in1, t) for t in times]
+        V_out1 = [nameat(acc, :out1, t) for t in times]
+        V_out2 = [nameat(acc, :out2, t) for t in times]
+        V_in1 = [nameat(acc, :in1, t) for t in times]
 
         # Verify oscillation occurs - outputs should swing significantly
         out1_min, out1_max = extrema(V_out1)

--- a/test/mna/photonic.jl
+++ b/test/mna/photonic.jl
@@ -1,7 +1,7 @@
 using Test
 using Cadnip
 using Cadnip.MNA
-using Cadnip.MNA: MNAContext, MNASpec, get_node!, stamp!, voltage, current
+using Cadnip.MNA: MNAContext, MNASpec, get_node!, stamp!
 using Cadnip.MNA: VoltageSource, Resistor, MNACircuit
 using Cadnip: dc!
 using NyanVerilogAParser
@@ -157,8 +157,8 @@ const deftol = 1e-6
         sol = dc!(circuit)
 
         # Two 1k resistors in series: R_total = 2000Ω, I = 0.5mA
-        @test isapprox(voltage(sol, :vcc), 1.0; atol=deftol)
-        @test isapprox(current(sol, :I_V1), -0.0005; atol=1e-5)
+        @test isapprox(sol[:vcc], 1.0; atol=deftol)
+        @test isapprox(sol[:I_V1], -0.0005; atol=1e-5)
     end
 
     @testset "Array ports with slicing" begin
@@ -216,14 +216,14 @@ const deftol = 1e-6
         circuit = MNACircuit(array_circuit)
         sol = dc!(circuit)
 
-        @test isapprox(voltage(sol, :a0), 1.0; atol=deftol)
-        @test isapprox(voltage(sol, :a1), 2.0; atol=deftol)
-        @test isapprox(voltage(sol, :a2), 3.0; atol=deftol)
-        @test isapprox(voltage(sol, :a3), 4.0; atol=deftol)
-        @test abs(voltage(sol, :b0)) > 0.1
-        @test abs(voltage(sol, :b1)) > 0.1
-        @test abs(voltage(sol, :b2)) > 0.1
-        @test abs(voltage(sol, :b3)) > 0.1
+        @test isapprox(sol[:a0], 1.0; atol=deftol)
+        @test isapprox(sol[:a1], 2.0; atol=deftol)
+        @test isapprox(sol[:a2], 3.0; atol=deftol)
+        @test isapprox(sol[:a3], 4.0; atol=deftol)
+        @test abs(sol[:b0]) > 0.1
+        @test abs(sol[:b1]) > 0.1
+        @test abs(sol[:b2]) > 0.1
+        @test abs(sol[:b3]) > 0.1
     end
 
     @testset "Photonic-style: Polar2Cartesian + Attenuator" begin

--- a/test/mna/photonic_integration.jl
+++ b/test/mna/photonic_integration.jl
@@ -1,7 +1,7 @@
 using Test
 using Cadnip
 using Cadnip.MNA
-using Cadnip.MNA: MNAContext, get_node!, stamp!, MNACircuit, voltage, assemble!
+using Cadnip.MNA: MNAContext, get_node!, stamp!, MNACircuit, assemble!
 using Cadnip.MNA: VoltageSource, Resistor
 using Cadnip: dc!
 using PhotonicModels
@@ -284,7 +284,7 @@ end
         end
 
         sol = dc!(MNACircuit(circuit))
-        @test isapprox(voltage(sol, :ele_out), 1.0; atol=0.01)
+        @test isapprox(sol[:ele_out], 1.0; atol=0.01)
     end
 
     @testset "TunableFilter: DC passthrough (wavelength=1550)" begin
@@ -304,7 +304,7 @@ end
 
         sol = dc!(MNACircuit(circuit))
         # Forward path: in[0]=1.0 → CartMul1(×1) → laplace(DC≈1) → CartMul2(×1) → out[0]
-        @test isapprox(voltage(sol, :outp_0), 1.0; atol=0.1)
+        @test isapprox(sol[:outp_0], 1.0; atol=0.1)
     end
 
     @testset "TunableFilter: transient with \$abstime" begin

--- a/test/mna/precompile.jl
+++ b/test/mna/precompile.jl
@@ -9,7 +9,7 @@ using LinearAlgebra
 # Import MNA module - use Cadnip.MNA
 using Cadnip.MNA: MNAContext, get_node!, resolve_index, get_rhs, reset_for_restamping!
 using Cadnip.MNA: stamp!, Resistor, Capacitor, VoltageSource, Diode
-using Cadnip.MNA: MNASpec, DCSolution, solve_dc, voltage, current
+using Cadnip.MNA: MNASpec, DCSolution, solve_dc
 using Cadnip.MNA: compile_structure, create_workspace, EvalWorkspace, CompiledStructure
 using Cadnip.MNA: fast_residual!, fast_rebuild!, system_size
 using Cadnip.MNA: MNACircuit, compile
@@ -132,8 +132,8 @@ end
     sol = solve_dc(cs.builder, cs.params, MNASpec(mode=:dcop))
 
     # Check voltage divider: V_mid = V * R2 / (R1 + R2) = 10 * 0.5 = 5.0
-    @test voltage(sol, :mid) ≈ 5.0 atol=1e-10
-    @test voltage(sol, :vin) ≈ 10.0 atol=1e-10
+    @test sol[:mid] ≈ 5.0 atol=1e-10
+    @test sol[:vin] ≈ 10.0 atol=1e-10
 end
 
 @testset "EvalWorkspace with DC solve" begin
@@ -162,8 +162,8 @@ end
 
     # DC solve using builder
     sol = solve_dc(cs.builder, cs.params, MNASpec(mode=:dcop))
-    @test voltage(sol, :vin) ≈ 5.0 atol=1e-10
-    @test voltage(sol, :out) ≈ 5.0 atol=1e-10  # No load, so V_out = V_in
+    @test sol[:vin] ≈ 5.0 atol=1e-10
+    @test sol[:out] ≈ 5.0 atol=1e-10  # No load, so V_out = V_in
 end
 
 @testset "fast_residual! computation" begin
@@ -265,8 +265,8 @@ end
     sol2 = solve_dc(ws2.structure.builder, ws2.structure.params, MNASpec(mode=:dcop))
 
     # Current I = V/R
-    I1 = current(sol1, :I_V1)
-    I2 = current(sol2, :I_V1)
+    I1 = sol1[:I_V1]
+    I2 = sol2[:I_V1]
 
     @test I1 ≈ -10.0/1000.0 atol=1e-10  # Negative due to sign convention
     @test I2 ≈ -10.0/500.0 atol=1e-10

--- a/test/mna/psp103_integration.jl
+++ b/test/mna/psp103_integration.jl
@@ -18,7 +18,7 @@
 
 using Cadnip
 using Cadnip.NyanSpectreNetlistParser
-using Cadnip.MNA: MNAContext, MNASpec, solve_dc, voltage, current, n_internal_nodes
+using Cadnip.MNA: MNAContext, MNASpec, solve_dc, n_internal_nodes
 using PSPModels
 using Test
 
@@ -34,18 +34,18 @@ Vds d 0 DC 1.2
 Vgs g 0 DC 0.6
 """
         ast = NyanSpectreNetlistParser.parse(IOBuffer(netlist); start_lang=:spice, implicit_title=true)
-        code = Cadnip.make_mna_circuit(ast; imported_hdl_modules=[PSPModels])
+        code = Cadnip._make_mna_circuit_with_sema(Cadnip.sema(ast; imported_hdl_modules=[PSPModels]); circuit_name=:circuit)
         circuit_fn = eval(code)
         @test circuit_fn !== nothing
 
         spec = MNASpec(temp=27.0, mode=:dcop)
         sol = solve_dc(circuit_fn, (;), spec)
 
-        @test isapprox(voltage(sol, :d), 1.2, atol=1e-6)
-        @test isapprox(voltage(sol, :g), 0.6, atol=1e-6)
+        @test isapprox(sol[:d], 1.2, atol=1e-6)
+        @test isapprox(sol[:g], 0.6, atol=1e-6)
 
         # Drain current should be reasonable (100s of µA for these bias conditions)
-        Id = current(sol, :I_vds)
+        Id = sol[:I_vds]
         @test abs(Id) > 100e-6 && abs(Id) < 1e-3
     end
 
@@ -93,18 +93,18 @@ Vds d 0 DC 1.2
 Vgs g 0 DC 0.6
 """
         ast = NyanSpectreNetlistParser.parse(IOBuffer(netlist); start_lang=:spice, implicit_title=true)
-        code = Cadnip.make_mna_circuit(ast; imported_hdl_modules=[PSPModels])
+        code = Cadnip._make_mna_circuit_with_sema(Cadnip.sema(ast; imported_hdl_modules=[PSPModels]); circuit_name=:circuit)
         circuit_fn = eval(code)
         @test circuit_fn !== nothing
 
         spec = MNASpec(temp=27.0, mode=:dcop)
         sol = solve_dc(circuit_fn, (;), spec)
 
-        @test isapprox(voltage(sol, :d), 1.2, atol=1e-6)
-        @test isapprox(voltage(sol, :g), 0.6, atol=1e-6)
+        @test isapprox(sol[:d], 1.2, atol=1e-6)
+        @test isapprox(sol[:g], 0.6, atol=1e-6)
 
         # Current should be reasonable
-        Id = current(sol, :I_vds)
+        Id = sol[:I_vds]
         @test abs(Id) > 10e-6 && abs(Id) < 10e-3
     end
 
@@ -138,7 +138,7 @@ Vin2 in2 0 DC 0.3
 Vdd vdd 0 DC 1.2
 """
         ast = NyanSpectreNetlistParser.parse(IOBuffer(netlist); start_lang=:spice, implicit_title=true)
-        code = Cadnip.make_mna_circuit(ast; imported_hdl_modules=[PSPModels])
+        code = Cadnip._make_mna_circuit_with_sema(Cadnip.sema(ast; imported_hdl_modules=[PSPModels]); circuit_name=:circuit)
         circuit_fn = eval(code)
 
         # Build structure and check internal nodes

--- a/test/mna/subckt_scoping.jl
+++ b/test/mna/subckt_scoping.jl
@@ -1,0 +1,110 @@
+module subckt_scoping_tests
+
+include(joinpath(@__DIR__, "..", "common.jl"))
+
+using Test
+using Cadnip
+using Cadnip.MNA: MNACircuit
+
+# Regression test for subckt internal-node namespacing.
+# Before the fix, two instances of the same subckt shared internal nodes in the
+# flat MNAContext map — effectively shorting their internals together.
+# After the fix, each instance's internal nodes are scoped by the instance name
+# via the `_mna_prefix_` mechanism (e.g., :x1_mid, :x2_mid).
+
+@testset "subckt scoping: flat, two instances" begin
+    # Two 2+2=4Ω chains in series through :a → 8Ω total.
+    # V_vcc=12 → I=1.5 A → V(a)=6, V(x1.mid)=9, V(x2.mid)=3.
+    circuit = MNACircuit(spc"""
+    subckt myres (p n)
+        r1 (p mid) resistor r=2
+        r2 (mid n) resistor r=2
+    ends myres
+
+    v1 (vcc 0) vsource dc=12
+    x1 (vcc a) myres
+    x2 (a 0) myres
+    """)
+    sol = dc!(circuit)
+
+    @test Set(sol.node_names) == Set([:vcc, :a, :x1_mid, :x2_mid])
+    @test isapprox(sol[:vcc], 12.0;   atol=1e-8)
+    @test isapprox(sol[:a],    6.0;   atol=1e-8)
+    @test isapprox(sol[:x1_mid], 9.0; atol=1e-8)
+    @test isapprox(sol[:x2_mid], 3.0; atol=1e-8)
+end
+
+@testset "subckt scoping: nested, two outer × two inner" begin
+    # outer contains xi1,xi2 → inner. Two outer instances xo1, xo2 share :a.
+    # Each inner's :mid should be uniquely scoped down to e.g. :xo1_xi1_mid.
+    # Resistor chain: 4 × 2Ω per outer = 8Ω, two outers in series = 16Ω.
+    # V_vcc=16 → I=1 A → V(a)=8, each outer's inner-series midpoint…
+    circuit = MNACircuit(spc"""
+    subckt inner (p n)
+        r1 (p mid) resistor r=1
+        r2 (mid n) resistor r=1
+    ends inner
+
+    subckt outer (p n)
+        xi1 (p mid) inner
+        xi2 (mid n) inner
+    ends outer
+
+    v1 (vcc 0) vsource dc=16
+    xo1 (vcc a) outer
+    xo2 (a 0) outer
+    """)
+    sol = dc!(circuit)
+
+    # Expected internal node names: top-level :vcc, :a, plus scoped nodes per (outer, inner).
+    expected = Set([
+        :vcc, :a,
+        :xo1_mid, :xo1_xi1_mid, :xo1_xi2_mid,
+        :xo2_mid, :xo2_xi1_mid, :xo2_xi2_mid,
+    ])
+    @test Set(sol.node_names) == expected
+
+    # Voltage divider math:
+    #   total R = 8 × 2Ω paths … wait, each inner is 1+1=2Ω, outer=2+2=4Ω, two outers in series → 8Ω.
+    #   I = 16/8 = 2 A, V(a) = 16 - 4*2 = 8.
+    #   xo1.mid is between xo1's two inner subckts → at V = 16 - 2*2 = 12.
+    #   xo1.xi1.mid is the midpoint of the first inner in xo1 → (vcc + xo1_mid)/2 = 14.
+    #   xo1.xi2.mid is midpoint of second inner in xo1 → (xo1_mid + a)/2 = 10.
+    #   xo2.mid = (a + 0)/2 = 4.
+    #   xo2.xi1.mid = (a + xo2_mid)/2 = 6.
+    #   xo2.xi2.mid = (xo2_mid + 0)/2 = 2.
+    @test isapprox(sol[:vcc], 16.0; atol=1e-8)
+    @test isapprox(sol[:a],    8.0; atol=1e-8)
+    @test isapprox(sol[:xo1_mid],     12.0; atol=1e-8)
+    @test isapprox(sol[:xo1_xi1_mid], 14.0; atol=1e-8)
+    @test isapprox(sol[:xo1_xi2_mid], 10.0; atol=1e-8)
+    @test isapprox(sol[:xo2_mid],      4.0; atol=1e-8)
+    @test isapprox(sol[:xo2_xi1_mid],  6.0; atol=1e-8)
+    @test isapprox(sol[:xo2_xi2_mid],  2.0; atol=1e-8)
+end
+
+@testset "subckt scoping: device name= scoped too" begin
+    # Two subckt instances, each with a named voltage source inside.
+    # After scoping, the two current names should be :I_x1_vinner and :I_x2_vinner.
+    circuit = MNACircuit(spc"""
+    subckt arm (out)
+        vinner (mid 0) vsource dc=3
+        r (out mid) resistor r=1
+    ends arm
+
+    x1 (a) arm
+    x2 (b) arm
+    r_load1 (a 0) resistor r=1
+    r_load2 (b 0) resistor r=1
+    """)
+    sol = dc!(circuit)
+
+    @test :I_x1_vinner ∈ sol.current_names
+    @test :I_x2_vinner ∈ sol.current_names
+    # Each arm independently drives its load through 1Ω + 1Ω (series with internal v=3).
+    # Steady state: v_internal holds mid=3 through 1Ω series + 1Ω load → V(a) = 1.5.
+    @test isapprox(sol[:a], 1.5; atol=1e-8)
+    @test isapprox(sol[:b], 1.5; atol=1e-8)
+end
+
+end # module

--- a/test/mna/va.jl
+++ b/test/mna/va.jl
@@ -8,7 +8,7 @@ using Test
 using Cadnip
 using Cadnip.MNA
 using Cadnip.MNA: MNAContext, MNASpec, get_node!, stamp!, assemble!
-using Cadnip.MNA: voltage, current, make_ode_problem, MNACircuit
+using Cadnip.MNA: make_ode_problem, MNACircuit
 using Cadnip: dc!
 using Cadnip.MNA: va_ddt, stamp_current_contribution!, evaluate_contribution, ContributionTag, JacobianTag
 using Cadnip.MNA: VoltageSource, Resistor  # Use MNA versions explicitly
@@ -253,8 +253,8 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
 
         # V = 5V, R = 2000Ω, I = 2.5mA
         # Voltage source current = -2.5mA (negative = sourcing)
-        @test isapprox_deftol(voltage(sol, :vcc), 5.0)
-        @test isapprox(current(sol, :I_V1), -0.0025; atol=1e-5)
+        @test isapprox_deftol(sol[:vcc], 5.0)
+        @test isapprox(sol[:I_V1], -0.0025; atol=1e-5)
     end
 
     @testset "VA capacitor transient" begin
@@ -354,8 +354,8 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
         # DC solution: I = V/R = 5/1000 = 5mA
         circuit = MNACircuit(va_parallel_rc_circuit)
         sol = dc!(circuit)
-        @test isapprox_deftol(voltage(sol, :vcc), 5.0)
-        @test isapprox(current(sol, :I_V1), -0.005; atol=1e-5)
+        @test isapprox_deftol(sol[:vcc], 5.0)
+        @test isapprox(sol[:I_V1], -0.005; atol=1e-5)
     end
 
 end

--- a/test/mna/va_mosfet.jl
+++ b/test/mna/va_mosfet.jl
@@ -13,7 +13,7 @@ using Test
 using Cadnip
 using Cadnip.MNA
 using Cadnip.MNA: MNAContext, MNASpec, get_node!, stamp!, assemble!, solve_dc
-using Cadnip.MNA: voltage, current, make_ode_problem
+using Cadnip.MNA: make_ode_problem
 using Cadnip.MNA: va_ddt, stamp_current_contribution!, evaluate_contribution
 using Cadnip.MNA: VoltageSource, CurrentSource, Resistor
 using ForwardDiff: Dual, value, partials
@@ -65,12 +65,12 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
         sol = solve_dc(vccs_test_circuit, (;), MNASpec())
 
         # Check voltages
-        @test isapprox(voltage(sol, :g), 1.0; atol=1e-6)
-        @test isapprox(voltage(sol, :d), 5.0; atol=1e-6)
+        @test isapprox(sol[:g], 1.0; atol=1e-6)
+        @test isapprox(sol[:d], 5.0; atol=1e-6)
 
         # Check current: I_Vdd should supply the VCCS current
         # Id = gm * Vgs = 0.002 * 1.0 = 2mA
-        I_Vdd = current(sol, :I_Vdd)
+        I_Vdd = sol[:I_Vdd]
         @test isapprox(I_Vdd, -0.002; atol=1e-5)  # Negative because sourcing
     end
 
@@ -131,11 +131,11 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
 
         sol = solve_dc(simple_mos_circuit, (;), MNASpec())
 
-        @test isapprox(voltage(sol, :g), 1.5; atol=1e-6)
-        @test isapprox(voltage(sol, :d), 2.0; atol=1e-6)
+        @test isapprox(sol[:g], 1.5; atol=1e-6)
+        @test isapprox(sol[:d], 2.0; atol=1e-6)
 
         # Drain current: Ids = K/2 * (1.5 - 0.5)^2 = 0.5mA
-        I_Vd = current(sol, :I_Vd)
+        I_Vd = sol[:I_Vd]
         @test isapprox(I_Vd, -0.0005; atol=1e-5)  # Negative = sourcing
     end
 
@@ -161,10 +161,10 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
 
         sol = solve_dc(simple_mos_linear_circuit, (;), MNASpec())
 
-        @test isapprox(voltage(sol, :d), 0.3; atol=1e-6)
+        @test isapprox(sol[:d], 0.3; atol=1e-6)
 
         # Ids = K * (Vov * Vds - Vds^2/2) = 0.001 * (1.0 * 0.3 - 0.09/2) = 0.000255
-        I_Vd = current(sol, :I_Vd)
+        I_Vd = sol[:I_Vd]
         @test isapprox(I_Vd, -0.000255; atol=1e-6)
     end
 
@@ -189,7 +189,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
         sol = solve_dc(simple_mos_cutoff_circuit, (;), MNASpec())
 
         # No current in cutoff
-        I_Vd = current(sol, :I_Vd)
+        I_Vd = sol[:I_Vd]
         @test isapprox(I_Vd, 0.0; atol=1e-8)
     end
 
@@ -251,7 +251,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
         sol = solve_dc(cap_mos_dc_circuit, (;), MNASpec())
 
         # Same as SimpleMOS in saturation
-        I_Vd = current(sol, :I_Vd)
+        I_Vd = sol[:I_Vd]
         @test isapprox(I_Vd, -0.0005; atol=1e-5)
 
         # Check that capacitances are stamped into C matrix
@@ -412,7 +412,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
         # - PMOS on (Vsg = Vdd - 0 = 3V > Vth)
         # - NMOS off (Vgs = 0 < Vth)
         # - Output pulled to Vdd
-        @test isapprox(voltage(sol, :out), Vdd; atol=0.01)
+        @test isapprox(sol[:out], Vdd; atol=0.01)
     end
 
     @testset "CMOS Inverter HIGH input" begin
@@ -450,7 +450,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
         # - PMOS off (Vsg = 0 < Vth)
         # - NMOS on (Vgs = Vdd > Vth)
         # - Output pulled to 0V
-        @test isapprox(voltage(sol, :out), 0.0; atol=0.01)
+        @test isapprox(sol[:out], 0.0; atol=0.01)
     end
 
     #==========================================================================#

--- a/test/mna/va_spice.jl
+++ b/test/mna/va_spice.jl
@@ -20,7 +20,7 @@ using Test
 using Cadnip
 using Cadnip.MNA
 using Cadnip.MNA: MNAContext, MNASpec, get_node!, stamp!, assemble!
-using Cadnip.MNA: voltage, current, MNACircuit
+using Cadnip.MNA: MNACircuit
 using Cadnip: dc!
 using Cadnip.MNA: VoltageSource, Resistor
 
@@ -57,8 +57,8 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
         ctx, sol = solve_mna_spice_code(spice; imported_hdl_modules=[varesistor_module])
 
         # Voltage divider: 10V * (2k / (2k + 2k)) = 5V
-        @test isapprox_deftol(voltage(sol, :vcc), 10.0)
-        @test isapprox_deftol(voltage(sol, :mid), 5.0)
+        @test isapprox_deftol(sol[:vcc], 10.0)
+        @test isapprox_deftol(sol[:mid], 5.0)
     end
 
     @testset "VA capacitor in SPICE RC network" begin
@@ -81,8 +81,8 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
         ctx, sol = solve_mna_spice_code(spice; imported_hdl_modules=[vacapacitor_module])
 
         # DC: capacitor is open, V(cap) = V(vcc) = 5V
-        @test isapprox_deftol(voltage(sol, :vcc), 5.0)
-        @test isapprox_deftol(voltage(sol, :cap), 5.0)
+        @test isapprox_deftol(sol[:vcc], 5.0)
+        @test isapprox_deftol(sol[:cap], 5.0)
 
         # Verify capacitance is stamped
         sys = assemble!(ctx)
@@ -123,8 +123,8 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
         # Total R = 4k, I = 10/4k = 2.5mA
         # V(n1) = 10 - 2.5mA * 1k = 7.5V
         # V(n2) = 7.5 - 2.5mA * 2k = 2.5V
-        @test isapprox(voltage(sol, :n1), 7.5; atol=0.01)
-        @test isapprox(voltage(sol, :n2), 2.5; atol=0.01)
+        @test isapprox(sol[:n1], 7.5; atol=0.01)
+        @test isapprox(sol[:n2], 2.5; atol=0.01)
     end
 
 end
@@ -154,8 +154,8 @@ end
 
         ctx, sol = solve_mna_spectre_code(spectre; imported_hdl_modules=[spectreres_module])
 
-        @test isapprox_deftol(voltage(sol, :vcc), 10.0)
-        @test isapprox_deftol(voltage(sol, :mid), 5.0)
+        @test isapprox_deftol(sol[:vcc], 10.0)
+        @test isapprox_deftol(sol[:mid], 5.0)
     end
 
     @testset "VA parallel RC in Spectre" begin
@@ -177,9 +177,9 @@ end
 
         ctx, sol = solve_mna_spectre_code(spectre; imported_hdl_modules=[spectrerc_module])
 
-        @test isapprox_deftol(voltage(sol, :vcc), 5.0)
+        @test isapprox_deftol(sol[:vcc], 5.0)
         # I = V/R = 5/500 = 10mA
-        @test isapprox(current(sol, :I_v1), -0.01; atol=1e-5)
+        @test isapprox(sol[:I_v1], -0.01; atol=1e-5)
     end
 
     @testset "Mixed VA and native Spectre devices" begin
@@ -205,8 +205,8 @@ end
         # Total R = 4k, I = 12/4k = 3mA
         # V(n1) = 12 - 3mA * 1k = 9V
         # V(n2) = 9 - 3mA * 2k = 3V
-        @test isapprox(voltage(sol, :n1), 9.0; atol=0.01)
-        @test isapprox(voltage(sol, :n2), 3.0; atol=0.01)
+        @test isapprox(sol[:n1], 9.0; atol=0.01)
+        @test isapprox(sol[:n2], 3.0; atol=0.01)
     end
 
 end
@@ -242,10 +242,10 @@ using PhotonicModels
         ctx, sol = solve_mna_spectre_code(spectre;
             imported_hdl_modules=[PhotonicModels.Polar2Cartesian_module])
 
-        @test isapprox(voltage(sol, :pol_0), 1.0; atol=0.01)
-        @test isapprox(voltage(sol, :pol_1), 0.0; atol=0.01)
-        @test isapprox(voltage(sol, :cart_0), 1.0; atol=0.01)
-        @test isapprox(voltage(sol, :cart_1), 0.0; atol=0.01)
+        @test isapprox(sol[:pol_0], 1.0; atol=0.01)
+        @test isapprox(sol[:pol_1], 0.0; atol=0.01)
+        @test isapprox(sol[:cart_0], 1.0; atol=0.01)
+        @test isapprox(sol[:cart_1], 0.0; atol=0.01)
     end
 
     @testset "Array port VA model in SPICE netlist" begin
@@ -261,10 +261,10 @@ using PhotonicModels
         ctx, sol = solve_mna_spice_code(spice;
             imported_hdl_modules=[PhotonicModels.Polar2Cartesian_module])
 
-        @test isapprox(voltage(sol, :pol_0), 1.0; atol=0.01)
-        @test isapprox(voltage(sol, :pol_1), 0.0; atol=0.01)
-        @test isapprox(voltage(sol, :cart_0), 1.0; atol=0.01)
-        @test isapprox(voltage(sol, :cart_1), 0.0; atol=0.01)
+        @test isapprox(sol[:pol_0], 1.0; atol=0.01)
+        @test isapprox(sol[:pol_1], 0.0; atol=0.01)
+        @test isapprox(sol[:cart_0], 1.0; atol=0.01)
+        @test isapprox(sol[:cart_1], 0.0; atol=0.01)
     end
 
     @testset "Array port VA model with nonzero phase" begin
@@ -282,8 +282,8 @@ using PhotonicModels
             imported_hdl_modules=[PhotonicModels.Polar2Cartesian_module])
 
         expected = 2.0 * cos(π/4)  # ≈ 1.4142
-        @test isapprox(voltage(sol, :cart_0), expected; atol=0.01)
-        @test isapprox(voltage(sol, :cart_1), expected; atol=0.01)
+        @test isapprox(sol[:cart_0], expected; atol=0.01)
+        @test isapprox(sol[:cart_1], expected; atol=0.01)
     end
 
     @testset "Mixed electrical and photonic VA devices" begin
@@ -305,10 +305,10 @@ using PhotonicModels
             imported_hdl_modules=[PhotonicModels.Polar2Cartesian_module])
 
         # Electrical divider
-        @test isapprox(voltage(sol, :mid), 5.0; atol=0.01)
+        @test isapprox(sol[:mid], 5.0; atol=0.01)
         # Photonic output: amplitude=5V, phase=0 -> cart_0=5, cart_1=0
-        @test isapprox(voltage(sol, :cart_0), 5.0; atol=0.01)
-        @test isapprox(voltage(sol, :cart_1), 0.0; atol=0.01)
+        @test isapprox(sol[:cart_0], 5.0; atol=0.01)
+        @test isapprox(sol[:cart_1], 0.0; atol=0.01)
     end
 
 end
@@ -350,8 +350,8 @@ end
         circuit = MNACircuit(directres_circuit)
         sol = dc!(circuit)
 
-        @test isapprox_deftol(voltage(sol, :vcc), 10.0)
-        @test isapprox_deftol(voltage(sol, :mid), 5.0)
+        @test isapprox_deftol(sol[:vcc], 10.0)
+        @test isapprox_deftol(sol[:mid], 5.0)
     end
 
     @testset "VA module chain" begin
@@ -385,8 +385,8 @@ end
         sol = dc!(circuit)
 
         # Total = 4k, I = 10V/4k = 2.5mA
-        @test isapprox(voltage(sol, :n1), 7.5; atol=0.01)
-        @test isapprox(voltage(sol, :n2), 2.5; atol=0.01)
+        @test isapprox(sol[:n1], 7.5; atol=0.01)
+        @test isapprox(sol[:n2], 2.5; atol=0.01)
     end
 
 end

--- a/test/mna/vadistiller.jl
+++ b/test/mna/vadistiller.jl
@@ -14,7 +14,7 @@ using Test
 using Cadnip
 using Cadnip.MNA
 using Cadnip.MNA: MNAContext, MNASpec, get_node!, stamp!, assemble!
-using Cadnip.MNA: voltage, current, make_ode_problem, MNACircuit
+using Cadnip.MNA: make_ode_problem, MNACircuit
 using Cadnip: dc!
 using Cadnip.MNA: va_ddt, stamp_current_contribution!, evaluate_contribution
 using Cadnip.MNA: VoltageSource, Resistor, Capacitor, CurrentSource
@@ -66,9 +66,9 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
             circuit = MNACircuit(resistor_divider)
             sol = dc!(circuit)
 
-            @test isapprox_deftol(voltage(sol, :vcc), 5.0)
-            @test isapprox_deftol(voltage(sol, :mid), 2.5)  # Voltage divider
-            @test isapprox(current(sol, :I_V1), -0.0025; atol=1e-5)  # 5V / 2kΩ
+            @test isapprox_deftol(sol[:vcc], 5.0)
+            @test isapprox_deftol(sol[:mid], 2.5)  # Voltage divider
+            @test isapprox(sol[:I_V1], -0.0025; atol=1e-5)  # 5V / 2kΩ
         end
 
         @testset "Simple capacitor" begin
@@ -170,7 +170,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
             # Expected: I = 1e-14 * (exp(0.6/0.02585) - 1) ≈ 1.05e-4 A
             Vt = 0.02585
             expected_I = 1e-14 * (exp(0.6/Vt) - 1)
-            actual_I = -current(sol, :I_V1)  # Negative because V1 sources current
+            actual_I = -sol[:I_V1]  # Negative because V1 sources current
             @test isapprox(actual_I, expected_I; rtol=0.01)
         end
 
@@ -213,7 +213,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
             # V_internal ≈ 0.6V (drops ~0.1V across Rs)
             # I ≈ 10mA (rough estimate)
             # The exact current depends on Newton convergence
-            actual_I = -current(sol, :I_V1)
+            actual_I = -sol[:I_V1]
             @test actual_I > 0  # Current should flow
             @test actual_I < 0.1  # Should be less than 100mA
         end
@@ -267,7 +267,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
 
             # Ids = gm * Vgs = 1e-3 * 1.0 = 1mA
             # Vdrain = Vdd - Ids * Rd = 5 - 1e-3 * 1000 = 4V
-            @test isapprox(voltage(sol, :drain), 4.0; atol=0.01)
+            @test isapprox(sol[:drain], 4.0; atol=0.01)
         end
 
         @testset "Simple square-law MOSFET" begin
@@ -308,7 +308,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
 
             # Ids = (1e-4/2) * (1.5 - 0.5)² = 0.5e-4 * 1 = 50µA
             # Vdrain = 5 - 50e-6 * 10000 = 5 - 0.5 = 4.5V
-            @test isapprox(voltage(sol, :drain), 4.5; atol=0.1)
+            @test isapprox(sol[:drain], 4.5; atol=0.1)
         end
 
     end
@@ -356,7 +356,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
             sol = solve_dc(nmos4_circuit, (;), MNASpec())
 
             # Same result as 3-terminal MOSFET
-            @test isapprox(voltage(sol, :drain), 4.5; atol=0.1)
+            @test isapprox(sol[:drain], 4.5; atol=0.1)
         end
 
     end
@@ -410,8 +410,8 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
 
             # Ids = (1e-4/2) * (2.0 - 0.5)² = 0.5e-4 * 2.25 = 112.5µA
             # Vdrain = 5 - 112.5e-6 * 10000 = 5 - 1.125 = 3.875V
-            @test isapprox(voltage(sol, :drain), 3.875; atol=0.1)
-            @test isapprox(voltage(sol, :gate), 2.0; atol=1e-6)
+            @test isapprox(sol[:drain], 3.875; atol=0.1)
+            @test isapprox(sol[:gate], 2.0; atol=1e-6)
         end
 
         @testset "MOSFET with gate capacitances (Transient)" begin
@@ -510,7 +510,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
             # With small Rs/Rd, drain voltage should be close to ideal MOSFET
             # Ids ≈ 112.5µA, voltage drops: Ids*Rs ≈ 1.1mV, Ids*Rd ≈ 1.1mV
             # So drain voltage should be very close to 3.875V
-            @test isapprox(voltage(sol, :drain), 3.875; atol=0.1)
+            @test isapprox(sol[:drain], 3.875; atol=0.1)
         end
 
         @testset "MOSFET with capacitances AND internal nodes" begin
@@ -561,7 +561,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
             end
 
             sol_dc = solve_dc(mosfull_dc_circuit, (;), MNASpec())
-            @test isapprox(voltage(sol_dc, :drain), 3.875; atol=0.1)
+            @test isapprox(sol_dc[:drain], 3.875; atol=0.1)
 
             # Transient test
             function mosfull_tran_circuit(params, spec, t::Real=0.0; x=Float64[], ctx=nothing)
@@ -635,7 +635,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
 
             # At Vgs=2.5V: Ids = (1e-4/2) * (2.5-0.5)² = 200µA
             # Vout = 5 - 200e-6 * 10000 = 3V
-            @test isapprox(voltage(sol_dc, :vout), 3.0; atol=0.2)
+            @test isapprox(sol_dc[:vout], 3.0; atol=0.2)
 
             # Verify capacitances are present in the system matrix
             ctx = inverter_circuit((;), MNASpec(mode=:tran))
@@ -693,14 +693,14 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
             sol = solve_dc(temp_resistor_circuit, (;), spec)
             # R = 1000 * (1 + 0.004 * (300.15 - 300)) = 1000 * 1.0006 ≈ 1000.6
             # I = 5V / 1000.6 ≈ 0.005
-            @test isapprox(current(sol, :I_V1), -0.005; atol=1e-4)
+            @test isapprox(sol[:I_V1], -0.005; atol=1e-4)
 
             # At 100°C (373.15K), resistance should be higher
             spec_hot = MNASpec(temp=100.0)
             sol_hot = solve_dc(temp_resistor_circuit, (;), spec_hot)
             # R = 1000 * (1 + 0.004 * (373.15 - 300)) = 1000 * 1.293 ≈ 1292.6
             # I = 5V / 1292.6 ≈ 0.00387
-            @test isapprox(current(sol_hot, :I_V1), -0.00387; atol=1e-4)
+            @test isapprox(sol_hot[:I_V1], -0.00387; atol=1e-4)
         end
 
         @testset "\$simparam access" begin
@@ -736,13 +736,13 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
             spec = MNASpec()
             sol = solve_dc(gmin_circuit, (;), spec)
             # I ≈ 5/1000 + 5*1e-12 ≈ 0.005
-            @test isapprox(current(sol, :I_V1), -0.005; atol=1e-6)
+            @test isapprox(sol[:I_V1], -0.005; atol=1e-6)
 
             # With custom gmin=1e-3 (very high for testing)
             spec_gmin = MNASpec(gmin=1e-3)
             sol_gmin = solve_dc(gmin_circuit, (;), spec_gmin)
             # I = 5/1000 + 5*1e-3 = 0.005 + 0.005 = 0.01
-            @test isapprox(current(sol_gmin, :I_V1), -0.01; atol=1e-6)
+            @test isapprox(sol_gmin[:I_V1], -0.01; atol=1e-6)
         end
 
         @testset "\$param_given check" begin
@@ -776,7 +776,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
             end, (;), MNASpec())
             # $param_given(R) is true, so uses R=2000
             # I = 5V / 2000Ω = 0.0025A
-            @test isapprox(current(sol_explicit, :I_V1), -0.0025; atol=1e-6)
+            @test isapprox(sol_explicit[:I_V1], -0.0025; atol=1e-6)
 
             # With only Ralt given (R is NOT "given")
             sol_default = solve_dc((p,s,t=0.0; x=Float64[], ctx=nothing) -> begin
@@ -792,7 +792,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
             end, (;), MNASpec())
             # $param_given(R) is false, so uses Ralt=500
             # I = 5V / 500Ω = 0.01A
-            @test isapprox(current(sol_default, :I_V1), -0.01; atol=1e-6)
+            @test isapprox(sol_default[:I_V1], -0.01; atol=1e-6)
         end
 
     end
@@ -831,7 +831,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
         end, (;), MNASpec())
         # R = 1000 * (1 + 0.001 * (100 - 27)) = 1000 * 1.073 = 1073
         # I = 5V / 1073Ω ≈ 0.00466A
-        @test isapprox(current(sol_tnom, :I_V1), -0.00466; atol=1e-4)
+        @test isapprox(sol_tnom[:I_V1], -0.00466; atol=1e-4)
 
         # Test 2: Using the alias (tref) - should have same effect as tnom
         sol_tref = solve_dc((p,s,t=0.0; x=Float64[], ctx=nothing) -> begin
@@ -846,7 +846,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
             return ctx
         end, (;), MNASpec())
         # Same result - alias forwards to tnom
-        @test isapprox(current(sol_tref, :I_V1), -0.00466; atol=1e-4)
+        @test isapprox(sol_tref[:I_V1], -0.00466; atol=1e-4)
 
         # Test 3: Verify property access - dev.tref should return dev.tnom
         dev = VAAliasTest(tnom=50.0)
@@ -894,9 +894,9 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
             circuit = MNACircuit(var_init_divider)
             sol = dc!(circuit)
 
-            @test isapprox_deftol(voltage(sol, :vcc), 5.0)
-            @test isapprox_deftol(voltage(sol, :mid), 2.5)  # Voltage divider
-            @test isapprox(current(sol, :I_V1), -0.0025; atol=1e-5)  # 5V / 2kΩ
+            @test isapprox_deftol(sol[:vcc], 5.0)
+            @test isapprox_deftol(sol[:mid], 2.5)  # Voltage divider
+            @test isapprox(sol[:I_V1], -0.0025; atol=1e-5)  # 5V / 2kΩ
         end
 
         @testset "Real variable with non-zero initialization" begin
@@ -930,9 +930,9 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
             circuit = MNACircuit(var_init_offset)
             sol = dc!(circuit)
 
-            @test isapprox_deftol(voltage(sol, :vcc), 4.5)
+            @test isapprox_deftol(sol[:vcc], 4.5)
             # Current should be (4.5 + 0.5) / 1000 = 5mA
-            @test isapprox(current(sol, :I_V1), -0.005; atol=1e-5)
+            @test isapprox(sol[:I_V1], -0.005; atol=1e-5)
         end
 
         @testset "Internal nodes" begin
@@ -972,8 +972,8 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
 
             # With two 1kΩ in series across 10V:
             # Total R = 2kΩ, I = 10V / 2kΩ = 5mA
-            @test isapprox(current(sol, :I_V1), -0.005; atol=1e-5)
-            @test isapprox(voltage(sol, :vcc), 10.0; atol=1e-6)
+            @test isapprox(sol[:I_V1], -0.005; atol=1e-5)
+            @test isapprox(sol[:vcc], 10.0; atol=1e-6)
 
             # Test 2: Multiple internal nodes (3 resistors in series)
             va"""
@@ -1007,7 +1007,7 @@ isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
 
             # With three 1kΩ in series across 9V:
             # Total R = 3kΩ, I = 9V / 3kΩ = 3mA
-            @test isapprox(current(sol2, :I_V1), -0.003; atol=1e-5)
+            @test isapprox(sol2[:I_V1], -0.003; atol=1e-5)
         end
 
     end

--- a/test/mna/vadistiller_integration.jl
+++ b/test/mna/vadistiller_integration.jl
@@ -14,20 +14,22 @@
 using Test
 using Cadnip
 using Cadnip.MNA
+using Cadnip.MNA: nameat
 using Cadnip.MNA: MNAContext, MNASpec, get_node!, stamp!, assemble!
-using Cadnip.MNA: voltage, current, make_ode_problem
+using Cadnip.MNA: make_ode_problem
 using Cadnip.MNA: VoltageSource, Resistor, Capacitor, CurrentSource
-using Cadnip.MNA: MNACircuit, MNASolutionAccessor
+using Cadnip.MNA: MNACircuit
 using Cadnip.MNA: reset_for_restamping!, CedarUICOp, CedarDCOp
 using ForwardDiff: Dual, value, partials
 using OrdinaryDiffEq: QNDF, Rodas5P
 using Sundials: IDA
 using LinearSolve: KLUFactorization
 using SciMLBase
-using Cadnip: tran!, dc!, parse_spice_to_mna
-
+using Cadnip: tran!, dc!
 # Import pre-parsed models from VADistillerModels package
 using VADistillerModels
+
+include(joinpath(@__DIR__, "..", "common.jl"))
 
 const deftol = 1e-6
 isapprox_deftol(a, b) = isapprox(a, b; atol=deftol, rtol=deftol)
@@ -109,8 +111,8 @@ Q2 q2_coll q2_base 0 npn1
                 circuit = MNACircuit(sp_resistor_divider)
                 sol = dc!(circuit)
 
-                @test isapprox_deftol(voltage(sol, :vcc), 5.0)
-                @test isapprox_deftol(voltage(sol, :mid), 2.5)
+                @test isapprox_deftol(sol[:vcc], 5.0)
+                @test isapprox_deftol(sol[:mid], 2.5)
             end
 
             @testset "sp_capacitor DC" begin
@@ -133,8 +135,8 @@ Q2 q2_coll q2_base 0 npn1
                 circuit = MNACircuit(sp_capacitor_circuit)
                 sol = dc!(circuit)
 
-                @test isapprox_deftol(voltage(sol, :vcc), 5.0)
-                @test isapprox_deftol(voltage(sol, :mid), 5.0)  # Open circuit at DC
+                @test isapprox_deftol(sol[:vcc], 5.0)
+                @test isapprox_deftol(sol[:mid], 5.0)  # Open circuit at DC
             end
 
             @testset "sp_inductor DC" begin
@@ -156,7 +158,7 @@ Q2 q2_coll q2_base 0 npn1
 
                 circuit = MNACircuit(sp_inductor_circuit)
                 sol = dc!(circuit)
-                @test isapprox(voltage(sol, :mid), 0.0; atol=0.01)
+                @test isapprox(sol[:mid], 0.0; atol=0.01)
             end
         end
 
@@ -253,11 +255,11 @@ Q2 q2_coll q2_base 0 npn1
 
                 if sol.retcode == SciMLBase.ReturnCode.Success
                     sys = assemble!(circuit)
-                    acc = MNASolutionAccessor(sol, sys)
+                    acc = sol  # MNASolutionAccessor removed — sol supports SII directly
 
                     # Check we got valid values (not NaN) at t=0.5ms
-                    v_q1_coll = voltage(acc, :q1_coll, 0.5e-3)
-                    v_q2_coll = voltage(acc, :q2_coll, 0.5e-3)
+                    v_q1_coll = nameat(acc, :q1_coll, 0.5e-3)
+                    v_q2_coll = nameat(acc, :q2_coll, 0.5e-3)
 
                     @test !isnan(v_q1_coll)
                     @test !isnan(v_q2_coll)
@@ -485,11 +487,11 @@ Q2 q2_coll q2_base 0 npn1
                 @test sol.retcode == SciMLBase.ReturnCode.Success
 
                 sys = assemble!(circuit)
-                acc = MNASolutionAccessor(sol, sys)
+                acc = sol  # MNASolutionAccessor removed — sol supports SII directly
 
                 # Sample in last half after startup transient
                 times = range(100e-9, 200e-9; length=500)
-                V_out1 = [voltage(acc, :out1, t) for t in times]
+                V_out1 = [nameat(acc, :out1, t) for t in times]
 
                 out1_min, out1_max = extrema(V_out1)
 
@@ -530,7 +532,7 @@ Q2 q2_coll q2_base 0 npn1
                 end
 
                 sol = solve_dc(sp_vdmos_circuit, (;), MNASpec())
-                @test 0.0 < voltage(sol, :drain) < 10.0
+                @test 0.0 < sol[:drain] < 10.0
             end
         end
 
@@ -593,7 +595,7 @@ Q2 q2_coll q2_base 0 npn1
                 end
 
                 sol = solve_dc(sp_bsim4v8_circuit, (;), MNASpec())
-                @test 0.9 < voltage(sol, :drain) < 1.0
+                @test 0.9 < sol[:drain] < 1.0
             end
         end
 
@@ -778,7 +780,7 @@ Q2 q2_coll q2_base 0 npn1
             @test sol_ida.retcode == SciMLBase.ReturnCode.Success
 
             sys = assemble!(circuit)
-            acc = MNASolutionAccessor(sol_ida, sys)
+            acc = sol_ida  # MNASolutionAccessor removed
 
             T = 1e-3
             @test length(sol_ida.t) > 50
@@ -792,13 +794,13 @@ Q2 q2_coll q2_base 0 npn1
                 @test abs(vout) < 10.0
             end
 
-            vin_pos = voltage(acc, :vin, T/4)
-            vout_pos = voltage(acc, :vout, T/4)
+            vin_pos = nameat(acc, :vin, T/4)
+            vout_pos = nameat(acc, :vout, T/4)
             @test vin_pos > 4.5
             @test vout_pos > 0.0
 
-            vin_neg = voltage(acc, :vin, 3T/4)
-            vout_neg = voltage(acc, :vout, 3T/4)
+            vin_neg = nameat(acc, :vin, 3T/4)
+            vout_neg = nameat(acc, :vout, 3T/4)
             @test vin_neg < -4.5
             @test vout_neg >= -0.1
         end
@@ -830,7 +832,7 @@ Q2 q2_coll q2_base 0 npn1
             @test sol_ida.retcode == SciMLBase.ReturnCode.Success
 
             sys = assemble!(circuit)
-            acc = MNASolutionAccessor(sol_ida, sys)
+            acc = sol_ida  # MNASolutionAccessor removed
 
             T = 1e-3
 
@@ -844,9 +846,9 @@ Q2 q2_coll q2_base 0 npn1
                 @test vdrain > 0.0 && vdrain < 5.5
             end
 
-            vd_t0 = voltage(acc, :vdrain, T)
-            vd_pos = voltage(acc, :vdrain, T + T/4)
-            vd_neg = voltage(acc, :vdrain, T + 3T/4)
+            vd_t0 = nameat(acc, :vdrain, T)
+            vd_pos = nameat(acc, :vdrain, T + T/4)
+            vd_neg = nameat(acc, :vdrain, T + 3T/4)
 
             @test !isnan(vd_t0) && !isnan(vd_pos) && !isnan(vd_neg)
             @test vd_pos < vd_neg

--- a/test/params.jl
+++ b/test/params.jl
@@ -5,7 +5,7 @@ include("common.jl")
 # MNA imports for parameter tests
 using Cadnip.MNA: MNAContext, MNACircuit, MNASpec, get_node!, stamp!, assemble!, solve_dc
 using Cadnip.MNA: Resistor, VoltageSource
-using Cadnip.MNA: voltage, current
+
 using Cadnip.MNA: alter, reset_for_restamping!  # MNA-specific alter for MNACircuit
 using Cadnip: ParamLens, IdentityLens
 using Cadnip: dc!
@@ -42,7 +42,7 @@ end
 circuit = MNACircuit(build_par_cir; spec=MNASpec(temp=340.0), R=1.0)
 sol = dc!(circuit)
 # Current through voltage source: I = -V/R = -5.0/1.0 = -5.0
-@test current(sol, :I_V) == -5.0
+@test sol[:I_V] == -5.0
 
 #==============================================================================#
 # Test 2: Nested subcircuit with ParamLens (replaces NestedParCir)
@@ -78,7 +78,7 @@ circuit = MNACircuit(build_nested_par_cir;
              child=(params=(R=1.0,),))
 sol = dc!(circuit)
 # Current through voltage source: I = -V/R = -5.0/1.0 = -5.0
-@test current(sol, :I_V) == -5.0
+@test sol[:I_V] == -5.0
 
 #==============================================================================#
 # Test 3: Function-based circuit with lens (replaces FuncCir)
@@ -113,7 +113,7 @@ circuit = MNACircuit(build_func_cir;
              params=(R=1.0,))
 sol = dc!(circuit)
 # Current through voltage source: I = -V/R = -5.0/1.0 = -5.0
-@test current(sol, :I_V) == -5.0
+@test sol[:I_V] == -5.0
 
 #==============================================================================#
 # Test 4: CairoMakie exploration (skip for MNA - requires different API)
@@ -196,7 +196,7 @@ sol = dc!(circuit)
 # With foo=2.0 override at x1.x1 level, R1 = foo = 2.0 Ohms
 # Current source i1 uses top-level foo=1 by default
 # V = I * R = 1A * 2Ω = 2V across R1
-@test isapprox_deftol(voltage(sol, :out), -2)
+@test isapprox_deftol(sol[:out], -2)
 
 # Test with top-level foo=2.0 - should affect both i1 and (via expression) R1
 # params=(foo=2.0,) at top level merges with defaults
@@ -205,7 +205,7 @@ sol = dc!(circuit)
 # foo=2.0 at top level: i1 DC = 2A, R1 = foo+2000 = 2002Ω at inner level
 # With default foo expression in subcircuit: foo = parent_foo + 2000 = 2002
 # V = I * R = 2A * 2002Ω = 4004V
-@test isapprox_deftol(voltage(sol, :out), -4004.0)
+@test isapprox_deftol(sol[:out], -4004.0)
 
 # Note: Direct component-level parameter overrides (like r1=(params=(r=100.0,),))
 # are not yet supported by MNA codegen - the resistor stamp uses the foo parameter
@@ -215,7 +215,7 @@ circuit = MNACircuit(mna_builder; x1=(x1=(params=(foo=100.0,),),))
 sol = dc!(circuit)
 # Override foo=100.0 at x1.x1 level, R1 = foo = 100Ω, i1 uses foo=1, so I = 1A
 # V = I * R = 1A * 100Ω = 100V
-@test isapprox_deftol(voltage(sol, :out), -100)
+@test isapprox_deftol(sol[:out], -100)
 
 # Test that our 'default parameterization' helper sees `foo` and `inner`
 default_params = Cadnip.get_default_parameterization(ast)
@@ -283,7 +283,7 @@ end
     # Test alter() on MNACircuit objects
     circuit = MNACircuit(build_par_cir; R=1000.0, V=5.0)
     sol = dc!(circuit)
-    @test voltage(sol, :vcc) ≈ 5.0
+    @test sol[:vcc] ≈ 5.0
 
     # Alter R parameter
     circuit2 = alter(circuit; R=500.0)
@@ -292,10 +292,10 @@ end
 
     # Both should give correct DC solution
     sol2 = dc!(circuit2)
-    @test voltage(sol2, :vcc) ≈ 5.0
+    @test sol2[:vcc] ≈ 5.0
 
     # Current should reflect new R: I = -V/R = -5/500 = -0.01
-    @test current(sol2, :I_V) ≈ -0.01
+    @test sol2[:I_V] ≈ -0.01
 end
 
 end # module params_tests

--- a/test/sweep.jl
+++ b/test/sweep.jl
@@ -7,7 +7,7 @@ include(joinpath(Base.pkgdir(Cadnip), "test", "common.jl"))
 # MNA imports for sweep tests
 using Cadnip.MNA: MNAContext, MNACircuit, get_node!, stamp!, reset_for_restamping!
 using Cadnip.MNA: Resistor, VoltageSource
-using Cadnip.MNA: voltage, current, DCSolution
+using Cadnip.MNA: DCSolution
 using Cadnip: ParamLens
 
 # Simple two-resistor circuit (MNA builder function):
@@ -226,8 +226,8 @@ end
     circuit = MNACircuit(build_two_resistor; R1=100.0, R2=100.0)
     sol = dc!(circuit)
     @test sol isa DCSolution
-    @test voltage(sol, :vcc) ≈ 1.0
-    @test voltage(sol, :out) ≈ 0.5  # Voltage divider: 1V * 100/(100+100)
+    @test sol[:vcc] ≈ 1.0
+    @test sol[:out] ≈ 0.5  # Voltage divider: 1V * 100/(100+100)
 end
 
 @testset "CircuitSweep" begin
@@ -299,22 +299,20 @@ end
     # Construct `CircuitSweep` object and run dc! on it
     cs = CircuitSweep(build_two_resistor, ProductSweep(R1 = 100.0:100.0:2000.0, R2 = 100.0:100.0:2000.0))
 
-    # Perform the solve - dc! on CircuitSweep returns vector of solutions
-    solutions = dc!(cs)
+    # Perform the solve — dc! on a CircuitSweep returns a SweepResult that
+    # iterates (params, sol) pairs, with parameters aligned to their solution.
+    result = dc!(cs)
 
-    # Verify results for each simulation in the sweep
-    for (sol, sim) in zip(solutions, cs)
-        R1 = sim.params.R1
-        R2 = sim.params.R2
+    for (params, sol) in result
         # Current through voltage source is negative (sources current)
         # I = V / (R1 + R2) = 1 / (R1 + R2)
-        @test isapprox(current(sol, :I_V), -1/(R1 + R2); atol=deftol)
+        @test isapprox(sol[:I_V], -1/(params.R1 + params.R2); atol=deftol)
     end
 end
 
 # Phase 4: MNA-based SPICE codegen tests
 @testset "MNA SPICE codegen: basic resistor circuit" begin
-    using Cadnip.MNA: voltage, current
+    
 
     spice_code = """
         * Simple voltage divider
@@ -341,12 +339,12 @@ end
     sol = Cadnip.dc!(circuit)
 
     # Verify voltage divider: out = 5 * 1k/(1k+1k) = 2.5V
-    @test isapprox(voltage(sol, :vcc), 5.0; atol=deftol)
-    @test isapprox(voltage(sol, :out), 2.5; atol=deftol)
+    @test isapprox(sol[:vcc], 5.0; atol=deftol)
+    @test isapprox(sol[:out], 2.5; atol=deftol)
 end
 
 @testset "MNA SPICE codegen: RLC circuit" begin
-    using Cadnip.MNA: voltage
+    
 
     spice_code = """
         * RLC circuit
@@ -373,15 +371,15 @@ end
     # At DC, inductor is short, capacitor is open
     # So n1 = 10V (after R, but L is short)
     # n2 = 10V (capacitor open, no current)
-    @test isapprox(voltage(sol, :in), 10.0; atol=deftol)
+    @test isapprox(sol[:in], 10.0; atol=deftol)
     # Inductor at DC is a short, so n1 ≈ n2 ≈ in (no resistor drop when no current)
     # Actually with capacitor open, no current flows, so all nodes at 10V
-    @test isapprox(voltage(sol, :n1), 10.0; atol=deftol)
-    @test isapprox(voltage(sol, :n2), 10.0; atol=deftol)
+    @test isapprox(sol[:n1], 10.0; atol=deftol)
+    @test isapprox(sol[:n2], 10.0; atol=deftol)
 end
 
 @testset "MNA SPICE codegen: current source" begin
-    using Cadnip.MNA: voltage
+    
 
     spice_code = """
         * Current source into resistor
@@ -404,11 +402,11 @@ end
     sol = Cadnip.dc!(circuit)
 
     # V = I * R = 1mA * 1kΩ = 1V
-    @test isapprox(voltage(sol, :out), 1.0; atol=deftol)
+    @test isapprox(sol[:out], 1.0; atol=deftol)
 end
 
 @testset "dc! sweep on SPICE-generated circuit with subcircuit params" begin
-    using Cadnip.MNA: voltage
+    
 
     # Subcircuit with parameterized resistors
     spice_code = """
@@ -437,8 +435,8 @@ end
     sol = Cadnip.dc!(circuit)
 
     # With r1val=2k and r2val=1k, vout = 3.0 * 1k/(2k+1k) = 1.0V
-    @test isapprox(voltage(sol, :vin), 3.0; atol=deftol)
-    @test isapprox(voltage(sol, :vout), 1.0; atol=deftol)
+    @test isapprox(sol[:vin], 3.0; atol=deftol)
+    @test isapprox(sol[:vout], 1.0; atol=deftol)
 end
 
 @testset "find_param_ranges" begin

--- a/test/testpdk/pdk_test.jl
+++ b/test/testpdk/pdk_test.jl
@@ -1,10 +1,9 @@
 """
 Test PDK and VA device precompilation with MNA.
 
-This tests:
-- `load_mna_modules()` for SPICE PDK files with subcircuits
-- `load_mna_va_module()` for Verilog-A device files
-- SPICE circuits that reference VA devices via `imported_hdl_modules`
+This tests the Cadnip.precompile_pdk / Cadnip.precompile_va APIs (the PDK-authoring
+side of the two-tier model). End users reach the output via netlist .hdl / jlpkg://
+directives; these tests exercise the bake-time codegen path directly.
 """
 
 using Test
@@ -17,43 +16,27 @@ const testpdk_path = joinpath(@__DIR__, "testpdk.spice")
 const test_va_path = joinpath(@__DIR__, "test_resistor.va")
 const circuit_with_va_path = joinpath(@__DIR__, "circuit_with_va.spice")
 
-# Load PDK modules directly into this module (like a real PDK package would do)
-# This is the preferred API for precompilation - evals internally and returns modules
-const corners = Cadnip.load_mna_modules(@__MODULE__, testpdk_path)
-
-# Load VA device module (like a device package would do)
-const va_device_mod = Cadnip.load_mna_va_module(@__MODULE__, test_va_path)
+const corners = Cadnip.precompile_pdk(@__MODULE__, testpdk_path)
+const va_device_mod = Cadnip.precompile_va(@__MODULE__, test_va_path)
 
 @testset "PDK MNA Module Generation" begin
 
-    @testset "load_mna_modules into module" begin
-        # Check that modules were created
+    @testset "precompile_pdk into module" begin
         @test haskey(corners, :typical)
         @test haskey(corners, :fast)
         @test haskey(corners, :slow)
 
-        # Check that submodules are defined in this module
         @test isdefined(@__MODULE__, :typical)
         @test isdefined(@__MODULE__, :fast)
         @test isdefined(@__MODULE__, :slow)
     end
 
-    @testset "load_mna_modules expression form" begin
-        # Test backward compatible expression-returning form
-        expr = Cadnip.load_mna_modules(testpdk_path)
-        @test expr.head == :toplevel
-        @test length(expr.args) == 3
-    end
-
-    @testset "load_mna_modules with names filter" begin
-        # Load only typical section (expression form)
-        expr = Cadnip.load_mna_modules(testpdk_path; names=["typical"])
-        @test length(expr.args) == 1
-    end
-
-    @testset "load_mna_pdk single section expression" begin
-        expr = Cadnip.load_mna_pdk(testpdk_path; section="typical")
-        @test expr.head == :module  # Direct module expression
+    @testset "precompile_pdk names filter" begin
+        # Load only typical section into a fresh module
+        m = Module(:pdk_only_typical)
+        nt = Cadnip.precompile_pdk(m, testpdk_path; names=["typical"])
+        @test haskey(nt, :typical)
+        @test !haskey(nt, :fast)
     end
 
     @testset "PDK module structure" begin
@@ -156,20 +139,10 @@ end
 
 @testset "VA Device Precompilation" begin
 
-    @testset "load_mna_va_module into module" begin
-        # Check that the module was created
+    @testset "precompile_va into module" begin
         @test va_device_mod isa Module
         @test isdefined(@__MODULE__, :test_resistor_module)
-
-        # Check that device type is exported
         @test isdefined(test_resistor_module, :test_resistor)
-    end
-
-    @testset "load_mna_va_module expression form" begin
-        # Test expression-returning form
-        expr = Cadnip.load_mna_va_module(test_va_path)
-        @test expr.head == :toplevel
-        @test length(expr.args) == 2  # module def + using statement
     end
 
     @testset "Use VA device in circuit" begin
@@ -254,43 +227,33 @@ end
 end
 
 @testset "SPICE Circuit with VA Device" begin
-    # This demonstrates the typical use case where:
-    # 1. A VA device comes from a precompiled package (like BSIM4.jl)
-    # 2. A SPICE netlist references that device by name
-    # 3. The circuit is built using make_mna_circuit with imported_hdl_modules
-    #
-    # In a real PDK, the SPICE file would use:
-    #   .hdl "jlpkg://BSIM4/bsim4.va"
-    # to reference the package. Here we demonstrate the equivalent pattern
-    # by passing the module via imported_hdl_modules.
+    # A VA device comes from a precompiled package (here: test_resistor_module).
+    # In a real PDK the SPICE netlist would reference it via `.hdl "jlpkg://..."`.
+    # For this unit test we construct the circuit via Cadnip._make_mna_circuit_with_sema
+    # on a sema result that has the module pre-populated on its scope walk list.
+
+    function _build_from_spice(ast, circuit_name::Symbol, mods::Vector{Module})
+        sema_result = Cadnip.sema(ast; imported_hdl_modules=mods)
+        return Cadnip._make_mna_circuit_with_sema(sema_result; circuit_name)
+    end
 
     @testset "Build circuit from SPICE with VA device" begin
-        # Parse the SPICE circuit
         using NyanSpectreNetlistParser
         ast = NyanSpectreNetlistParser.parsefile(circuit_with_va_path; implicit_title=true)
         @test !ast.ps.errored
 
-        # Build the MNA circuit, passing the VA device module
-        # This is equivalent to what happens when SPICE uses .hdl "jlpkg://..."
-        builder_code = Cadnip.make_mna_circuit(ast;
-            circuit_name=:va_circuit,
-            imported_hdl_modules=[test_resistor_module])
-
-        # Eval the builder
+        builder_code = _build_from_spice(ast, :va_circuit, [test_resistor_module])
         builder = @eval $builder_code
 
-        # Build and solve
         circuit = MNACircuit(builder)
         sol = dc!(circuit)
 
-        # Build ctx to get node indices
         ctx = builder((;), MNASpec())
         out_idx = ctx.node_to_idx[:out]
         @test sol.x[out_idx] ≈ 0.5 atol=1e-6
     end
 
     @testset "Compare SPICE-defined vs Julia-defined circuit" begin
-        # Build the same circuit in pure Julia for comparison
         function build_julia_circuit(params, spec::MNASpec, t::Real=0.0; x=Float64[], ctx=nothing)
             if ctx === nothing
                 ctx = MNAContext()
@@ -301,36 +264,27 @@ end
             vin = get_node!(ctx, :vin)
             out = get_node!(ctx, :out)
 
-            # VA resistor
             dev = test_resistor_module.test_resistor(R=500.0)
             stamp!(dev, ctx, vin, out; _mna_t_=0.0, _mna_mode_=:dcop, _mna_x_=Float64[])
 
-            # Regular resistor
             stamp!(Cadnip.MNA.Resistor(500.0), ctx, out, 0)
-
-            # Voltage source
             stamp!(VoltageSource(1.0), ctx, vin, 0)
 
             return ctx
         end
 
-        # Solve Julia-defined circuit
         circuit_julia = MNACircuit(build_julia_circuit)
         sol_julia = dc!(circuit_julia)
         ctx_julia = build_julia_circuit((;), MNASpec())
 
-        # Solve SPICE-defined circuit
         using NyanSpectreNetlistParser
         ast = NyanSpectreNetlistParser.parsefile(circuit_with_va_path; implicit_title=true)
-        builder_code = Cadnip.make_mna_circuit(ast;
-            circuit_name=:va_circuit2,
-            imported_hdl_modules=[test_resistor_module])
+        builder_code = _build_from_spice(ast, :va_circuit2, [test_resistor_module])
         builder = @eval $builder_code
         circuit_spice = MNACircuit(builder)
         sol_spice = dc!(circuit_spice)
         ctx_spice = builder((;), MNASpec())
 
-        # Both should give same output voltage
         out_julia = sol_julia.x[ctx_julia.node_to_idx[:out]]
         out_spice = sol_spice.x[ctx_spice.node_to_idx[:out]]
 

--- a/test/transients.jl
+++ b/test/transients.jl
@@ -5,7 +5,7 @@ include("common.jl")
 using Cadnip.MNA: MNAContext, MNASpec, get_node!, stamp!, assemble!, solve_dc, reset_for_restamping!
 using Cadnip.MNA: Resistor, Capacitor, Inductor, VoltageSource, CurrentSource
 using Cadnip.MNA: pwl_at_time
-using Cadnip.MNA: voltage, current, MNACircuit
+using Cadnip.MNA: MNACircuit
 using SciMLBase: ODEProblem
 
 # We'll create a piecewise linear current source that goes through a resistor

--- a/test/varegress.jl
+++ b/test/varegress.jl
@@ -3,7 +3,7 @@ module varegress
 using Cadnip
 using Cadnip.MNA
 using Cadnip.MNA: MNAContext, MNASpec, get_node!, stamp!, assemble!
-using Cadnip.MNA: voltage, current, make_ode_problem
+using Cadnip.MNA: make_ode_problem
 using Cadnip.MNA: VoltageSource, Capacitor, MNACircuit
 using Cadnip: dc!
 using OrdinaryDiffEq
@@ -43,8 +43,8 @@ endmodule
     # V_out should equal V_vcc = 1V (no DC current through capacitor)
     circuit = MNACircuit(circuit1)
     sol = dc!(circuit)
-    @test isapprox(voltage(sol, :vcc), 1.0; atol=1e-10)
-    @test isapprox(voltage(sol, :out), 1.0; atol=1e-10)
+    @test isapprox(sol[:vcc], 1.0; atol=1e-10)
+    @test isapprox(sol[:out], 1.0; atol=1e-10)
 
     # Transient analysis - RC charging
     ctx = circuit1((;), MNASpec(mode=:tran))
@@ -114,8 +114,8 @@ endmodule
     # DC analysis
     circuit = MNACircuit(circuit2)
     sol = dc!(circuit)
-    @test isapprox(voltage(sol, :vcc), 1.0; atol=1e-10)
-    @test isapprox(voltage(sol, :out), 1.0; atol=1e-10)
+    @test isapprox(sol[:vcc], 1.0; atol=1e-10)
+    @test isapprox(sol[:out], 1.0; atol=1e-10)
 
     # Transient analysis
     ctx = circuit2((;), MNASpec(mode=:tran))


### PR DESCRIPTION
## Summary

Implements the plan in `doc/api_consolidation_plan.md`. One coherent API for the full workflow: load a SPICE/Spectre netlist from a file or string, reference PDKs via `jlpkg://`, solve via `dc!`/`tran!`/`ac!`, access results via `sol[:name]`.

### Public API — new

| Category | What |
|---|---|
| File loading | `MNACircuit("amp.sp")`, `Base.include(@__MODULE__, SpiceFile(path))`, `SpiceFile` / `SpectreFile` |
| String loading | `sp"..."`, `spc"..."` (new, symmetric with `sp"..."`), `MNACircuit(code; lang=:spice)` |
| PDK authoring | `Cadnip.precompile_pdk(mod, file)`, `Cadnip.precompile_va(mod, file)` |
| Sweeps | `SweepResult{P,S}` returned by `dc!(cs)` / `tran!(cs, tspan)`, iterates `(params, sol)` |
| Solution access | `sol[:name]` everywhere (DC/AC/transient), `nameat(sol, :name, t)` for time-indexed lookup |
| Other | `prepare!(circuit)` for explicit eager structure discovery |

### Public API — deleted (hard break, per plan)

- `parse_spice_to_mna`, `parse_spice_file_to_mna`, `solve_spice_mna`
- `load_mna_pdk`, `load_mna_modules`, `load_mna_va_module`, `load_mna_va_modules`
- `MNASolutionAccessor`, `voltage(sol, :x)`, `current(sol, :x)` accessors
- `imported_hdl_modules` kwarg from all public APIs

### Two-tier model resolution

`spice_select_device` (`src/spc/sema.jl`) now resolves:

1. **Tier 2 (scope walk)** — netlist directives (`.hdl`, `.include`, `.lib`, `jlpkg://`); most-recent include wins.
2. **Tier 1 (registry)** — `ModelRegistry.getmodel` fallback for SPICE-standard builtins.

### SymbolicIndexingInterface

`MNAData` implements SII (`is_variable`, `variable_symbols`, `variable_index`, etc.) and is threaded as `sys` through `ODEFunction` / `DAEFunction` / `DDEFunction`. DC + AC solutions also support `sol[:name]` natively. `nameat` is added for `sol(t)[:name]`-style time-indexed access.

### Codegen hygiene

All Type-B runtime references in generated code are now fully qualified (`Cadnip.MNA.stamp!(...)`, `Base.error(...)`, `ForwardDiff.Dual`, etc.). Baremodule preambles trimmed to Type-A language-level identifiers and device types only. A user parameter named `stamp`, `error`, or `get_node` no longer collides. Regression test added in `test/mna/codegen_hygiene.jl`.

### Breaking changes (hard-break policy, per plan)

- All call sites of `voltage(sol, :x)` / `current(sol, :x)` → `sol[:x]`.
- `MNASolutionAccessor(sol, sys)` → drop the wrapper; `sol` supports SII directly.
- `voltage(acc, :x, t)` → `nameat(sol, :x, t)`.
- `parse_spice_to_mna` / `parse_spice_file_to_mna` users → `Base.include(@__MODULE__, SpiceFile(path))` at top level, then `MNACircuit(builder_fn)`; OR `MNACircuit("code"; lang=:spice)` at top level.
- `load_mna_pdk` / `load_mna_modules` users → `Cadnip.precompile_pdk(@__MODULE__, path)` at package build time.
- `zip(dc!(cs), cs)` → `for (params, sol) in dc!(cs)`.

### Top-level-only contract for runtime parsing

`MNACircuit(path)` and `MNACircuit(code; lang=...)` call `Base.eval` internally to install the builder. Julia captures the caller's world age at function entry, so these constructors work at the REPL / module top level but error cleanly inside a function body. For that case, load the circuit at top level and pass the builder fn — same contract the old `parse_spice_to_mna` + `eval` pattern had.

The `sp"..."` / `spc"..."` / `va"..."` string macros expand at the call site and work in both contexts.

## Test plan

- [x] `test/mna/core.jl`
- [x] `test/basic.jl`, `test/sweep.jl`, `test/params.jl`, `test/transients.jl`
- [x] `test/mna/va.jl`, `test/mna/va_mosfet.jl`, `test/mna/va_spice.jl`
- [x] `test/mna/audio_integration.jl`, `test/mna/monostable_test.jl`, `test/mna/psp103_integration.jl`
- [x] `test/testpdk/pdk_test.jl`, `test/mna/codegen_hygiene.jl` (new)
- [x] `test/mna/precompile.jl`, `test/mna/photonic.jl`, `test/mna/laplace.jl`, `test/mna/vadistiller.jl`
- [ ] Full `test/runtests.jl core` end-to-end (CI)
- [ ] `test/runtests.jl integration` (CI)
- [ ] Benchmarks: spot-check `benchmarks/vacask/rc/cedarsim/runme.jl` and `benchmarks/vacask/graetz/cedarsim/runme.jl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)