### PR TITLE
fix: make SPICE PULSE source repeat periodically

### DIFF
--- a/src/mna/devices.jl
+++ b/src/mna/devices.jl
@@ -70,11 +70,43 @@ and infinitely steep segments (same time, different values).
     end
 end
 
+"""
+    pulse_at_time(v1, v2, td, tr, tf, pw, per, t) -> value
+
+Evaluate a SPICE PULSE source at time `t`.
+
+- Before the delay `td`, holds the initial value `v1`.
+- From `td` onward the waveform repeats with period `per`: a linear rise from
+  `v1` to `v2` over `tr`, a flat top at `v2` for `pw`, a linear fall back to
+  `v1` over `tf`, then a flat bottom at `v1` for the rest of the period.
+
+A non-positive `per` produces a single (non-repeating) pulse.
+"""
+@inline function pulse_at_time(v1, v2, td, tr, tf, pw, per, t)
+    type_stable_time = 0.0 * t  # Preserves type (e.g. ForwardDiff.Dual)
+    if t < td
+        return v1 + type_stable_time
+    end
+    # Phase within the current period; a single pulse when per <= 0.
+    phase = per > 0 ? mod(t - td, per) : (t - td)
+    if phase < tr
+        # Rising edge (instantaneous if tr == 0)
+        return tr > 0 ? v1 + (v2 - v1) * (phase / tr) : v2 + type_stable_time
+    elseif phase < tr + pw
+        return v2 + type_stable_time
+    elseif phase < tr + pw + tf
+        # Falling edge (instantaneous if tf == 0)
+        return tf > 0 ? v2 + (v1 - v2) * ((phase - tr - pw) / tf) : v1 + type_stable_time
+    else
+        return v1 + type_stable_time
+    end
+end
+
 export stamp!
 export Resistor, Capacitor, Inductor
 export VoltageSource, CurrentSource
 export VCVS, VCCS, CCVS, CCCS
-export pwl_at_time
+export pwl_at_time, pulse_at_time
 
 #==============================================================================#
 # Device Type Hierarchy

--- a/src/spc/codegen.jl
+++ b/src/spc/codegen.jl
@@ -2419,7 +2419,7 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
 
         elseif fname == :pulse
             # PULSE source: pulse(v1 v2 td tr tf pw period)
-            # Implement as PWL approximation
+            # Periodic: repeats with period `per` from `td` onward (see pulse_at_time).
             vals = [cg_expr!(state, v) for v in tran_source.values]
             n_vals = length(vals)
 
@@ -2431,63 +2431,23 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{<:Union{SP.Voltag
             pw_expr = n_vals >= 6 ? vals[6] : 1e-3
             per_expr = n_vals >= 7 ? vals[7] : 2e-3
 
-            # Check if all parameters are numeric constants (for zero-allocation StaticPWL)
-            all_constant = all(x -> x isa Number, [v1_expr, v2_expr, td_expr, tr_expr, tf_expr, pw_expr, per_expr])
+            # DC value: use explicit dc= if specified, otherwise use v1 (initial pulse value)
+            dc_expr = dc_val !== nothing ? dc_val : v1_expr
 
-            if all_constant
-                # ZERO-ALLOCATION PATH: Compute PWL points at compile time, use SVector
-                v1, v2 = Float64(v1_expr), Float64(v2_expr)
-                td, tr, tf, pw, per = Float64(td_expr), Float64(tr_expr), Float64(tf_expr), Float64(pw_expr), Float64(per_expr)
-
-                # Compute PWL times and values for one period
-                t0, t1, t2, t3, t4, t5 = 0.0, td, td+tr, td+tr+pw, td+tr+pw+tf, per
-                v_1, v_2, v_3, v_4, v_5, v_6 = v1, v1, v2, v2, v1, v1
-
-                # DC value: use explicit dc= if specified, otherwise use v1 (initial pulse value)
-                dc_value = dc_val !== nothing ? dc_val : v1
-
-                if is_voltage
-                    return quote
-                        let ts = $(StaticArrays).SVector{6,Float64}($t0, $t1, $t2, $t3, $t4, $t5),
-                            ys = $(StaticArrays).SVector{6,Float64}($v_1, $v_2, $v_3, $v_4, $v_5, $v_6),
-                            dc = $dc_value
-                            $(MNA).stamp!(VoltageSource(dc; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(_scoped_sym_expr(Symbol(name)))),
-                                   ctx, $p, $n, t, spec.mode)
-                        end
-                    end
-                else
-                    return quote
-                        let ts = $(StaticArrays).SVector{6,Float64}($t0, $t1, $t2, $t3, $t4, $t5),
-                            ys = $(StaticArrays).SVector{6,Float64}($v_1, $v_2, $v_3, $v_4, $v_5, $v_6),
-                            dc = $dc_value
-                            $(MNA).stamp!(CurrentSource(dc; tran=_t -> $(MNA).pwl_at_time(ts, ys, _t), name=$(_scoped_sym_expr(Symbol(name)))),
-                                   ctx, $p, $n, t, spec.mode)
-                        end
+            if is_voltage
+                return quote
+                    let v1 = $v1_expr, v2 = $v2_expr, td = $td_expr,
+                        tr = $tr_expr, tf = $tf_expr, pw = $pw_expr, per = $per_expr, dc = $dc_expr
+                        $(MNA).stamp!(VoltageSource(dc; tran=_t -> $(MNA).pulse_at_time(v1, v2, td, tr, tf, pw, per, _t), name=$(_scoped_sym_expr(Symbol(name)))),
+                               ctx, $p, $n, t, spec.mode)
                     end
                 end
             else
-                # FALLBACK PATH: Dynamic arrays
-                # DC value: use explicit dc= if specified, otherwise use v1/i1 (initial pulse value)
-                dc_expr = dc_val !== nothing ? dc_val : v1_expr
-                if is_voltage
-                    return quote
-                        let v1 = $v1_expr, v2 = $v2_expr, td = $td_expr,
-                            tr = $tr_expr, tf = $tf_expr, pw = $pw_expr, per = $per_expr, dc = $dc_expr
-                            times = [0.0, td, td+tr, td+tr+pw, td+tr+pw+tf, per]
-                            values = [v1, v1, v2, v2, v1, v1]
-                            $(MNA).stamp!(VoltageSource(dc; tran=_t -> $(MNA).pwl_at_time(times, values, _t), name=$(_scoped_sym_expr(Symbol(name)))),
-                                   ctx, $p, $n, t, spec.mode)
-                        end
-                    end
-                else
-                    return quote
-                        let i1 = $v1_expr, i2 = $v2_expr, td = $td_expr,
-                            tr = $tr_expr, tf = $tf_expr, pw = $pw_expr, per = $per_expr, dc = $dc_expr
-                            times = [0.0, td, td+tr, td+tr+pw, td+tr+pw+tf, per]
-                            values = [i1, i1, i2, i2, i1, i1]
-                            $(MNA).stamp!(CurrentSource(dc; tran=_t -> $(MNA).pwl_at_time(times, values, _t), name=$(_scoped_sym_expr(Symbol(name)))),
-                                   ctx, $p, $n, t, spec.mode)
-                        end
+                return quote
+                    let i1 = $v1_expr, i2 = $v2_expr, td = $td_expr,
+                        tr = $tr_expr, tf = $tf_expr, pw = $pw_expr, per = $per_expr, dc = $dc_expr
+                        $(MNA).stamp!(CurrentSource(dc; tran=_t -> $(MNA).pulse_at_time(i1, i2, td, tr, tf, pw, per, _t), name=$(_scoped_sym_expr(Symbol(name)))),
+                               ctx, $p, $n, t, spec.mode)
                     end
                 end
             end

--- a/test/transients.jl
+++ b/test/transients.jl
@@ -149,7 +149,7 @@ end
     Base.eval(m, :(using Cadnip.SpectreEnvironment))
     builder = Base.eval(m, code)
 
-    tspan = (0.0, td + 3*per)  # span several periods
+    tspan = (0.0, td + 4*per)  # span several periods (room to sample the 4th pulse plateau)
     circuit = Base.invokelatest(MNACircuit, builder, (;), MNASpec(temp=27.0))
     n = Cadnip.MNA.system_size(circuit)
     prob = Base.invokelatest(ODEProblem, circuit, tspan; u0=zeros(n))

--- a/test/transients.jl
+++ b/test/transients.jl
@@ -109,6 +109,71 @@ end
 end
 =#
 
+@testset "PULSE repeats" begin
+    # A PULSE source must be periodic. Regression test: previously the codegen
+    # built PWL points for only a single period, so after the first cycle the
+    # output held v1 forever instead of repeating.
+    using Cadnip.MNA: pulse_at_time
+
+    v1, v2 = 0.0, 1.0
+    td, tr, tf, pw, per = 1e-3, 1e-6, 1e-6, 2e-3, 5e-3
+
+    # Direct helper checks across several periods. Sample mid-plateau (phase
+    # tr + pw/2) so the value is unambiguously v2 regardless of float rounding.
+    high_phase = tr + pw / 2
+    low_phase = tr + tf + pw + (per - (tr + tf + pw)) / 2  # solidly in the flat-bottom region
+    @test pulse_at_time(v1, v2, td, tr, tf, pw, per, 0.0) == v1                       # before delay
+    @test pulse_at_time(v1, v2, td, tr, tf, pw, per, td + high_phase) == v2           # 1st pulse
+    # The high portion must recur in later periods, not stay flat at v1.
+    @test pulse_at_time(v1, v2, td, tr, tf, pw, per, td + per + high_phase) == v2     # 2nd pulse
+    @test pulse_at_time(v1, v2, td, tr, tf, pw, per, td + 3*per + high_phase) == v2   # 4th pulse
+    # And the low portion must recur too.
+    @test pulse_at_time(v1, v2, td, tr, tf, pw, per, td + 2*per + low_phase) == v1
+
+    # Now drive a node through a SPICE PULSE source and confirm the simulated
+    # waveform pulses more than once. Feed a PULSE voltage into an RC low-pass
+    # filter so the output tracks (smoothed) the periodic input.
+    R_val, C_val = 1e3, 1e-9  # τ = 1µs ≪ pw, so vout settles near v2/v1 each cycle
+    spice_code = """
+    * PULSE repeat test
+    V1 vin 0 PULSE($(v1) $(v2) $(td) $(tr) $(tf) $(pw) $(per))
+    R1 vin vout $(R_val)
+    C1 vout 0 $(C_val)
+    """
+
+    ast = NyanSpectreNetlistParser.parse(IOBuffer(spice_code); start_lang=:spice, implicit_title=true)
+    code = Cadnip.make_mna_circuit(ast)
+    m = Module()
+    Base.eval(m, :(using Cadnip.MNA))
+    Base.eval(m, :(using Cadnip: ParamLens))
+    Base.eval(m, :(using Cadnip.SpectreEnvironment))
+    builder = Base.eval(m, code)
+
+    tspan = (0.0, td + 3*per)  # span several periods
+    circuit = Base.invokelatest(MNACircuit, builder, (;), MNASpec(temp=27.0))
+    n = Cadnip.MNA.system_size(circuit)
+    prob = Base.invokelatest(ODEProblem, circuit, tspan; u0=zeros(n))
+    sol = OrdinaryDiffEq.solve(prob, Rodas5P(linsolve=KLUFactorization()); reltol=1e-6, abstol=1e-6, maxiters=1_000_000)
+
+    dc_spec = MNASpec(temp=27.0, mode=:dcop, time=0.0)
+    ctx = Base.invokelatest(builder, (;), dc_spec)
+    sys = Cadnip.MNA.assemble!(ctx)
+    vout_idx = findfirst(nm -> nm == :vout, sys.node_names)
+
+    # Sample the output near the middle of the high portion of each pulse.
+    # With τ ≪ pw the filtered output reaches close to v2 on every cycle.
+    for k in 0:3
+        t_high = td + k*per + tr + pw/2
+        @test isapprox(sol(t_high)[vout_idx], v2; atol=0.1)
+    end
+
+    # And near the end of each low portion it should be back near v1.
+    for k in 0:2
+        t_low = td + k*per + per - 1e-6
+        @test isapprox(sol(t_low)[vout_idx], v1; atol=0.1)
+    end
+end
+
 # Create a third-order Butterworth filter, according to https://en.wikipedia.org/wiki/Butterworth_filter#Example
 # The circuit diagram is:
 #


### PR DESCRIPTION
The PULSE source codegen built PWL points spanning only a single period,
so once the simulation time passed the last point, pwl_at_time held the
final value (v1) forever. The source emitted one pulse and never repeated.

Add a dedicated pulse_at_time helper that evaluates the waveform from
phase = mod(t - td, per), making it periodic (a non-positive period gives
a single pulse). Rewrite the codegen pulse branch to capture the scalar
parameters and call it, mirroring the SIN-source pattern and replacing the
single-period PWL approximation. Add a regression test covering both the
helper and an end-to-end PULSE-driven RC filter across multiple periods.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ep4pV569dHrLrLx4FpDH45