### PR TITLE
benchmarks: add real VACASK reference numbers via official benchmark.py

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ jobs:
   benchmark:
     name: VACASK Benchmarks - Julia ${{ matrix.version }}
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 360  # GitHub Actions per-job maximum; the real c6288 VACASK run is slow
     strategy:
       fail-fast: false
       matrix:
@@ -41,16 +41,31 @@ jobs:
             Pkg.precompile()
           '
 
+      - name: Run real VACASK reference benchmarks
+        run: |
+          # Run every case including the slow c6288. The four small cases are
+          # folded into run_benchmarks.jl's comparison tables; c6288 (which has
+          # no Cadnip counterpart yet) is published in the standalone table.
+          CASES="rc graetz mul ring c6288" benchmarks/vacask/run_vacask.sh vacask_reference.md
+
       - name: Run VACASK benchmarks
+        env:
+          VACASK_REFERENCE_TSV: vacask_reference.tsv
         run: |
           julia --project=benchmarks benchmarks/vacask/run_benchmarks.jl benchmark_results.md
 
       - name: Publish benchmark results
-        run: cat benchmark_results.md >> $GITHUB_STEP_SUMMARY
+        run: |
+          cat benchmark_results.md >> $GITHUB_STEP_SUMMARY
+          echo >> $GITHUB_STEP_SUMMARY
+          cat vacask_reference.md >> $GITHUB_STEP_SUMMARY
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-results-julia-${{ matrix.version }}
-          path: benchmark_results.md
+          path: |
+            benchmark_results.md
+            vacask_reference.md
+            vacask_reference.tsv
           retention-days: 30

--- a/benchmarks/vacask/README.md
+++ b/benchmarks/vacask/README.md
@@ -24,6 +24,18 @@ Ngspice, Xyce and Gnucap were using builtin models of circuit elements. VACASK u
 
 For each test problem the number of timepoints and the number of Newton-Raphson (NR) iterations (residual evaluations for Xyce) is listed. In some cases the number of rejected timepoints is also given. All benchmarks were run on a computer with an AMD Threadripper 7970 processor. 
 
+# Reproducing the VACASK numbers
+
+The tables below were measured by the VACASK authors on an AMD Threadripper 7970. To obtain real VACASK numbers on the same machine that runs the Cadnip benchmarks (so the comparison is apples-to-apples), use [`run_vacask.sh`](run_vacask.sh):
+
+```bash
+benchmarks/vacask/run_vacask.sh results.md
+```
+
+The script downloads a prebuilt VACASK release (pinned to `0.3.3-dev`, which ships the PSP103.4 and SPICE-distilled OSDI models used here), then runs the official [`benchmark.py`](benchmark.py) methodology (1 warmup + 5 timed runs, averaged) on every case and writes a markdown table of wall-clock time, timepoints, rejected timepoints, and NR iterations. Set `VACASK_DIR` to point at an already-extracted release to skip the download, or `CASES="rc graetz mul ring"` to skip the slow c6288 case.
+
+Absolute timings depend on the machine, but the timepoint and iteration counts should match the upstream tables closely (the released binary reproduces the same algorithms).
+
 # Results
 
 ## RC circuit excited by a pulse train (rc)

--- a/benchmarks/vacask/benchmark.py
+++ b/benchmarks/vacask/benchmark.py
@@ -1,6 +1,20 @@
 #!/usr/bin/python3
-import sys, os, time, subprocess, shutil, importlib, platform
-import numpy as np
+import sys, os, time, subprocess, shutil, importlib, importlib.util, platform
+
+# numpy is optional - fall back to the stdlib statistics module so the script
+# runs in minimal CI environments without an extra pip install.
+try:
+    import numpy as np
+except ImportError:
+    import statistics as _st
+    class _np:
+        @staticmethod
+        def array(x): return list(x)
+        @staticmethod
+        def mean(x): return _st.mean(x)
+        @staticmethod
+        def std(x, ddof=0): return _st.stdev(x) if ddof == 1 else _st.pstdev(x)
+    np = _np()
 
 # Simple benchmarking framework
 # 

--- a/benchmarks/vacask/run_benchmarks.jl
+++ b/benchmarks/vacask/run_benchmarks.jl
@@ -65,7 +65,7 @@ end
 BenchmarkResult(name, solver, status, error_msg="") = BenchmarkResult(name, solver, status, NaN, NaN, NaN, NaN, 0, 0, 0, error_msg)
 
 # Label used for rows sourced from the real VACASK simulator (run_vacask.sh).
-const VACASK_REF_SOLVER = "VACASK (ref)"
+const VACASK_REF_SOLVER = "VACASK"
 
 #==============================================================================#
 # VACASK reference numbers
@@ -89,7 +89,7 @@ function load_vacask_reference()
         tp = something(tryparse(Int, cols[3]), 0)
         rej = something(tryparse(Int, cols[4]), 0)
         push!(refs, BenchmarkResult(name, VACASK_REF_SOLVER, :success,
-                                    t, t, t, NaN, 0, tp, rej, "reference simulator"))
+                                    t, t, t, NaN, 0, tp, rej, ""))
     end
     return refs
 end
@@ -128,10 +128,6 @@ function generate_markdown(results::Vector{BenchmarkResult})
     println(io)
     println(io, "Benchmarks run on Julia $(VERSION)")
     println(io)
-    if any(r -> r.solver == VACASK_REF_SOLVER, results)
-        println(io, "Rows labelled **$(VACASK_REF_SOLVER)** are the real VACASK simulator measured on the same machine (see `run_vacask.sh`), for an apples-to-apples comparison.")
-        println(io)
-    end
 
     # Summary table with all solvers
     println(io, "## Summary")

--- a/benchmarks/vacask/run_benchmarks.jl
+++ b/benchmarks/vacask/run_benchmarks.jl
@@ -128,6 +128,10 @@ function generate_markdown(results::Vector{BenchmarkResult})
     println(io)
     println(io, "Benchmarks run on Julia $(VERSION)")
     println(io)
+    if any(r -> r.solver == VACASK_REF_SOLVER, results)
+        println(io, "Rows labelled **$(VACASK_REF_SOLVER)** are the real VACASK simulator measured on the same machine (see `run_vacask.sh`), for an apples-to-apples comparison.")
+        println(io)
+    end
 
     # Summary table with all solvers
     println(io, "## Summary")
@@ -156,11 +160,10 @@ function generate_markdown(results::Vector{BenchmarkResult})
         successful = filter(r -> r.status == :success, bench_results)
 
         if !isempty(successful)
-            println(io, "| Solver | Median | Min | Max | Rejected | Memory | Notes |")
-            println(io, "|--------|--------|-----|-----|----------|--------|-------|")
+            println(io, "| Solver | Median | Min | Max | Rejected | Memory |")
+            println(io, "|--------|--------|-----|-----|----------|--------|")
             for r in successful
-                notes = isempty(r.error_msg) ? "" : r.error_msg
-                println(io, "| $(r.solver) | $(format_time(r.median_time)) | $(format_time(r.min_time)) | $(format_time(r.max_time)) | $(r.rejected) | $(format_memory(r.memory)) | $(notes) |")
+                println(io, "| $(r.solver) | $(format_time(r.median_time)) | $(format_time(r.min_time)) | $(format_time(r.max_time)) | $(r.rejected) | $(format_memory(r.memory)) |")
             end
             println(io)
 

--- a/benchmarks/vacask/run_benchmarks.jl
+++ b/benchmarks/vacask/run_benchmarks.jl
@@ -64,6 +64,36 @@ end
 
 BenchmarkResult(name, solver, status, error_msg="") = BenchmarkResult(name, solver, status, NaN, NaN, NaN, NaN, 0, 0, 0, error_msg)
 
+# Label used for rows sourced from the real VACASK simulator (run_vacask.sh).
+const VACASK_REF_SOLVER = "VACASK (ref)"
+
+#==============================================================================#
+# VACASK reference numbers
+#
+# run_vacask.sh runs the real VACASK binary via the upstream benchmark.py and
+# writes a TSV (benchmark, time_s, timepoints, rejected, iterations). If the
+# path is provided via $VACASK_REFERENCE_TSV we fold those rows into the same
+# comparison tables for an apples-to-apples, same-machine comparison.
+#==============================================================================#
+function load_vacask_reference()
+    refs = BenchmarkResult[]
+    path = get(ENV, "VACASK_REFERENCE_TSV", "")
+    (isempty(path) || !isfile(path)) && return refs
+    for line in eachline(path)
+        isempty(strip(line)) && continue
+        cols = split(line, '\t')
+        length(cols) < 5 && continue
+        name = String(cols[1])
+        t = tryparse(Float64, cols[2])
+        t === nothing && continue
+        tp = something(tryparse(Int, cols[3]), 0)
+        rej = something(tryparse(Int, cols[4]), 0)
+        push!(refs, BenchmarkResult(name, VACASK_REF_SOLVER, :success,
+                                    t, t, t, NaN, 0, tp, rej, "reference simulator"))
+    end
+    return refs
+end
+
 function format_time(seconds::Float64)
     if isnan(seconds)
         return "-"
@@ -98,6 +128,10 @@ function generate_markdown(results::Vector{BenchmarkResult})
     println(io)
     println(io, "Benchmarks run on Julia $(VERSION)")
     println(io)
+    if any(r -> r.solver == VACASK_REF_SOLVER, results)
+        println(io, "Rows labelled **$(VACASK_REF_SOLVER)** are the real VACASK simulator measured on the same machine (see `run_vacask.sh`), for an apples-to-apples comparison.")
+        println(io)
+    end
 
     # Summary table with all solvers
     println(io, "## Summary")
@@ -134,10 +168,20 @@ function generate_markdown(results::Vector{BenchmarkResult})
             end
             println(io)
 
-            # Show fastest
-            fastest = argmin(r -> r.median_time, successful)
-            println(io, "> 🏆 Fastest: **$(fastest.solver)** ($(format_time(fastest.median_time)))")
-            println(io)
+            # Show fastest Cadnip solver (excluding the VACASK reference row)
+            cadnip_successful = filter(r -> r.solver != VACASK_REF_SOLVER, successful)
+            if !isempty(cadnip_successful)
+                fastest = argmin(r -> r.median_time, cadnip_successful)
+                note = ""
+                ref = filter(r -> r.solver == VACASK_REF_SOLVER, successful)
+                if !isempty(ref)
+                    ratio = ref[1].median_time / fastest.median_time
+                    note = ratio >= 1 ? " — $(round(ratio, digits=2))× faster than VACASK" :
+                                        " — $(round(1/ratio, digits=2))× slower than VACASK"
+                end
+                println(io, "> 🏆 Fastest Cadnip solver: **$(fastest.solver)** ($(format_time(fastest.median_time)))$(note)")
+                println(io)
+            end
         end
 
         # Show failures
@@ -218,33 +262,42 @@ function main()
 
     results = BenchmarkResult[]
 
+    # VACASK reference numbers (real simulator, same machine) if available.
+    vacask_refs = load_vacask_reference()
+    if !isempty(vacask_refs)
+        println("Including VACASK reference numbers for: ",
+                join((r.name for r in vacask_refs), ", "))
+        println()
+    end
+
+    # Append a benchmark's Cadnip solver results, immediately followed by the
+    # matching VACASK reference row so the tables compare side by side.
+    function add_benchmark!(name, script, solvers)
+        append!(results, run_benchmark_all_solvers(name, script, solvers))
+        for ref in vacask_refs
+            ref.name == name && push!(results, ref)
+        end
+    end
+
     # RC Circuit - linear circuit, ImplicitEuler is 3x faster
-    append!(results, run_benchmark_all_solvers(
-        "RC Circuit",
+    add_benchmark!("RC Circuit",
         joinpath(BENCHMARK_DIR, "rc", "cedarsim", "runme.jl"),
-        SOLVERS_RC
-    ))
+        SOLVERS_RC)
 
     # Graetz Bridge - nonlinear (diodes), needs robust DAE solver
-    append!(results, run_benchmark_all_solvers(
-        "Graetz Bridge",
+    add_benchmark!("Graetz Bridge",
         joinpath(BENCHMARK_DIR, "graetz", "cedarsim", "runme.jl"),
-        SOLVERS_NONLINEAR
-    ))
+        SOLVERS_NONLINEAR)
 
     # Voltage Multiplier - nonlinear (diodes), needs robust DAE solver
-    append!(results, run_benchmark_all_solvers(
-        "Voltage Multiplier",
+    add_benchmark!("Voltage Multiplier",
         joinpath(BENCHMARK_DIR, "mul", "cedarsim", "runme.jl"),
-        SOLVERS_NONLINEAR
-    ))
+        SOLVERS_NONLINEAR)
 
     # Ring Oscillator - IDA only (needs tuned settings for oscillation)
-    append!(results, run_benchmark_all_solvers(
-        "Ring Oscillator (PSP103)",
+    add_benchmark!("Ring Oscillator (PSP103)",
         joinpath(BENCHMARK_DIR, "ring", "cedarsim", "runme.jl"),
-        SOLVERS_RING
-    ))
+        SOLVERS_RING)
 
     # # C6288 Multiplier - all solvers
     # append!(results, run_benchmark_all_solvers(

--- a/benchmarks/vacask/run_vacask.sh
+++ b/benchmarks/vacask/run_vacask.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#==============================================================================#
+# VACASK reference benchmark runner
+#
+# Runs the *real* VACASK simulator on every benchmark case using the official
+# upstream methodology (benchmark.py: 1 warmup run + N timed runs, averaged).
+#
+# This gives apples-to-apples reference numbers on the same machine that runs
+# the Cadnip benchmarks (benchmarks/vacask/run_benchmarks.jl), instead of the
+# upstream-published numbers in README.md which were measured on a different
+# machine (AMD Threadripper 7970).
+#
+# Usage:
+#   ./run_vacask.sh [output.md]
+#
+# When an output file is given, a machine-readable <output>.tsv is written
+# alongside it (columns: benchmark, time_s, timepoints, rejected, iterations).
+# run_benchmarks.jl reads this TSV (via $VACASK_REFERENCE_TSV) to fold the
+# reference numbers into its own comparison tables.
+#
+# The VACASK binary is located in this order:
+#   1. $VACASK_DIR              -- a pre-extracted release dir (must contain
+#                                  simulator/vacask and simulator/lib)
+#   2. a previously cached download under $CACHE_DIR
+#   3. downloaded from $VACASK_URL (pinned release below)
+#
+# Environment overrides:
+#   VACASK_DIR   path to an extracted release (skips download)
+#   VACASK_URL   release tarball URL
+#   CACHE_DIR    where to cache the download (default: ~/.cache/cadnip-vacask)
+#   RUNS         number of timed runs (default 5)
+#   CASES        space-separated case list (default: rc graetz mul ring c6288)
+#==============================================================================#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+VACASK_URL="${VACASK_URL:-https://github.com/pepijndevos/VACASK/releases/download/_0.3.3-dev/vacask_0.3.3-dev_linux-x86_64.tar.gz}"
+CACHE_DIR="${CACHE_DIR:-$HOME/.cache/cadnip-vacask}"
+RUNS="${RUNS:-5}"
+CASES="${CASES:-rc graetz mul ring c6288}"
+OUT="${1:-}"
+
+#------------------------------------------------------------------------------#
+# Locate (or fetch) the VACASK release
+#------------------------------------------------------------------------------#
+locate_vacask() {
+    if [[ -n "${VACASK_DIR:-}" && -x "$VACASK_DIR/simulator/vacask" ]]; then
+        echo "$VACASK_DIR"
+        return
+    fi
+    mkdir -p "$CACHE_DIR"
+    local extracted="$CACHE_DIR/vacask"
+    if [[ ! -x "$extracted/simulator/vacask" ]]; then
+        local tarball="$CACHE_DIR/vacask.tar.gz"
+        if [[ ! -f "$tarball" ]]; then
+            echo "Downloading VACASK release..." >&2
+            curl -fsSL -o "$tarball" "$VACASK_URL"
+        fi
+        echo "Extracting VACASK release..." >&2
+        rm -rf "$extracted"
+        mkdir -p "$extracted"
+        tar xzf "$tarball" -C "$extracted" --strip-components=1
+    fi
+    chmod +x "$extracted/simulator/vacask" "$extracted/simulator/openvaf-r" 2>/dev/null || true
+    echo "$extracted"
+}
+
+VC="$(locate_vacask)"
+BIN="$VC/simulator/vacask"
+export LD_LIBRARY_PATH="$VC/simulator/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+VERSION="$("$BIN" --help 2>&1 | head -1 | sed 's/This is //; s/\.$//')"
+CPU="$(grep -m1 'model name' /proc/cpuinfo | cut -d: -f2 | sed 's/^ *//')"
+
+echo "Simulator: $VERSION" >&2
+echo "Binary:    $BIN" >&2
+echo "CPU:       $CPU" >&2
+echo "Runs:      $RUNS (+1 warmup) per case" >&2
+echo >&2
+
+#------------------------------------------------------------------------------#
+# Run each case through the official benchmark.py and collect results
+#------------------------------------------------------------------------------#
+emit() { if [[ -n "$OUT" ]]; then echo "$1" >>"$OUT"; else echo "$1"; fi; }
+
+TSV=""
+if [[ -n "$OUT" ]]; then
+    : >"$OUT"
+    TSV="${OUT%.md}.tsv"
+    : >"$TSV"
+fi
+tsv() { [[ -n "$TSV" ]] && printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" >>"$TSV"; }
+
+emit "# VACASK reference benchmark results"
+emit ""
+emit "Measured with the upstream methodology (\`benchmark.py\`: 1 warmup + $RUNS timed runs, averaged)."
+emit ""
+emit "- Simulator: \`$VERSION\`"
+emit "- CPU: $CPU"
+emit ""
+emit "| Benchmark | Time (s) | Rel. std | Timepoints | Rejected | Iterations |"
+emit "|-----------|----------|----------|------------|----------|------------|"
+
+# Names must match the benchmark names in run_benchmarks.jl so the TSV can be
+# joined into its comparison tables.
+declare -A NAMES=(
+    [rc]="RC Circuit"
+    [graetz]="Graetz Bridge"
+    [mul]="Voltage Multiplier"
+    [ring]="Ring Oscillator (PSP103)"
+    [c6288]="C6288 Multiplier"
+)
+
+for c in $CASES; do
+    log="$(mktemp)"
+    echo "Running $c ..." >&2
+    python3 "$HERE/benchmark.py" -n "$RUNS" -nd 1 "$HERE/$c/vacask" "$BIN" >"$log" 2>&1 || {
+        echo "  FAILED (see below)" >&2; tail -20 "$log" >&2; emit "| ${NAMES[$c]:-$c} | FAILED | - | - | - | - |"; rm -f "$log"; continue;
+    }
+    avg="$(grep -E 'Average runtime|Runtime:' "$log" | tail -1 | grep -oE '[0-9.]+')"
+    rel="$(grep -E 'relative:' "$log" | tail -1 | grep -oE '[0-9.]+' || echo '')"
+    tp="$(grep -E 'Accepted timepoints:' "$log" | tail -1 | grep -oE '[0-9]+')"
+    rej="$(grep -E 'Rejected timepoints:' "$log" | tail -1 | grep -oE '[0-9]+')"
+    it="$(grep -E 'NR solver iterations:' "$log" | tail -1 | grep -oE '[0-9]+')"
+    relpct=""
+    [[ -n "$rel" ]] && relpct="$(awk -v r="$rel" 'BEGIN{printf "%.1f%%", r*100}')"
+    avgfmt="$(awk -v a="$avg" 'BEGIN{printf "%.2f", a}')"
+    emit "| ${NAMES[$c]:-$c} | $avgfmt | ${relpct:--} | ${tp:--} | ${rej:--} | ${it:--} |"
+    tsv "${NAMES[$c]:-$c}" "$avg" "${tp:-0}" "${rej:-0}" "${it:-0}"
+    echo "  done: ${avgfmt}s, ${tp} timepoints, ${rej} rejected, ${it} iterations" >&2
+    rm -f "$log"
+done
+
+[[ -n "$OUT" ]] && echo "Report written to: $OUT" >&2
+echo "Done." >&2


### PR DESCRIPTION
Run the actual VACASK simulator (release 0.3.3-dev) on every benchmark
case using the upstream benchmark.py methodology (1 warmup + 5 timed
runs, averaged) and fold the numbers into our comparison tables for an
apples-to-apples, same-machine comparison against the Cadnip solvers.

- run_vacask.sh: download/locate the VACASK release, run benchmark.py on
  each case, emit a markdown table plus a TSV joined by run_benchmarks.jl.
- run_benchmarks.jl: read $VACASK_REFERENCE_TSV and add "VACASK (ref)"
  rows next to each benchmark's Cadnip solvers; fastest-solver pick
  excludes the reference and reports the speedup vs VACASK.
- benchmark.py: fix importlib.util import under Python 3.11 and make
  numpy optional (stdlib statistics fallback) so it runs in CI without
  an extra install.
- benchmark.yml: run the real VACASK suite (including c6288) before the
  Julia benchmarks, publish both tables to the job summary, upload the
  reference artifacts, and raise the job timeout to the 360-minute max.
- README: document how to reproduce the VACASK numbers.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VAQcMmTNK3fNfRcrdpdRb4