### PR TITLE
Hook up .hdl / ahdl_include for on-the-fly VA loading

### DIFF
--- a/src/spc/cache.jl
+++ b/src/spc/cache.jl
@@ -9,7 +9,14 @@ function parse_and_cache_spc!(cache::CedarParseCache, path::String)
     if haskey(cache.spc_cache, path)
         return cache.spc_cache[path]
     end
-    abspath = isabspath(path) ? path : joinpath(dirname(pathof(cache.thismod)), "..", path)
+    abspath = if isabspath(path)
+        path
+    else
+        thismod_file = pathof(cache.thismod)
+        thismod_file === nothing ?
+            Base.abspath(path) :
+            joinpath(dirname(thismod_file), "..", path)
+    end
     sa = NyanSpectreNetlistParser.parsefile(abspath; implicit_title=false)
     cache_spc!(cache.thismod, path, sa; abspath)
     return sa
@@ -20,7 +27,14 @@ function parse_and_cache_va!(cache::CedarParseCache, path::String)
     if haskey(cache.va_cache, path)
         return cache.va_cache[path]
     end
-    abspath = isabspath(path) ? path : joinpath(dirname(pathof(cache.thismod)), "..", path)
+    abspath = if isabspath(path)
+        path
+    else
+        thismod_file = pathof(cache.thismod)
+        thismod_file === nothing ?
+            Base.abspath(path) :
+            joinpath(dirname(thismod_file), "..", path)
+    end
     va = NyanVerilogAParser.parsefile(abspath)
     if va.ps.errored
         cedarthrow(LoadError(abspath, 0, VAParseError(va)))

--- a/src/spc/codegen.jl
+++ b/src/spc/codegen.jl
@@ -3080,10 +3080,12 @@ ctx = circuit_fn((R1=1000.0,), MNASpec())
 sol = MNA.solve_dc(ctx)
 ```
 """
-function make_mna_circuit(ast; circuit_name::Symbol=:circuit)
+function make_mna_circuit(ast; circuit_name::Symbol=:circuit,
+                           parse_cache::Union{CedarParseCache,Nothing}=nothing)
     # Run semantic analysis (use sema() not sema_file_or_section to get parameter_order)
     # Tier 2 scope walk (imported_hdl_modules) is populated by netlist directives only.
-    sema_result = sema(ast)
+    # parse_cache enables on-the-fly codegen of `.hdl` VA includes via codegen_hdl!.
+    sema_result = sema(ast; parse_cache)
     return _make_mna_circuit_with_sema(sema_result; circuit_name)
 end
 

--- a/src/spc/interface.jl
+++ b/src/spc/interface.jl
@@ -33,80 +33,13 @@ function generate_sp_code(world::UInt64, source::LineNumberNode, ::Type{SpCircui
     return gen(world, source, codegen(sema))
 end
 
-function analyze_mosfet_import(dialect, level)
-    if dialect == :ngspice
-        if level == 5
-            #error("bsim2 not supported")
-            #return :bsim2
-        elseif level == 8 || level == 49
-            #error("bsim3 not supported")
-            #return :bsim3
-        elseif level == 14 || level == 54
-            return :BSIM4
-        end
-    end
-    return nothing
-end
-
-function analyze_imports!(n::SNode, parse_cache::Union{CedarParseCache, Nothing}, traverse_imports::Bool=false;
-        imports=Set{Symbol}(),
-        hdl_imports=Set{String}(),
-        includes::Set{String}=Set{String}(),
-        pkg_hdl_imports=Set{String}(),
-        pkg_spc_import=Set{String}(),
-        thispath::Union{String, Nothing}=nothing)
-    for stmt in n.stmts
-        if isa(stmt, SNode{SP.IncludeStatement}) || isa(stmt, SNode{SP.LibInclude}) || isa(stmt, SNode{SP.HDLStatement})
-            str = strip(unescape_string(String(stmt.path)), ['"', '\'']) # verify??
-            if startswith(str, JLPATH_PREFIX)
-                path = str[sizeof(JLPATH_PREFIX)+1:end]
-                components = splitpath(path)
-                push!(imports, Symbol(components[1]))
-                if isa(stmt, SNode{SP.HDLStatement})
-                    push!(pkg_hdl_imports, str)
-                else
-                    push!(pkg_spc_import, str)
-                end
-            else
-                if thispath !== nothing
-                    str = joinpath(dirname(thispath), str)
-                end
-                if parse_cache !== nothing
-                    if isa(stmt, SNode{SP.HDLStatement})
-                        parse_and_cache_va!(parse_cache, str)
-                    else
-                        str in includes && continue
-                        push!(includes, str)
-                        analyze_imports!(parse_and_cache_spc!(parse_cache, str), parse_cache; imports, hdl_imports, includes, thispath=str)
-                    end
-                else
-                    if isa(stmt, SNode{SP.HDLStatement})
-                        push!(hdl_imports, str)
-                    else
-                        push!(includes, str)
-                    end
-                end
-            end
-        elseif isa(stmt, SNode{SP.Model})
-            typ = LSymbol(stmt.typ)
-            mosfet_type = typ in (:nmos, :pmos) ? typ : nothing
-            local level = 1
-            for p in stmt.parameters
-                name = LSymbol(p.name)
-                if name == :level
-                    # TODO
-                    level = parse(Float64, String(p.val))
-                    continue
-                end
-            end
-            mosfet_type === nothing && continue
-            imp = analyze_mosfet_import(:ngspice, level)
-            imp !== nothing && push!(imports, imp)
-        elseif isa(stmt, Union{SNode{SPICENetlistSource}, SNode{SP.Subckt}, SNode{SP.LibStatement}})
-            analyze_imports!(stmt, parse_cache; imports, hdl_imports, includes, pkg_hdl_imports, pkg_spc_import, thispath)
-        end
-    end
-    return imports, hdl_imports, includes, pkg_hdl_imports, pkg_spc_import
+# Create a fresh top-level-ish module for holding a generated SPICE builder
+# and any on-the-fly VA baremodules. Imports Cadnip so the generated
+# `import ..Cadnip` inside VA baremodules resolves.
+function _fresh_netlist_module(name::Symbol)
+    mod = Module(gensym(name))
+    Core.eval(mod, :(import Cadnip))
+    return mod
 end
 
 function ensure_cache!(mod::Module)
@@ -118,59 +51,37 @@ function ensure_cache!(mod::Module)
     return cache
 end
 
-function codegen_missing_imports!(thismod::Module, imps::Union{Dict{Symbol, Module}, NamedTuple}, pkg_hdl_imports::Set{String}, pkg_spc_import::Set{String})
-    if isa(imps, NamedTuple)
-        imps = Dict{Symbol, Module}(pairs(imps)...)
-    end
-    for imp in pkg_spc_import
-        @assert startswith(imp, JLPATH_PREFIX)
-        path = imp[sizeof(JLPATH_PREFIX)+1:end]
-        components = splitpath(path)
-        mod = imps[Symbol(components[1])]
-        localpath = joinpath(components[2:end])
-        cache = ensure_cache!(mod)
-        if haskey(cache.spc_cache, localpath)
-            continue
-        end
-        imports, _, _, sub_pkg_hdl_imports, sub_pkg_spc_import = analyze_imports!(parse_and_cache_spc!(cache, localpath), cache, thispath=localpath)
-        sub_imps = Dict{Symbol, Module}(Symbol(pkg) => Base.require(mod, Symbol(pkg)) for pkg in imports)
-        codegen_missing_imports!(mod, sub_imps, sub_pkg_hdl_imports, sub_pkg_spc_import)
-    end
-    for imp in pkg_hdl_imports
-        @assert startswith(imp, JLPATH_PREFIX)
-        path = imp[sizeof(JLPATH_PREFIX)+1:end]
-        components = splitpath(path)
-        mod = imps[Symbol(components[1])]
-        localpath = joinpath(components[2:end])
-        cache = ensure_cache!(mod)
-        codegen_hdl_import!(mod, cache, localpath)
-    end
-end
+"""
+    codegen_hdl!(cache::CedarParseCache, path::String) -> Module
 
-function codegen_hdl_import!(mod::Module, cache::CedarParseCache, imp::String)
-    va = get(cache.va_cache, imp, nothing)
-    va isa Pair && return
-    if va === nothing
-        va = parse_and_cache_va!(cache, imp)
+Parse and codegen a Verilog-A file referenced by a SPICE `.hdl` directive,
+returning the generated baremodule. Idempotent: if the cache already holds
+a `(VANode, Module)` pair (e.g. from PDK precompilation), the cached module
+is returned unchanged.
+
+Called from the sema walk in `src/spc/sema.jl` when a `.hdl` directive is
+encountered. Evals into `cache.thismod`, which is the same module where the
+SPICE builder function will be eval'd — so the generated device types are
+visible at stamp time via ordinary module-level resolution.
+"""
+codegen_hdl!(cache::CedarParseCache, path::AbstractString) = codegen_hdl!(cache, String(path))
+
+function codegen_hdl!(cache::CedarParseCache, path::String)
+    entry = get(cache.va_cache, path, nothing)
+    if entry isa Pair{VANode, Module}
+        return entry.second
     end
-
-    vamod = va.stmts[end]
-    s = gensym(String(vamod.id))
-    sm = Core.eval(mod, :(baremodule $s
-        const VerilogAEnvironment = $(Cadnip.VerilogAEnvironment)
-        using .VerilogAEnvironment
-        $(Cadnip.make_spice_device(vamod))
-        const $(Symbol(lowercase(String(vamod.id)))) = $(Symbol(vamod.id))
-    end))
-
-    recache_va!(mod, imp, Pair{VANode, Module}(va, sm))
-end
-
-function codegen_hdl_imports!(mod::Module, hdl_imports)
-    cache = mod.var"#cedar_parse_cache#"
-    for imp in hdl_imports
-        codegen_hdl_import!(mod, cache, imp)
-    end
+    va = entry === nothing ? parse_and_cache_va!(cache, path) : entry
+    @assert va isa VANode
+    expr = Cadnip.make_mna_module(va)
+    @assert expr.head === :toplevel
+    module_def = expr.args[1]
+    @assert module_def.head === :module
+    mod_name = module_def.args[2]::Symbol
+    Core.eval(cache.thismod, expr)
+    sm = getfield(cache.thismod, mod_name)
+    recache_va!(cache.thismod, path, Pair{VANode, Module}(va, sm))
+    return sm
 end
 
 #==============================================================================#
@@ -227,9 +138,11 @@ macro sp_str(str, flag="")
     sa = NyanSpectreNetlistParser.parse(IOBuffer(str); start_lang=:spice, enable_julia_escape,
         implicit_title = !inline, fname=String(__source__.file), srcline=__source__.line)
 
-    # Generate MNA builder function
+    # Generate MNA builder function. Pass the caller's cache so `.hdl` VA
+    # includes codegen into the caller's module alongside the SPICE builder.
+    parse_cache = ensure_cache!(__module__)
     circuit_name = gensym(:circuit)
-    code = make_mna_circuit(sa; circuit_name)
+    code = make_mna_circuit(sa; circuit_name, parse_cache)
 
     # Return the builder function
     return esc(quote
@@ -258,8 +171,9 @@ macro spc_str(str, flag="")
     sa = NyanSpectreNetlistParser.parse(IOBuffer(str); start_lang=:spectre, enable_julia_escape,
         fname=String(__source__.file), srcline=__source__.line)
 
+    parse_cache = ensure_cache!(__module__)
     circuit_name = gensym(:circuit)
-    code = make_mna_circuit(sa; circuit_name)
+    code = make_mna_circuit(sa; circuit_name, parse_cache)
 
     return esc(quote
         $code
@@ -338,14 +252,16 @@ end
 
 function Base.include(mod::Module, f::SpiceFile)
     sa = _parse_netlist_file(f.path, :spice)
-    code = make_mna_circuit(sa; circuit_name=f.name)
+    parse_cache = ensure_cache!(mod)
+    code = make_mna_circuit(sa; circuit_name=f.name, parse_cache)
     Base.eval(mod, code)
     return nothing
 end
 
 function Base.include(mod::Module, f::SpectreFile)
     sa = _parse_netlist_file(f.path, :spectre)
-    code = make_mna_circuit(sa; circuit_name=f.name)
+    parse_cache = ensure_cache!(mod)
+    code = make_mna_circuit(sa; circuit_name=f.name, parse_cache)
     Base.eval(mod, code)
     return nothing
 end
@@ -415,7 +331,7 @@ function MNA.MNACircuit(path_or_code::AbstractString;
         eff_lang = infer_lang_from_ext(path)
         eff_name = name === nothing ?
             Symbol(first(splitext(basename(path)))) : name
-        mod = Module(gensym(eff_name))
+        mod = _fresh_netlist_module(eff_name)
         if eff_lang === :spice
             Base.include(mod, SpiceFile(path; name=eff_name))
         else
@@ -426,8 +342,9 @@ function MNA.MNACircuit(path_or_code::AbstractString;
         eff_lang = something(lang, :spice)
         sa = _parse_netlist_string(path_or_code, eff_lang; source_dir=source_dir)
         eff_name = name === nothing ? gensym(:circuit) : name
-        builder_code = make_mna_circuit(sa; circuit_name=eff_name)
-        mod = Module(gensym(:netlist))
+        mod = _fresh_netlist_module(:netlist)
+        parse_cache = ensure_cache!(mod)
+        builder_code = make_mna_circuit(sa; circuit_name=eff_name, parse_cache)
         Base.eval(mod, builder_code)
         builder = getfield(mod, eff_name)
     end

--- a/src/spc/sema.jl
+++ b/src/spc/sema.jl
@@ -174,6 +174,21 @@ function sema!(scope::SemaResult, n::SNode{<:SC.AbstractBlockASTNode})
             # Global node declaration - handled implicitly
         elseif isa(stmt, SNode{SC.Simulator})
             # Simulator directive (lang=spectre etc.) - skip
+        elseif isa(stmt, SNode{SC.AHDLInclude})
+            # On-the-fly Verilog-A include, Spectre dialect.
+            if !isempty(scope.condition_stack)
+                error("ahdl_include not allowed in conditional blocks")
+            end
+            raw_str = String(stmt.filename)
+            str = strip(unescape_string(raw_str), ['"', '\''])
+            if isabspath(str)
+                path = str
+            else
+                thispath = scope.ast.ps.srcfile.path
+                path = thispath === nothing ? str : joinpath(dirname(thispath), str)
+            end
+            sm = codegen_hdl!(scope.parse_cache, path)
+            push!(scope.imported_hdl_modules, sm)
         else
             # Unknown Spectre statement - warn but continue
             # @warn "Skipping unknown Spectre statement type: $(typeof(stmt))"

--- a/src/spc/sema.jl
+++ b/src/spc/sema.jl
@@ -46,7 +46,6 @@ mutable struct SemaResult
     options::Dict{Symbol, Vector{Pair{UInt, SNode}}}
 
     instances::OrderedDict{Symbol, Vector{Pair{UInt, MaybeConditional{SNode}}}}
-    hdl_includes::Vector{Pair{UInt, Pair{SNode, VANode}}}
 
     warnings::Vector
 
@@ -67,7 +66,7 @@ end
 function SemaResult(ast::SNode)
     SemaResult(ast, nothing, nothing, nothing, UInt64(0), SpectreCircuit,
         Vector{Pair{UInt, MaybeConditional{SNode}}}(), Vector{UInt}(),
-        Dict(), Dict(), Dict(), Dict(), Dict(), Dict(), Dict(), Vector(), Vector(),
+        Dict(), Dict(), Dict(), Dict(), Dict(), Dict(), Dict(), Vector(),
         OrderedSet{Symbol}(), OrderedSet{Symbol}(), OrderedSet{Symbol}(),
         OrderedSet{Symbol}(),
         Int[], Module[], nothing)
@@ -445,11 +444,13 @@ function sema!(scope::SemaResult, n::Union{SNode{SPICENetlistSource}, SNode{SP.S
                 push!(get!(()->[], scope.params, name), scope.global_position=>MaybeConditional(scope, param))
                 sema_visit_expr!(scope, param.val)
             end
-        elseif isa(stmt, SNode{SP.IncludeStatement}) || isa(stmt, SNode{SP.LibInclude}) || isa(stmt, SNode{SP.HDLStatement})
+        elseif isa(stmt, SNode{SP.IncludeStatement}) || isa(stmt, SNode{SP.LibInclude}) || isa(stmt, SNode{SP.HDLStatement}) || isa(stmt, SNode{SC.AHDLInclude})
             if !isempty(scope.condition_stack)
                 error("Includes not allowed in conditional blocks. If you need this feature, please file an issue.")
             end
-            str = strip(unescape_string(String(stmt.path)), ['"', '\'']) # verify??
+            # AHDLInclude (Spectre) uses `filename`; the SPICE nodes use `path`.
+            raw_str = isa(stmt, SNode{SC.AHDLInclude}) ? String(stmt.filename) : String(stmt.path)
+            str = strip(unescape_string(raw_str), ['"', '\'']) # verify??
             if startswith(str, JLPATH_PREFIX)
                 path = str[sizeof(JLPATH_PREFIX)+1:end]
                 components = splitpath(path)
@@ -475,16 +476,9 @@ function sema!(scope::SemaResult, n::Union{SNode{SPICENetlistSource}, SNode{SP.S
                     end
                 end
             end
-            if isa(stmt, SNode{SP.HDLStatement})
-                isempty(scope.condition_stack) || error("HDL includes not allowed in conditional blocks")
-                vm = parse_and_cache_va!(parse_cache, path)
-                if vm === nothing
-                    error("Preprocessing pass missed HDL include $path")
-                elseif isa(vm, VANode)
-                    error("HDL include $path was not codegen'ed at sema time")
-                else
-                    push!(scope.imported_hdl_modules, vm[2])
-                end
+            if isa(stmt, SNode{SP.HDLStatement}) || isa(stmt, SNode{SC.AHDLInclude})
+                sm = codegen_hdl!(parse_cache, path)
+                push!(scope.imported_hdl_modules, sm)
             else
                 # Handle self-referential includes: when a file includes a .LIB section from itself
                 this_path = scope.ast.ps.srcfile.path
@@ -802,10 +796,3 @@ function sema_assign_ids(r::SemaResult)
     end
 end
 
-function sema_codegen_hdl(r::SemaResult)
-    ret = Expr(:toplevel)
-    for (_, (_, va)) in r.hdl_includes
-        push!(ret.args, Cadnip.make_mna_module(va))
-    end
-    return ret
-end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -451,6 +451,19 @@ open(_HDL_SCS_NETLIST; write=true) do io
 end
 const _HDL_SCS_CIRCUIT = MNACircuit(_HDL_SCS_NETLIST)
 
+# cwd-relative .hdl from an inline netlist (no source_dir, no srcfile).
+# Tests the cache.jl fallback that handles `pathof(thismod) === nothing`.
+const _HDL_CWD_DIR = mktempdir(; cleanup=true)
+cp(_HDL_RESISTOR_VA, joinpath(_HDL_CWD_DIR, "resistor.va"))
+const _HDL_CWD_CIRCUIT = cd(_HDL_CWD_DIR) do
+    MNACircuit("""
+    * relative .hdl, no source_dir — must resolve via cwd
+    .hdl "resistor.va"
+    V1 vcc 0 DC 1
+    X1 vcc 0 BasicVAResistor R=1000
+    """; lang=:spice)
+end
+
 @testset "SPICE .hdl include (on-the-fly VA codegen)" begin
     @testset "inline MNACircuit(code) with absolute path" begin
         code = """
@@ -501,6 +514,12 @@ const _HDL_SCS_CIRCUIT = MNACircuit(_HDL_SCS_NETLIST)
         sol = dc!(_HDL_SCS_CIRCUIT)
         @test isapprox_deftol(sol[:vcc], 2.0)
         @test isapprox_deftol(sol[:I_v1], -2/4000)
+    end
+
+    @testset "relative .hdl from MNACircuit(code; lang) resolves against cwd" begin
+        sol = dc!(_HDL_CWD_CIRCUIT)
+        @test isapprox_deftol(sol[:vcc], 1.0)
+        @test isapprox_deftol(sol[:I_v1], -1/1000)
     end
 end
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -419,32 +419,74 @@ end
     end
 end
 
-# TODO: Verilog-A include support
-#=
-@testset "Verilog include" begin
-    # Test Spectre ahdl_include
-    ckt = """
-    ahdl_include "resistor.va"
+# HDL include tests — `va"..."`-level fixture path is resolved at module
+# top level so @testset closures (function bodies) can call MNACircuit/dc!
+# without tripping world-age.
+const _HDL_RESISTOR_VA = joinpath(dirname(pathof(Cadnip.NyanVerilogAParser)),
+                                   "..", "test", "inputs", "resistor.va")
+@assert isfile(_HDL_RESISTOR_VA) "fixture missing: $(_HDL_RESISTOR_VA)"
 
-    x1 (vcc 0) BasicVAResistor R=2k
-    v1 (vcc 0) vsource dc=1
-    """
-    inc = joinpath(dirname(pathof(Cadnip.NyanVerilogAParser)), "../test/inputs")
-    sys, sol = solve_spectre_code(ckt; include_dirs=[inc]);
-    @test all(isapprox.(sol[sys.v1.I], -1/2e3))
-
-    # Test SPICE .hdl
-    ckt2 = """
-    * Verilog Include 2
+# File-path MNACircuit call requires the builder to be defined at top level.
+# Write a persistent fixture netlist next to the .va in a subdir of @__DIR__.
+const _HDL_FIXTURE_DIR = mktempdir(; cleanup=true)
+cp(_HDL_RESISTOR_VA, joinpath(_HDL_FIXTURE_DIR, "resistor.va"))
+const _HDL_NETLIST = joinpath(_HDL_FIXTURE_DIR, "hdl_test.sp")
+open(_HDL_NETLIST; write=true) do io
+    write(io, """
+    * HDL via file path
     .hdl "resistor.va"
-
-    x1 vcc 0 BasicVAResistor r=2k
-    v1 vcc 0 dc=1
-    """
-    sys, sol = solve_spice_code(ckt2; include_dirs=[inc]);
-    @test all(isapprox.(sol[sys.v1.I], -1/2e3))
+    X1 vcc 0 BasicVAResistor R=4000
+    V1 vcc 0 DC 2
+    """)
 end
-=#
+const _HDL_FILE_CIRCUIT = MNACircuit(_HDL_NETLIST)
+
+@testset "SPICE .hdl include (on-the-fly VA codegen)" begin
+    @testset "inline MNACircuit(code) with absolute path" begin
+        code = """
+        * HDL on-the-fly smoke test
+        .hdl "$_HDL_RESISTOR_VA"
+        X1 vcc 0 BasicVAResistor R=2000
+        V1 vcc 0 DC 1
+        """
+        circuit = MNACircuit(code; lang=:spice)
+        sol = dc!(circuit)
+        @test isapprox_deftol(sol[:vcc], 1.0)
+        @test isapprox_deftol(sol[:I_v1], -1/2000)
+    end
+
+    @testset "file-path MNACircuit with sibling .va" begin
+        sol = dc!(_HDL_FILE_CIRCUIT)
+        @test isapprox_deftol(sol[:vcc], 2.0)
+        @test isapprox_deftol(sol[:I_v1], -2/4000)
+    end
+
+    @testset "double .hdl of same file is idempotent" begin
+        # Two directives referencing the same file should not error; the second
+        # finds the cached Pair and reuses the existing module.
+        code = """
+        * Double HDL include
+        .hdl "$_HDL_RESISTOR_VA"
+        .hdl "$_HDL_RESISTOR_VA"
+        X1 vcc 0 BasicVAResistor R=1000
+        V1 vcc 0 DC 1
+        """
+        circuit = MNACircuit(code; lang=:spice)
+        sol = dc!(circuit)
+        @test isapprox_deftol(sol[:I_v1], -1/1000)
+    end
+
+    @testset "Spectre ahdl_include" begin
+        code = """
+        ahdl_include "$_HDL_RESISTOR_VA"
+        x1 (vcc 0) BasicVAResistor R=2000
+        v1 (vcc 0) vsource type=dc dc=1
+        """
+        circuit = MNACircuit(code; lang=:spectre)
+        sol = dc!(circuit)
+        @test isapprox_deftol(sol[:vcc], 1.0)
+    end
+end
 
 @testset "SPICE parameter scope" begin
     # Same SPICE code as original

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -441,6 +441,16 @@ open(_HDL_NETLIST; write=true) do io
 end
 const _HDL_FILE_CIRCUIT = MNACircuit(_HDL_NETLIST)
 
+const _HDL_SCS_NETLIST = joinpath(_HDL_FIXTURE_DIR, "hdl_test.scs")
+open(_HDL_SCS_NETLIST; write=true) do io
+    write(io, """
+    ahdl_include "resistor.va"
+    v1 (vcc 0) vsource type=dc dc=2
+    x1 (vcc 0) BasicVAResistor R=4000
+    """)
+end
+const _HDL_SCS_CIRCUIT = MNACircuit(_HDL_SCS_NETLIST)
+
 @testset "SPICE .hdl include (on-the-fly VA codegen)" begin
     @testset "inline MNACircuit(code) with absolute path" begin
         code = """
@@ -476,7 +486,7 @@ const _HDL_FILE_CIRCUIT = MNACircuit(_HDL_NETLIST)
         @test isapprox_deftol(sol[:I_v1], -1/1000)
     end
 
-    @testset "Spectre ahdl_include" begin
+    @testset "Spectre ahdl_include (inline)" begin
         code = """
         ahdl_include "$_HDL_RESISTOR_VA"
         x1 (vcc 0) BasicVAResistor R=2000
@@ -485,6 +495,12 @@ const _HDL_FILE_CIRCUIT = MNACircuit(_HDL_NETLIST)
         circuit = MNACircuit(code; lang=:spectre)
         sol = dc!(circuit)
         @test isapprox_deftol(sol[:vcc], 1.0)
+    end
+
+    @testset "Spectre .scs file with ahdl_include + sibling .va" begin
+        sol = dc!(_HDL_SCS_CIRCUIT)
+        @test isapprox_deftol(sol[:vcc], 2.0)
+        @test isapprox_deftol(sol[:I_v1], -2/4000)
     end
 end
 


### PR DESCRIPTION
## Summary

- Fixes the on-the-fly HDL loading hole in the two-tier resolution API from PR #171: netlists referencing a sibling `.va` now work end-to-end via `sp"..."`, `MNACircuit(path)`, `MNACircuit(code; lang=:spice)`, `Base.include(mod, SpiceFile(...))`, and their Spectre equivalents.
- Before: `MNACircuit(sp"""..hdl \"foo.va\"; ..."""))` errored with "HDL include \<path\> was not codegen'ed at sema time"; `ahdl_include` in Spectre netlists was silently dropped.
- After: sema runs VA codegen on demand, installs the generated baremodule into the same module that receives the SPICE builder, and Tier 2 device lookup finds the VA models.

## Design

- New `codegen_hdl!(cache, path) -> Module` in `src/spc/interface.jl`. Idempotent; returns the cached module for the PDK-precompile path, otherwise calls `make_mna_module(va)`, evals into `cache.thismod`, and upgrades the cache entry to `Pair{VANode, Module}`.
- Sema `.hdl` / `ahdl_include` branch (`src/spc/sema.jl:447`) now dispatches both `SP.HDLStatement` and `SC.AHDLInclude` to `codegen_hdl!` (AHDLInclude uses `filename` instead of `path`, so the str extraction is guarded).
- `make_mna_circuit(ast; parse_cache=nothing)` takes a cache kwarg, threaded through all entry points — `sp"..."`, `spc"..."`, `Base.include(mod, SpiceFile/SpectreFile)`, and both branches of `MNACircuit(path_or_code)`.
- `MNACircuit(path_or_code)` builds the fresh per-call module via a new `_fresh_netlist_module(name)` helper that does `import Cadnip` so the VA baremodule's `import ..Cadnip` resolves.

## Cleanup

Removed dead pre-MNA DAECompiler-era helpers along the way (all unreachable after the `.hdl` rewire):

- `codegen_hdl_import!`, `codegen_hdl_imports!`, `codegen_missing_imports!` (used `make_spice_device`, the old DAECompiler codepath; no callers anywhere in `src/`)
- `analyze_imports!`, `analyze_mosfet_import` (only reachable via the deleted `codegen_missing_imports!`)
- `sema_codegen_hdl` and the never-populated `hdl_includes::Vector{...}` field on `SemaResult`

Net: **+124 / -176**.

## Test plan

New testset `SPICE .hdl include (on-the-fly VA codegen)` in `test/basic.jl` covers:

- [x] Inline `MNACircuit(code; lang=:spice)` with a `.hdl` referencing an absolute-path `.va`.
- [x] File-based `MNACircuit(path)` with a sibling `.va` in the same dir.
- [x] Double `.hdl` of the same file is idempotent (second hit returns the cached module, no re-codegen).
- [x] Spectre `ahdl_include`.
- [x] Full `julia --project=test test/runtests.jl` passes (exit 0), including PDK Precompilation (27/27) — the precompile path wasn't touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)