### PR TITLE
CI: inline parser tests, drop redundant main-env instantiate

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ jobs:
   benchmark:
     name: VACASK Benchmarks - Julia ${{ matrix.version }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,29 +32,6 @@ jobs:
 
       - uses: julia-actions/cache@v3
 
-      - name: Install dependencies
-        run: |
-          julia --project=. -e '
-            using Pkg
-            Pkg.instantiate()
-          '
-
-      - name: Run NyanSpectreNetlistParser tests
-        run: |
-          julia --project=NyanSpectreNetlistParser.jl -e '
-            using Pkg
-            Pkg.instantiate()
-            Pkg.test()
-          '
-
-      - name: Run NyanVerilogAParser tests
-        run: |
-          julia --project=NyanVerilogAParser.jl -e '
-            using Pkg
-            Pkg.instantiate()
-            Pkg.test()
-          '
-
       - name: Disable heavy precompile workloads
         run: |
           cat > test/LocalPreferences.toml << 'EOF'
@@ -104,13 +81,6 @@ jobs:
           version: ${{ matrix.version }}
 
       - uses: julia-actions/cache@v3
-
-      - name: Install dependencies
-        run: |
-          julia --project=. -e '
-            using Pkg
-            Pkg.instantiate()
-          '
 
       - name: Install and precompile test dependencies
         run: |

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CMCModels = "8a844b39-05e3-4819-8383-f5fae2d66f33"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
@@ -6,6 +7,7 @@ CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Cadnip = "28ce5535-9df1-4533-abc1-da0fb7327efb"
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 ControlSystemsBase = "aaaaaaaa-a6ca-5380-bf3e-84a91bcd477e"
+DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 DescriptorSystems = "a81e2ce2-54d1-11eb-2c75-db236b00f339"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,16 +5,26 @@ using Random
 # fixed seed chosen by fair dice roll
 Random.seed!(10)
 
-# Test group filtering via ARGS (from Pkg.test(test_args=[...]))
+# Test group filtering via ARGS
 # Supported groups:
 #   - "integration": Run only vadistiller integration tests (large VA models)
 #   - "core": Run core tests only (excludes integration)
+#   - "parsers": Run only parser tests
 #   - "all": Run all tests including integration
 #   - (default): Same as "core" - integration tests are opt-in
 const RUN_INTEGRATION = "integration" in ARGS || "all" in ARGS
 const RUN_CORE = !("integration" in ARGS) || "all" in ARGS
+const RUN_PARSERS = "parsers" in ARGS || RUN_CORE || "all" in ARGS
 
-if RUN_INTEGRATION && !RUN_CORE
+if RUN_PARSERS && !RUN_CORE && !RUN_INTEGRATION
+    @info "Running parser tests only"
+    @testset "NyanSpectreNetlistParser" begin
+        include("../NyanSpectreNetlistParser.jl/test/runtests.jl")
+    end
+    @testset "NyanVerilogAParser" begin
+        include("../NyanVerilogAParser.jl/test/runtests.jl")
+    end
+elseif RUN_INTEGRATION && !RUN_CORE
     # Integration-only mode
     @info "Running integration tests only (large VA models)"
     using Cadnip
@@ -32,6 +42,14 @@ if RUN_INTEGRATION && !RUN_CORE
     end
 elseif RUN_CORE
     @info "Running core tests"
+
+    # Parser tests (run before loading Cadnip - no dependency on it)
+    @testset "NyanSpectreNetlistParser" begin
+        include("../NyanSpectreNetlistParser.jl/test/runtests.jl")
+    end
+    @testset "NyanVerilogAParser" begin
+        include("../NyanVerilogAParser.jl/test/runtests.jl")
+    end
 
     using Cadnip
 


### PR DESCRIPTION
## Summary
- Inline the `NyanSpectreNetlistParser` and `NyanVerilogAParser` testsets into `test/runtests.jl` so they share the `--project=test` environment instead of each spinning up its own via `Pkg.test()`.
- Drop the `Pkg.instantiate()` on `--project=.` from both `test-core` and `test-integration` — the test env already develops Cadnip, so the extra instantiate was just re-resolving/pre-compiling overlapping deps in a separate Manifest.
- Bump benchmark `timeout-minutes: 60 → 90` (recent runs have been finishing in the 56–59 min range).

## Why not the bigger PR (#161)?
Tried a shared precompile job in #161 — downstream jobs run 10–25 min faster each, but the 27–33 min serial precompile step makes the whole workflow ~30 min slower end-to-end (91 min vs 61 min on main). Closing that approach in favor of just removing the duplicated work within each job.

## Test plan
- [ ] Core, integration, and benchmark jobs pass on both Julia 1.11 and 1.12
- [ ] Total wall clock should be about the same as main (or slightly better), not worse

🤖 Generated with [Claude Code](https://claude.com/claude-code)