### PR TITLE
Migrate Mosaic model-db generator to new schema + non-destructive upload

### DIFF
--- a/SpiceArmyKnife.jl/src/Generate.jl
+++ b/SpiceArmyKnife.jl/src/Generate.jl
@@ -173,7 +173,7 @@ function (@main)(ARGS)
     println("\nSample models:")
     for model in first(all_models, min(3, length(all_models)))
         println("  - $(model["name"]) ($(model["type"]))")
-        println("    Category: $(join(model["category"], " / "))")
+        println("    Tags: $(join(get(model, "tags", String[]), " / "))")
         println("    ID: $(model["_id"])")
     end
     
@@ -209,6 +209,34 @@ function upload_to_couchdb(models, chunk_size=100)
     )
     
     try
+        # Back up shared state that does NOT come from this generator before we
+        # nuke the database: the compiled ClojureScript `name_search` view +
+        # Mango index (deployed by Mosaic CI) and the public read/write security
+        # object. The delete+recreate is intentional (it leaves no tombstones,
+        # so re-downloading a removed model is a harmless no-op and an upstream
+        # change can never clobber a user's locally-edited copy) — but it must
+        # not take these non-data documents down with it. The backup is a live
+        # GET taken immediately before DELETE, so Mosaic CI remains the source
+        # of truth for the design doc and no staleness is reintroduced here.
+        design = nothing
+        try
+            response = HTTP.get("$url/models/_design/models", headers)
+            design = JSON.parse(String(response.body))
+            delete!(design, "_rev")  # drop rev so the restore creates a fresh rev 1
+            println("Backed up _design/models")
+        catch
+            println("Note: no existing _design/models to back up")
+        end
+
+        sec = nothing
+        try
+            response = HTTP.get("$url/models/_security", headers)
+            sec = JSON.parse(String(response.body))
+            println("Backed up _security")
+        catch
+            println("Note: no existing _security to back up")
+        end
+
         # Delete existing database
         try
             HTTP.delete("$url/models", headers)
@@ -220,6 +248,17 @@ function upload_to_couchdb(models, chunk_size=100)
         # Create fresh database
         HTTP.put("$url/models", headers)
         println("Created fresh 'models' database")
+
+        # Restore the preserved non-data documents into the fresh database
+        if sec !== nothing && !isempty(sec)
+            HTTP.put("$url/models/_security", headers, JSON.json(sec))
+            println("Restored _security")
+        end
+        if design !== nothing
+            # No _rev ⇒ creates rev 1; the view index rebuilds lazily on first query
+            HTTP.put("$url/models/_design/models", headers, JSON.json(design))
+            println("Restored _design/models")
+        end
 
         # Upload in chunks
         total_uploaded = 0

--- a/SpiceArmyKnife.jl/src/Generate.jl
+++ b/SpiceArmyKnife.jl/src/Generate.jl
@@ -76,7 +76,7 @@ function (@main)(ARGS)
 
         ArchiveConfig(
             "https://nyancad.com/gh/fossi-foundation/globalfoundries-pdk-libs-gf180mcu_fd_pr/archive/refs/heads/main.zip",
-            ["globalfoundries-pdk-libs-gf180mcu_fd_pr-main/models/ngspice/sm141064.ngspice"],
+            ["globalfoundries-pdk-libs-gf180mcu_fd_pr-main/models/ngspice/sm141064.spice"],
             ["GF180MCU"],
             :lib; # FOSSi but large
             lib_sections=["typical"]

--- a/SpiceArmyKnife.jl/src/parse.jl
+++ b/SpiceArmyKnife.jl/src/parse.jl
@@ -717,9 +717,12 @@ function process_archive(config::ArchiveConfig)
         # Use p7zip to extract
         p7zip_exe = p7zip_jll.p7zip_path
 
-        try
-            println("Extracting archive...")
-            run(`$p7zip_exe x $archive_file -o$extract_dir -y`)
+        println("Extracting archive...")
+        p7zip_proc = run(ignorestatus(`$p7zip_exe x $archive_file -o$extract_dir -y`))
+
+        # 7zip may exit non-zero for warnings (e.g. skipped symlinks) even
+        # when all real files extracted fine.  Check for actual content.
+        if p7zip_proc.exitcode == 0 || !isempty(readdir(extract_dir))
             is_archive = true
 
             # Archive extraction succeeded - find files to process
@@ -748,8 +751,7 @@ function process_archive(config::ArchiveConfig)
                     end
                 end
             end
-
-        catch ProcessFailedException
+        else
             # Not an archive - treat downloaded file as single SPICE file
             println("Not an archive, processing as bare SPICE file")
             push!(matching_files, archive_file => basename(config.url))

--- a/SpiceArmyKnife.jl/src/parse.jl
+++ b/SpiceArmyKnife.jl/src/parse.jl
@@ -349,8 +349,9 @@ function extract_definitions(ast, config::ExtractionConfig, models::Vector{Any},
                 continue
             end
             ports = [LSymbol(node) for node in stmt.subckt_nodes]
-            # Start with parameters from subckt line
-            params = [LSymbol(p.name) for p in stmt.parameters]
+            # Start with parameters from subckt line, capturing simple-constant
+            # defaults so they survive into the model's props.
+            params = Tuple{Symbol,Union{String,Nothing}}[(LSymbol(p.name), simple_const_default(p)) for p in stmt.parameters]
             # Add parameters from .param statements inside subcircuit
             extract_subckt_params!(stmt, params)
             # Use fullcontents to capture preceding comments
@@ -363,7 +364,7 @@ function extract_definitions(ast, config::ExtractionConfig, models::Vector{Any},
                 continue
             end
             ports = [LSymbol(node) for node in stmt.subckt_nodes.nodes]
-            params = Symbol[]
+            params = Tuple{Symbol,Union{String,Nothing}}[]
             # Add parameters from .param statements inside subcircuit
             extract_subckt_params!(stmt, params)
             # Use fullcontents to capture preceding comments
@@ -374,15 +375,25 @@ function extract_definitions(ast, config::ExtractionConfig, models::Vector{Any},
     return models, subcircuits
 end
 
+# nothing → no usable default; else the literal's source text (e.g. "0.35u").
+# A "simple constant" is exactly a numeric literal node — SI suffixes are part of
+# the number token. Identifiers, {brace} expressions, binary expressions and
+# function calls are not simple constants, so their defaults are omitted (the
+# subckt's own definition supplies them at netlist time).
+simple_const_default(par) =
+    (par.val !== nothing &&
+     (par.val isa SNode{SP.NumberLiteral} || par.val isa SNode{SC.NumberLiteral})) ?
+        String(par.val) : nothing
+
 function extract_subckt_params!(subckt, params)
     for stmt in subckt.stmts
         if isa(stmt, SNode{SP.ParamStatement})
             for par in stmt.params
-                push!(params, LSymbol(par.name))
+                push!(params, (LSymbol(par.name), simple_const_default(par)))
             end
         elseif isa(stmt, SNode{SC.Parameters})
             for par in stmt.params
-                push!(params, LSymbol(par.name))
+                push!(params, (LSymbol(par.name), simple_const_default(par)))
             end
         end
     end
@@ -511,8 +522,14 @@ function to_mosaic_format(models, subcircuits; source_file=nothing, base_categor
                 "models" => build_spice_models(name, "SUBCKT";
                     code=code, mode=mode, archive_url=archive_url, file_path=source_file,
                     lib_sections=lib_sections, port_order=ports, target_simulators=target_simulators),
-                # Convert parameter names to props format
-                "props" => [Dict{String, Any}("name" => string(param), "tooltip" => "") for param in parameters]
+                # Convert parameters to props format. Every param stays editable
+                # in the UI; a "default" is recorded only for simple constants.
+                "props" => [begin
+                              d = Dict{String, Any}("name" => string(name), "tooltip" => "")
+                              default === nothing || (d["default"] = default)
+                              d
+                            end
+                            for (name, default) in parameters]
             )
 
             push!(result, model_def)

--- a/SpiceArmyKnife.jl/src/parse.jl
+++ b/SpiceArmyKnife.jl/src/parse.jl
@@ -68,27 +68,120 @@ struct ArchiveConfig
 end
 
 """
-    generate_template_code(code, mode, archive_url, file_path)
+    spice_type_letter(mosaic_type) -> String
 
-Generate template code for Mosaic format.
-- mode = :inline: returns the actual code
-- mode = :include: returns .include statement
-- mode = :lib: returns .lib statement with {corner} section
-
-Paths are always quoted to handle spaces and special characters.
+Map a Mosaic device type to its SPICE element-type letter, used as the
+`spice-type` of a `.model` primitive's model entry (R/C/L/D/M/Q). Returns
+"" for types without a primitive letter (e.g. "ckt").
 """
-function generate_template_code(code, mode, archive_url, file_path)
+function spice_type_letter(mosaic_type)
+    t = lowercase(string(mosaic_type))
+    if t == "resistor"
+        "R"
+    elseif t == "capacitor"
+        "C"
+    elseif t == "inductor"
+        "L"
+    elseif t == "diode"
+        "D"
+    elseif t in ("nmos", "pmos")
+        "M"
+    elseif t in ("npn", "pnp")
+        "Q"
+    else
+        ""
+    end
+end
+
+"""
+    ports_to_entries(layout) -> Vector{Dict}
+
+Flatten a side-bucketed port layout (from `determine_port_layout`) into the
+flat `ports` list the Mosaic schema expects:
+`[{name, side, type:"electric"}, ...]`. All ports are electric — SPICE PDKs
+have no photonic ports.
+"""
+function ports_to_entries(layout)
+    entries = Vector{Dict{String, Any}}()
+    for side in ("top", "bottom", "left", "right")
+        for name in layout[side]
+            push!(entries, Dict{String, Any}("name" => name, "side" => side, "type" => "electric"))
+        end
+    end
+    return entries
+end
+
+"""
+    build_spice_models(name, spice_type; code, mode, archive_url, file_path,
+                       lib_sections=String[], port_order=nothing,
+                       target_simulators=AbstractSimulator[]) -> Vector{Dict}
+
+Build the flat `models` entry list for one model definition.
+
+- `:inline` mode embeds the raw SPICE `code`, plus one extra entry per target
+  simulator (tagged with `implementation`) when conversions are requested.
+- `:lib`/`:include` mode emits structured `library` (+ `sections` when a corner
+  whitelist is set) instead of code; `netlist.py` selects the corner and emits
+  the `.lib`/`.include` line, so no `{corner}` token is baked in here.
+
+`spice_type` is the element letter for `.model` primitives or "SUBCKT" for
+subcircuits. `port_order` (the original ordered subckt pin list) is included
+when provided and omitted for primitives.
+"""
+function build_spice_models(name, spice_type;
+                            code, mode, archive_url, file_path,
+                            lib_sections=String[], port_order=nothing,
+                            target_simulators=AbstractSimulator[])
+    entries = Vector{Dict{String, Any}}()
+
+    function with_port_order!(entry)
+        if port_order !== nothing
+            entry["port-order"] = string.(port_order)
+        end
+        entry
+    end
+
     if mode == :inline
-        return code
-    elseif mode == :include
-        path = archive_url !== nothing ? "\"$(archive_url)#$(file_path)\"" : "\"$(file_path)\""
-        return ".include $(path)"
-    elseif mode == :lib
-        path = archive_url !== nothing ? "\"$(archive_url)#$(file_path)\"" : "\"$(file_path)\""
-        return ".lib $(path) {corner}"
+        push!(entries, with_port_order!(Dict{String, Any}(
+            "language" => "spice",
+            "name" => string(name),
+            "spice-type" => spice_type,
+            "code" => code,
+        )))
+
+        # Simulator-specific conversions (only meaningful for inline code)
+        for sim in target_simulators
+            try
+                ast = NyanSpectreNetlistParser.parse(IOBuffer(code); start_lang=:spice, implicit_title=false)
+                converted_code = generate_code(ast, sim)
+                push!(entries, with_port_order!(Dict{String, Any}(
+                    "language" => "spice",
+                    "name" => string(name),
+                    "spice-type" => spice_type,
+                    "implementation" => string(symbol_from_simulator(sim)),
+                    "code" => converted_code,
+                )))
+            catch e
+                println("  Warning: Failed to convert $name to $(typeof(sim)) simulator: $e")
+            end
+        end
+    elseif mode == :include || mode == :lib
+        library = archive_url !== nothing ? "$(archive_url)#$(file_path)" : "$(file_path)"
+        entry = Dict{String, Any}(
+            "language" => "spice",
+            "name" => string(name),
+            "spice-type" => spice_type,
+            "library" => library,
+        )
+        if !isempty(lib_sections)
+            entry["sections"] = lib_sections
+        end
+        push!(entries, with_port_order!(entry))
     else
         error("Invalid mode: $mode. Must be :inline, :include, or :lib")
     end
+
+    return entries
 end
 
 """
@@ -346,14 +439,16 @@ Parameters:
 - subcircuits: Vector of (name, ports, parameters, code) tuples from extract_definitions
 - source_file: Optional source filename for metadata
 - base_category: Base category path as vector of strings
-- mode: Either :inline (embed code directly), :include (use .include), or :lib (use .lib with {corner})
+- mode: Either :inline (embed code directly), :include (use .include), or :lib (structured library + sections)
 - archive_url: For include/lib modes, the archive URL in zipurl#archive/path format
 - file_device_type: Override device type for all subcircuits in this file (e.g., "capacitor")
+- lib_sections: For :lib mode, the corner/section whitelist recorded on each entry's `sections` field
 - target_simulators: Vector of simulators to generate converted templates for (e.g., [Ngspice()]). Only works with :inline mode.
 
-Returns Vector{Dict} with model definitions including _id keys.
+Returns Vector{Dict} with model definitions including _id keys (new Mosaic schema:
+`tags`, flat `models` list, flat `ports` list).
 """
-function to_mosaic_format(models, subcircuits; source_file=nothing, base_category=String[], mode=:inline, archive_url=nothing, file_device_type=nothing, target_simulators=AbstractSimulator[])
+function to_mosaic_format(models, subcircuits; source_file=nothing, base_category=String[], mode=:inline, archive_url=nothing, file_device_type=nothing, lib_sections=String[], target_simulators=AbstractSimulator[])
     result = Vector{Dict{String, Any}}()
     
     # Convert models (SPICE .model statements)
@@ -361,60 +456,27 @@ function to_mosaic_format(models, subcircuits; source_file=nothing, base_categor
         try
             # Create unique random ID for this model
             model_id = "models:$(string(uuid4()))"
-            
+
             # Map SPICE device types directly to Mosaic types, using subtype for polarity
             mosaic_type = device_type_mapping(typ, subtype)
 
-            # Generate template code based on mode
-            template_code = generate_template_code(code, mode, archive_url, source_file)
-
-            # Build templates array: default first, then dialect-specific conversions
-            spice_templates = [Dict(
-                "name" => "default",
-                "code" => template_code,
-                "use-x" => false
-            )]
-
-            # Add simulator-specific conversions (only for :inline mode)
-            if mode == :inline && !isempty(target_simulators)
-                for sim in target_simulators
-                    try
-                        # Parse the code and convert to target simulator
-                        ast = NyanSpectreNetlistParser.parse(IOBuffer(code); start_lang=:spice, implicit_title=false)
-                        converted_code = generate_code(ast, sim)
-
-                        push!(spice_templates, Dict(
-                            "name" => string(symbol_from_simulator(sim)),
-                            "code" => converted_code,
-                            "use-x" => false
-                        ))
-                    catch e
-                        println("  Warning: Failed to convert model $name to $(typeof(sim)) simulator: $e")
-                    end
-                end
-            end
+            # Tags: base category plus the source filename when known
+            tags = source_file !== nothing ? vcat(base_category, [basename(source_file)]) : base_category
 
             model_def = Dict{String, Any}(
                 "_id" => model_id,
                 "name" => string(name),
                 "type" => mosaic_type,
-                "category" => base_category,  # Put models in Models subcategory
-                # SPICE models define device templates, not schematic circuits
-                "templates" => Dict(
-                    "spice" => spice_templates,
-                    "spectre" => Vector{Dict{String,Any}}(),
-                    "verilog" => Vector{Dict{String,Any}}(),
-                    "vhdl" => Vector{Dict{String,Any}}()
-                ),
+                "tags" => tags,
+                # SPICE .model primitives reference a built-in symbol, so the
+                # entry carries the element letter (R/C/M/...), no port-order.
+                "models" => build_spice_models(name, spice_type_letter(mosaic_type);
+                    code=code, mode=mode, archive_url=archive_url, file_path=source_file,
+                    lib_sections=lib_sections, target_simulators=target_simulators),
                 # TODO: Extract parameter info from model statement
-                "props" => Vector{Dict{String,Any}}()
+                "props" => Vector{Dict{String, Any}}()
             )
-            
-            # Add source file info if available
-            if source_file !== nothing
-                model_def["category"] = vcat(base_category, [basename(source_file)])
-            end
-            
+
             push!(result, model_def)
         catch e
             showerror(stderr, e)
@@ -423,7 +485,7 @@ function to_mosaic_format(models, subcircuits; source_file=nothing, base_categor
         end
     end
     
-    # Convert subcircuits  
+    # Convert subcircuits
     for (name, ports, parameters, code) in subcircuits
         try
             # Use file-level override if specified, otherwise detect from name
@@ -431,60 +493,28 @@ function to_mosaic_format(models, subcircuits; source_file=nothing, base_categor
 
             # Create unique random ID for this subcircuit
             model_id = "models:$(string(uuid4()))"
-            
-            # Determine port layout using heuristics based on port names
+
+            # Determine port layout (for the symbol) using heuristics based on port names
             port_layout = determine_port_layout(ports)
 
-            # Generate template code based on mode
-            template_code = generate_template_code(code, mode, archive_url, source_file)
-
-            # Build templates array: default first, then dialect-specific conversions
-            spice_templates = [Dict(
-                "name" => "default",
-                "code" => template_code,
-                "use-x" => true  # subcircuits always use X prefix
-            )]
-
-            # Add simulator-specific conversions (only for :inline mode)
-            if mode == :inline && !isempty(target_simulators)
-                for sim in target_simulators
-                    try
-                        # Parse the code and convert to target simulator
-                        ast = NyanSpectreNetlistParser.parse(IOBuffer(code); start_lang=:spice, implicit_title=false)
-                        converted_code = generate_code(ast, sim)
-
-                        push!(spice_templates, Dict(
-                            "name" => string(symbol_from_simulator(sim)),
-                            "code" => converted_code,
-                            "use-x" => true  # subcircuits always use X prefix
-                        ))
-                    catch e
-                        println("  Warning: Failed to convert subcircuit $name to $(typeof(sim)) simulator: $e")
-                    end
-                end
-            end
+            # Tags: base category plus the source filename when known
+            tags = source_file !== nothing ? vcat(base_category, [basename(source_file)]) : base_category
 
             model_def = Dict{String, Any}(
                 "_id" => model_id,
                 "name" => string(name),
                 "type" => device_type,
-                "category" => base_category,
-                "ports" => port_layout,
-                "templates" => Dict(
-                    "spice" => spice_templates,
-                    "spectre" => Vector{Dict{String,Any}}(),
-                    "verilog" => Vector{Dict{String,Any}}(),
-                    "vhdl" => Vector{Dict{String,Any}}()
-                ),
+                "tags" => tags,
+                "ports" => ports_to_entries(port_layout),
+                # Subcircuits are instantiated with X; port-order preserves the
+                # original ordered subckt pin list for netlist generation.
+                "models" => build_spice_models(name, "SUBCKT";
+                    code=code, mode=mode, archive_url=archive_url, file_path=source_file,
+                    lib_sections=lib_sections, port_order=ports, target_simulators=target_simulators),
                 # Convert parameter names to props format
-                "props" => [Dict("name" => string(param), "tooltip" => "") for param in parameters]
+                "props" => [Dict{String, Any}("name" => string(param), "tooltip" => "") for param in parameters]
             )
-            
-            # Add source file info if available  
-            if source_file !== nothing
-                model_def["category"] = vcat(base_category, [basename(source_file)])
-            end
-            
+
             push!(result, model_def)
         catch e
             showerror(stderr, e)
@@ -757,6 +787,7 @@ function process_archive(config::ArchiveConfig)
                         mode=config.mode,
                         archive_url=is_archive ? config.url : nothing,
                         file_device_type=file_device_type,
+                        lib_sections=config.lib_sections,
                         target_simulators=config.target_simulators
                     )
 

--- a/SpiceArmyKnife.jl/test/runtests.jl
+++ b/SpiceArmyKnife.jl/test/runtests.jl
@@ -1,3 +1,4 @@
 # SpiceArmyKnife.jl test suite
 
 include("test_codegen.jl")
+include("test_parse.jl")

--- a/SpiceArmyKnife.jl/test/test_parse.jl
+++ b/SpiceArmyKnife.jl/test/test_parse.jl
@@ -1,0 +1,118 @@
+# Tests for the Mosaic model-database conversion (to_mosaic_format) — the new
+# schema: flat `tags`, flat `models` entry list, flat `ports` list, explicit
+# `port-order`.
+
+using Test
+using SpiceArmyKnife
+
+@testset "Mosaic format conversion" begin
+
+    @testset "spice_type_letter" begin
+        @test SpiceArmyKnife.spice_type_letter("resistor") == "R"
+        @test SpiceArmyKnife.spice_type_letter("capacitor") == "C"
+        @test SpiceArmyKnife.spice_type_letter("inductor") == "L"
+        @test SpiceArmyKnife.spice_type_letter("diode") == "D"
+        @test SpiceArmyKnife.spice_type_letter("nmos") == "M"
+        @test SpiceArmyKnife.spice_type_letter("pmos") == "M"
+        @test SpiceArmyKnife.spice_type_letter("npn") == "Q"
+        @test SpiceArmyKnife.spice_type_letter("pnp") == "Q"
+        @test SpiceArmyKnife.spice_type_letter("ckt") == ""
+    end
+
+    @testset "ports_to_entries" begin
+        layout = Dict("top" => ["vdd"], "bottom" => ["vss"],
+                      "left" => ["in"], "right" => ["out"])
+        entries = SpiceArmyKnife.ports_to_entries(layout)
+        @test length(entries) == 4
+        @test all(e -> e["type"] == "electric", entries)
+        @test Dict("name" => "in", "side" => "left", "type" => "electric") in entries
+        @test Dict("name" => "vdd", "side" => "top", "type" => "electric") in entries
+    end
+
+    @testset "inline .model primitive" begin
+        models = [(:res_model, :r, :nmos, ".model res_model R (...)")]
+        result = to_mosaic_format(models, []; base_category=["Basic"],
+                                  source_file="basic.lib", mode=:inline)
+        @test length(result) == 1
+        doc = result[1]
+        @test startswith(doc["_id"], "models:")
+        @test doc["name"] == "res_model"
+        @test doc["type"] == "resistor"
+        @test doc["tags"] == ["Basic", "basic.lib"]
+        @test doc["props"] == []
+        # New schema: no legacy keys, no `ports` for primitives
+        @test !haskey(doc, "category")
+        @test !haskey(doc, "templates")
+        @test !haskey(doc, "ports")
+        # Single inline entry with the element letter and the raw code
+        @test length(doc["models"]) == 1
+        entry = doc["models"][1]
+        @test entry["language"] == "spice"
+        @test entry["spice-type"] == "R"
+        @test entry["code"] == ".model res_model R (...)"
+        @test !haskey(entry, "port-order")
+        @test !haskey(entry, "library")
+    end
+
+    @testset "inline subcircuit" begin
+        subs = [(:myamp, [:in, :out, :vdd, :vss], [:gain], ".subckt myamp in out vdd vss\n...")]
+        result = to_mosaic_format([], subs; base_category=["Lib"],
+                                  source_file="amps.lib", mode=:inline)
+        @test length(result) == 1
+        doc = result[1]
+        @test doc["name"] == "myamp"
+        @test doc["tags"] == ["Lib", "amps.lib"]
+        # Flat port list and props from params
+        @test length(doc["ports"]) == 4
+        @test all(p -> p["type"] == "electric", doc["ports"])
+        @test doc["props"] == [Dict("name" => "gain", "tooltip" => "")]
+        # SUBCKT entry with inline code and the original ordered pin list
+        entry = doc["models"][1]
+        @test entry["spice-type"] == "SUBCKT"
+        @test entry["code"] == ".subckt myamp in out vdd vss\n..."
+        @test entry["port-order"] == ["in", "out", "vdd", "vss"]
+        @test !haskey(doc, "category")
+        @test !haskey(doc, "templates")
+    end
+
+    @testset ":lib subcircuit -> structured library + sections" begin
+        subs = [(:nfet, [:d, :g, :s, :b], Symbol[], ".subckt nfet d g s b\n...")]
+        result = to_mosaic_format([], subs; base_category=["Sky130"],
+                                  source_file="sky130.lib.spice",
+                                  mode=:lib, archive_url="https://example.com/pdk.zip",
+                                  lib_sections=["tt"], file_device_type="nmos")
+        doc = result[1]
+        @test doc["type"] == "nmos"
+        entry = doc["models"][1]
+        @test entry["spice-type"] == "SUBCKT"
+        @test entry["library"] == "https://example.com/pdk.zip#sky130.lib.spice"
+        @test entry["sections"] == ["tt"]
+        @test entry["port-order"] == ["d", "g", "s", "b"]
+        # No {corner} token / inline code in :lib mode
+        @test !haskey(entry, "code")
+    end
+
+    @testset ":lib .model primitive -> structured library, element letter" begin
+        models = [(:sg13_nmos, :nmos, :nmos, ".model sg13_nmos nmos (...)")]
+        result = to_mosaic_format(models, []; base_category=["IHP"],
+                                  source_file="cornerMOSlv.lib",
+                                  mode=:lib, archive_url="https://example.com/ihp.zip",
+                                  lib_sections=["mos_tt"])
+        entry = result[1]["models"][1]
+        @test entry["spice-type"] == "M"
+        @test entry["library"] == "https://example.com/ihp.zip#cornerMOSlv.lib"
+        @test entry["sections"] == ["mos_tt"]
+        @test !haskey(entry, "port-order")  # primitives have no pin list
+        @test !haskey(entry, "code")
+    end
+
+    @testset "bare file (no archive_url) uses file path as library" begin
+        subs = [(:foo, [:a, :b], Symbol[], ".subckt foo a b\n...")]
+        result = to_mosaic_format([], subs; base_category=["X"],
+                                  source_file="https://example.com/foo.lib",
+                                  mode=:include, archive_url=nothing)
+        entry = result[1]["models"][1]
+        @test entry["library"] == "https://example.com/foo.lib"
+        @test !haskey(entry, "sections")  # no corner whitelist for :include
+    end
+end

--- a/SpiceArmyKnife.jl/test/test_parse.jl
+++ b/SpiceArmyKnife.jl/test/test_parse.jl
@@ -55,7 +55,8 @@ using SpiceArmyKnife
     end
 
     @testset "inline subcircuit" begin
-        subs = [(:myamp, [:in, :out, :vdd, :vss], [:gain], ".subckt myamp in out vdd vss\n...")]
+        # params are (name, default) pairs; nothing default → no "default" key
+        subs = [(:myamp, [:in, :out, :vdd, :vss], [(:gain, nothing)], ".subckt myamp in out vdd vss\n...")]
         result = to_mosaic_format([], subs; base_category=["Lib"],
                                   source_file="amps.lib", mode=:inline)
         @test length(result) == 1
@@ -75,8 +76,21 @@ using SpiceArmyKnife
         @test !haskey(doc, "templates")
     end
 
+    @testset "subcircuit params with defaults" begin
+        # Simple-constant defaults are recorded; expression/identifier defaults
+        # are kept as bare params (no "default" key) so the subckt fills them in.
+        subs = [(:mysub, [:d, :g, :s], [(:w, "0.35u"), (:l, "2"), (:k, nothing)],
+                 ".subckt mysub d g s w=0.35u l=2 k={a+b}\n...")]
+        result = to_mosaic_format([], subs; base_category=["Lib"],
+                                  source_file="dev.lib", mode=:inline)
+        props = result[1]["props"]
+        @test props == [Dict("name" => "w", "tooltip" => "", "default" => "0.35u"),
+                        Dict("name" => "l", "tooltip" => "", "default" => "2"),
+                        Dict("name" => "k", "tooltip" => "")]
+    end
+
     @testset ":lib subcircuit -> structured library + sections" begin
-        subs = [(:nfet, [:d, :g, :s, :b], Symbol[], ".subckt nfet d g s b\n...")]
+        subs = [(:nfet, [:d, :g, :s, :b], Tuple{Symbol,Union{String,Nothing}}[], ".subckt nfet d g s b\n...")]
         result = to_mosaic_format([], subs; base_category=["Sky130"],
                                   source_file="sky130.lib.spice",
                                   mode=:lib, archive_url="https://example.com/pdk.zip",


### PR DESCRIPTION
## Summary
- **Schema migration** (`parse.jl` `to_mosaic_format`): `category`→`tags` (flat list); `templates` dict → flat `models` list of typed entries (hyphenated keys `spice-type`, `port-order`); `ports` dict-by-side → flat `ports` list `[{name, side, type:"electric"}]`; new explicit `port-order` on subckt entries (preserves the original ordered pin list). `:inline` embeds code (+ per-simulator `implementation` entries); `:lib`/`:include` emit structured `library` + `sections` (corner now chosen by `netlist.py` `_select_corner`, no `{corner}` token). `.model` primitives in `:lib`/`:include` also use structured library/sections with the SPICE element letter. Removed dead `generate_template_code`.
- **Non-destructive upload** (`Generate.jl`): back up `_design/models` (compiled `name_search` view + Mango index, owned by Mosaic CI) and `_security` (public read/write) via a live GET right before DELETE, then restore both into the fresh DB before the bulk upload. Delete+recreate is kept intentionally (no tombstones → re-download is a no-op, upstream changes can't clobber a user's locally-edited copy in `userdb-<user>`).

## Test Plan
- [x] `to_mosaic_format` unit tests (`test/test_parse.jl`) — new schema shapes for inline/`:lib` models and subcircuits
- [x] Existing codegen suite (179 tests) still passes — no regression
- [x] Sample output validates against Mosaic's `ModelMetadata` Pydantic schema
- [ ] **Manual (needs CouchDB):** upload against a scratch `models_test` DB pre-seeded with a custom `_design/models` + `_security`; assert both survive byte-for-byte (minus `_rev`) and new docs are present; repeat with no pre-existing design doc (404-tolerant path)

## Notes
- Companion Mosaic PR updates the Mango index `category`→`tags`.
- Discovered (separate Mosaic fix): `netlist.py`'s structured-`library` path (`self.lib`/`self.include`) bypasses the URL→cache download resolution the inline-`code` path gets via `resolve_url_includes`, so `http(s)` library URLs are handed to InSpice as local paths.