### PR TITLE
fix: stamp diode (D) instances in MNA codegen

### DIFF
--- a/src/spc/codegen.jl
+++ b/src/spc/codegen.jl
@@ -2140,6 +2140,85 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.BipolarTransis
 end
 
 """
+    cg_mna_instance!(state, instance::SNode{SP.Diode})
+
+Generate MNA builder code for diode instances (D elements).
+
+A diode resolves through its `.model <name> d ...` card to a VA-generated
+device (e.g. `sp_diode` from VADistillerModels, registered via ModelRegistry
+Tier 1). The model card supplies the device parameters via the model variable
+generated in `codegen_mna!`; instance parameters (`area`, `temp`, …) are passed
+as keyword arguments and override/augment the model.
+"""
+function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Diode})
+    nets = sema_nets(instance)
+    pos = cg_net_name!(state, nets[1])
+    neg = cg_net_name!(state, nets[2])
+    name = LString(instance.name)
+
+    # Reference the model variable generated for the .model card
+    model_name = cg_model_name!(state, instance.model)
+    model_sym = LSymbol(instance.model)
+
+    # Build a case-insensitive instance-parameter lookup against the model's
+    # field names (SPICE is case-insensitive; VA field names may be mixed case).
+    case_insensitive = Dict{Symbol,Symbol}()
+    if haskey(state.sema.models, model_sym) && !isempty(state.sema.models[model_sym])
+        (_, def) = last(state.sema.models[model_sym])
+        model_globalref = def.val[2]
+        if model_globalref isa GlobalRef
+            T = getglobal(model_globalref.mod, model_globalref.name)
+            if T isa DataType && T <: Cadnip.ParsedModel
+                T = T.parameters[1]
+            end
+            case_insensitive = Dict(Symbol(lowercase(String(kw))) => kw for kw in fieldnames(T))
+        end
+    end
+
+    is_large_model = is_large_va_model(state, model_sym)
+
+    # Build instance parameter kwargs with case-insensitive lookup
+    param_kwargs = Expr[]
+    for p in instance.params
+        param_name = LSymbol(p.name)
+        param_val = cg_expr!(state, p.val)
+        lname = Symbol(lowercase(String(param_name)))
+        rname = get(case_insensitive, lname, param_name)
+        push!(param_kwargs, Expr(:kw, rname, param_val))
+    end
+
+    # Create the device instance via spicecall + setproperties, matching the
+    # pattern used by MOSFET/BJT/OSDI handlers.
+    device_expr = if isempty(param_kwargs)
+        :($(spicecall)($model_name).device)
+    else
+        :($(spicecall)($model_name; $(param_kwargs...)).device)
+    end
+
+    local_name = QuoteNode(Symbol(name))
+
+    if is_large_model
+        return quote
+            let dev = $device_expr
+                local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
+                Base.invokelatest($(MNA).stamp!, dev, ctx, $pos, $neg;
+                    _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
+                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+            end
+        end
+    else
+        return quote
+            let dev = $device_expr
+                local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
+                $(MNA).stamp!(dev, ctx, $pos, $neg;
+                    _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
+                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+            end
+        end
+    end
+end
+
+"""
     cg_mna_instance!(state, instance::SNode{SP.OSDIDevice})
 
 Generate MNA builder code for OSDI device instances (N elements).

--- a/test/mna/vadistiller_integration.jl
+++ b/test/mna/vadistiller_integration.jl
@@ -77,6 +77,32 @@ Q2 q2_coll q2_base 0 npn1
 .END
 """i
 
+# Diode resistor-divider defined via the SPICE API: `.model <name> d` card +
+# `D` instance. This resolves to VADistillerModels.sp_diode via ModelRegistry
+# (Tier 1). Regression guard: a missing `cg_mna_instance!` method for SP.Diode
+# silently dropped the instance (open circuit => zero current). See the
+# "Diode via SPICE API" testset below.
+const sp_diode_divider = sp"""
+* diode current limiter
+.model diode_a d is=1e-14 rs=0
+V1 vcc 0 DC 1.0
+R1 vcc da 1k
+D1 da 0 diode_a
+.END
+"""i
+
+# Same topology with a 100x larger saturation current. Confirms that model-card
+# parameters actually reach the device: larger `is` => smaller forward drop.
+# A distinct model name avoids colliding with `sp_diode_divider` above.
+const sp_diode_divider_bigis = sp"""
+* diode current limiter, large is
+.model diode_b d is=1e-12 rs=0
+V1 vcc 0 DC 1.0
+R1 vcc da 1k
+D1 da 0 diode_b
+.END
+"""i
+
 @testset "VADistiller Integration Tests" begin
 
     #==========================================================================#
@@ -206,6 +232,31 @@ Q2 q2_coll q2_base 0 npn1
                 drop_reasonable = (v_diode_a - v_a_int) < 0.01
 
                 @test has_internal_node && junction_ok && drop_ok && drop_reasonable
+            end
+
+            @testset "Diode via SPICE API (parameter passing)" begin
+                # Regression test: before SP.Diode had an MNA codegen method, the
+                # `D1` instance was silently dropped (the .model parameters were
+                # computed but never passed to a stamp! call), leaving the diode
+                # an open circuit. The node `da` floated up to V(vcc) and no
+                # current flowed.
+                circuit = MNACircuit(sp_diode_divider)
+                sol = dc!(circuit)
+
+                v_vcc = sol[:vcc]
+                v_da = sol[:da]
+                i_r1 = (v_vcc - v_da) / 1000.0  # current through R1 == diode current
+
+                @test isapprox(v_vcc, 1.0; atol=1e-9)
+                # The diode must conduct: forward drop in the diode region and a
+                # clearly non-zero current (the bug produced exactly 0 A).
+                @test 0.4 < v_da < 0.75
+                @test i_r1 > 1e-5
+
+                # Model-card parameters must reach the device: a 100x larger
+                # saturation current lowers the forward drop at the same current.
+                sol_big = dc!(MNACircuit(sp_diode_divider_bigis))
+                @test sol_big[:da] < v_da
             end
         end
 


### PR DESCRIPTION
SPICE `D` (diode) instances had no `cg_mna_instance!` method, so they fell
through to the generic fallback that emits `nothing`. The `.model` card's
parameters were computed into a model variable but never passed to any
`stamp!` call, leaving the diode an open circuit — the junction node floated
and zero current flowed.

Add a `cg_mna_instance!(state, instance::SNode{SP.Diode})` method that
references the generated model variable and stamps the device on its two
terminals, mirroring the MOSFET/BJT/OSDI handlers (case-insensitive instance
parameter lookup, spicecall + setproperties, large-model invokelatest path).

Add a regression test exercising sp_diode via the SPICE API: it asserts the
diode conducts (non-zero current, forward drop in the junction region) and
that model-card parameters reach the device (larger `is` lowers the drop).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MJaXT1fpp8Y9w7R2U364sj