### PR TITLE
Fix multi-GB allocations in VA device stamping, wire up $mfactor

### DIFF
--- a/src/Cadnip.jl
+++ b/src/Cadnip.jl
@@ -44,21 +44,6 @@ const sim_mode = ScopedValue{Symbol}(:dcop)
 # Minimal types previously in simulate_ir.jl (used by spectre.jl)
 # These are stubs for backward compatibility - MNA uses different types
 
-# ParallelInstances for device multiplicity
-struct ParallelInstances
-    device
-    multiplier::Float64
-
-    function ParallelInstances(device, multiplier::Float64)
-        if multiplier < 0.0
-            cedarthrow(ArgumentError("Cannot construct a ParallelInstances with non-positive multiplier '$(multiplier)'"))
-        end
-        return new(device, multiplier)
-    end
-end
-ParallelInstances(device, multiplier::Number) = ParallelInstances(device, Float64(multiplier))
-ParallelInstances(device, multiplier::DefaultOr) = ParallelInstances(device, undefault(multiplier))
-
 # Base types for circuit elements and simulation (stubs)
 abstract type CircuitElement end
 abstract type AbstractSim{C} end

--- a/src/spc/codegen.jl
+++ b/src/spc/codegen.jl
@@ -2026,21 +2026,26 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.MOSFET})
     model_sym = LSymbol(instance.model)
     is_large_model = is_large_va_model(state, model_sym)
 
+    # Device multiplicity ("m=") is a SPICE instance parameter, not a VA struct
+    # field - the VA model reads it back via the $mfactor builtin. Pull it out
+    # of the kwargs headed for spicecall/setproperties.
+    m_expr = hasparam(instance.parameters, "m") ? cg_expr!(state, getparam(instance.parameters, "m")) : 1.0
+
     # Build instance parameter kwargs
     param_kwargs = Expr[]
     for p in instance.parameters
         param_name = LSymbol(p.name)
+        param_name === :m && continue
         param_val = cg_expr!(state, p.val)
         push!(param_kwargs, Expr(:kw, param_name, param_val))
     end
 
     # Generate code to create device instance using spicecall + setproperties pattern
     # This avoids recompiling the 200-kwarg constructor for each netlist parse
-    # spicecall returns ParallelInstances, extract .device for stamping
     if isempty(param_kwargs)
-        device_expr = :($(spicecall)($model_name).device)
+        device_expr = :($(spicecall)($model_name))
     else
-        device_expr = :($(spicecall)($model_name; $(param_kwargs...)).device)
+        device_expr = :($(spicecall)($model_name; $(param_kwargs...)))
     end
 
     # NOTE: VA modules use _mna_*_ prefixes to avoid conflicts with VA parameter/variable names
@@ -2054,7 +2059,8 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.MOSFET})
                 local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
                 Base.invokelatest($(MNA).stamp!, dev, ctx, $d, $g, $s, $b;
                     _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
-                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_,
+                    _mna_mfactor_ = $m_expr)
             end
         end
     else
@@ -2064,7 +2070,8 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.MOSFET})
                 local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
                 $(MNA).stamp!(dev, ctx, $d, $g, $s, $b;
                     _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
-                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_,
+                    _mna_mfactor_ = $m_expr)
             end
         end
     end
@@ -2096,21 +2103,26 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.BipolarTransis
     model_sym = LSymbol(instance.model)
     is_large_model = is_large_va_model(state, model_sym)
 
+    # Device multiplicity ("m=") is a SPICE instance parameter, not a VA struct
+    # field - the VA model reads it back via the $mfactor builtin. Pull it out
+    # of the kwargs headed for spicecall/setproperties.
+    m_expr = hasparam(instance.params, "m") ? cg_expr!(state, getparam(instance.params, "m")) : 1.0
+
     # Build instance parameter kwargs
     param_kwargs = Expr[]
     for p in instance.params
         param_name = LSymbol(p.name)
+        param_name === :m && continue
         param_val = cg_expr!(state, p.val)
         push!(param_kwargs, Expr(:kw, param_name, param_val))
     end
 
     # Generate code to create device instance using spicecall + setproperties pattern
     # This avoids recompiling the 200-kwarg constructor for each netlist parse
-    # spicecall returns ParallelInstances, extract .device for stamping
     if isempty(param_kwargs)
-        device_expr = :($(spicecall)($model_name).device)
+        device_expr = :($(spicecall)($model_name))
     else
-        device_expr = :($(spicecall)($model_name; $(param_kwargs...)).device)
+        device_expr = :($(spicecall)($model_name; $(param_kwargs...)))
     end
 
     # NOTE: VA modules use _mna_*_ prefixes to avoid conflicts with VA parameter/variable names
@@ -2123,7 +2135,8 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.BipolarTransis
                 local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
                 Base.invokelatest($(MNA).stamp!, dev, ctx, $c, $b, $e, $s;
                     _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
-                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_,
+                    _mna_mfactor_ = $m_expr)
             end
         end
     else
@@ -2133,7 +2146,8 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.BipolarTransis
                 local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
                 $(MNA).stamp!(dev, ctx, $c, $b, $e, $s;
                     _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
-                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_,
+                    _mna_mfactor_ = $m_expr)
             end
         end
     end
@@ -2177,12 +2191,20 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Diode})
 
     is_large_model = is_large_va_model(state, model_sym)
 
+    # Device multiplicity ("m=") is a SPICE instance parameter, not a VA struct
+    # field - the VA model reads it back via the $mfactor builtin. It is handled
+    # separately from the case-insensitive model-field lookup below: on a diode
+    # *instance* line "m" always means multiplicity (never the model-card-only
+    # "m" grading-coefficient parameter aliased to mj).
+    m_expr = hasparam(instance.params, "m") ? cg_expr!(state, getparam(instance.params, "m")) : 1.0
+
     # Build instance parameter kwargs with case-insensitive lookup
     param_kwargs = Expr[]
     for p in instance.params
         param_name = LSymbol(p.name)
-        param_val = cg_expr!(state, p.val)
         lname = Symbol(lowercase(String(param_name)))
+        lname === :m && continue
+        param_val = cg_expr!(state, p.val)
         rname = get(case_insensitive, lname, param_name)
         push!(param_kwargs, Expr(:kw, rname, param_val))
     end
@@ -2190,9 +2212,9 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Diode})
     # Create the device instance via spicecall + setproperties, matching the
     # pattern used by MOSFET/BJT/OSDI handlers.
     device_expr = if isempty(param_kwargs)
-        :($(spicecall)($model_name).device)
+        :($(spicecall)($model_name))
     else
-        :($(spicecall)($model_name; $(param_kwargs...)).device)
+        :($(spicecall)($model_name; $(param_kwargs...)))
     end
 
     local_name = QuoteNode(Symbol(name))
@@ -2203,7 +2225,8 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Diode})
                 local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
                 Base.invokelatest($(MNA).stamp!, dev, ctx, $pos, $neg;
                     _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
-                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_,
+                    _mna_mfactor_ = $m_expr)
             end
         end
     else
@@ -2212,7 +2235,8 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Diode})
                 local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
                 $(MNA).stamp!(dev, ctx, $pos, $neg;
                     _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
-                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_,
+                    _mna_mfactor_ = $m_expr)
             end
         end
     end
@@ -2271,24 +2295,29 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.OSDIDevice})
     # Check if this is a large model that needs invokelatest
     is_large_model = is_large_va_model(state, model_sym)
 
+    # Device multiplicity ("m=") is a SPICE instance parameter, not a VA struct
+    # field - the VA model reads it back via the $mfactor builtin. Pull it out
+    # of the kwargs headed for spicecall/setproperties.
+    m_expr = hasparam(instance.parameters, "m") ? cg_expr!(state, getparam(instance.parameters, "m")) : 1.0
+
     # Build instance parameter kwargs with case-insensitive lookup
     param_kwargs = Expr[]
     for p in instance.parameters
         param_name = LSymbol(p.name)
+        lname = Symbol(lowercase(String(param_name)))
+        lname === :m && continue
         param_val = cg_expr!(state, p.val)
         # Use case-insensitive lookup to find correct parameter name
-        lname = Symbol(lowercase(String(param_name)))
         rname = get(case_insensitive, lname, param_name)
         push!(param_kwargs, Expr(:kw, rname, param_val))
     end
 
     # Generate code to create device instance using spicecall + setproperties pattern
     # This avoids recompiling the 200-kwarg constructor for each netlist parse
-    # spicecall returns ParallelInstances, extract .device for stamping
     if isempty(param_kwargs)
-        device_expr = :($(spicecall)($model_name).device)
+        device_expr = :($(spicecall)($model_name))
     else
-        device_expr = :($(spicecall)($model_name; $(param_kwargs...)).device)
+        device_expr = :($(spicecall)($model_name; $(param_kwargs...)))
     end
 
     # Generate stamp! call with variable number of node arguments
@@ -2306,7 +2335,8 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.OSDIDevice})
                 local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
                 Base.invokelatest($(MNA).stamp!, dev, ctx, nodes...;
                     _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
-                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_,
+                    _mna_mfactor_ = $m_expr)
             end
         end
     else
@@ -2317,7 +2347,8 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.OSDIDevice})
                 local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
                 $(MNA).stamp!(dev, ctx, nodes...;
                     _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
-                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_,
+                    _mna_mfactor_ = $m_expr)
             end
         end
     end

--- a/src/spc/codegen.jl
+++ b/src/spc/codegen.jl
@@ -2635,7 +2635,7 @@ function codegen_toplevel_models!(state::CodegenState)
                     end
                 end
                 model_var = cg_model_name!(state, model_name)
-                push!(model_defs, :($model_var = ($(model_params...),)))
+                push!(model_defs, :(const $model_var = ($(model_params...),)))
             elseif model_ref isa GlobalRef && model_ref.mod !== Cadnip && model_ref.mod !== Cadnip.SpectreEnvironment
                 # VA model from imported HDL module or external package
                 # Get the model type to build case-insensitive parameter lookup
@@ -2683,7 +2683,15 @@ function codegen_toplevel_models!(state::CodegenState)
                 model_var = cg_model_name!(state, model_name)
                 # Use Cadnip pattern: pass params as NamedTuple to spicecall
                 # This avoids embedding 200 kwargs in the generated code
-                push!(model_defs, :($model_var = $(spicecall)($(ParsedModel), $model_ref, ($(model_params...),))))
+                #
+                # const is essential here, not cosmetic: these bindings are
+                # captured by the circuit builder function as module globals
+                # (not locals/arguments), and a plain `=` global is always
+                # ::Any at use sites regardless of what's assigned to it. That
+                # made every `spicecall(model_var; ...)` call in the builder
+                # infer to Any, forcing the device struct to be heap-boxed on
+                # every stamp!() call (every Newton iteration).
+                push!(model_defs, :(const $model_var = $(spicecall)($(ParsedModel), $model_ref, ($(model_params...),))))
             end
         end
     end

--- a/src/spectre.jl
+++ b/src/spectre.jl
@@ -252,8 +252,6 @@ function ntfromstruct(x::T) where {T}
      values = fieldvalues(x)
      return NamedTuple{names}(values)
 end
-ntfromstruct(x::Cadnip.ParallelInstances) = (; m=x.multiplier, ntfromstruct(x.device)...)
-
 function modelparams(m)
     args = m.params
     t = m.type
@@ -438,8 +436,8 @@ function (bm::BinnedModel)(; l, w, kwargs...)
 end
 
 "Instantiate a model using SPICE case insensitive semantics"
-function spicecall(model; m=1.0, kwargs...)
-    ParallelInstances(model(;kwargs...), m)
+function spicecall(model; kwargs...)
+    model(;kwargs...)
 end
 
 @Base.assume_effects :foldable function mknondefault_nt(nt::NamedTuple)
@@ -468,10 +466,9 @@ end
 # @noinline prevents aggressive inlining/SROA that causes OOM with large VA models
 # (e.g., 782-field PSP103VA struct). The setproperties call can generate huge IR
 # if inlined into the circuit builder function.
-@noinline function spicecall(pm::ParsedModel{T}; m=1, kwargs...) where T
+@noinline function spicecall(pm::ParsedModel{T}; kwargs...) where T
     instkwargs = case_adjust_kwargs(T, mknondefault_nt(values(kwargs)))::ParsedNT
-    inst = setproperties(pm.model, instkwargs)
-    ParallelInstances(inst, m)
+    setproperties(pm.model, instkwargs)
 end
 
 function spicecall(bm::BinnedModel; l, w, kwargs...)

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -2028,8 +2028,8 @@ end
 function (to_julia::MNAScope)(ip::VANode{SystemIdentifier})
     id = Symbol(ip)
     if id == Symbol("\$mfactor")
-        # Device multiplicity - default to 1.0
-        return :(hasproperty(_mna_spec_, :mfactor) ? _mna_spec_.mfactor : 1.0)
+        # Device multiplicity, threaded through from the instance's `m=` parameter
+        return :(_mna_mfactor_)
     elseif id == Symbol("\$temperature")
         return :(_mna_spec_.temp + 273.15)
     elseif id == Symbol("\$abstime")
@@ -2905,8 +2905,14 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
         # See detect_or_cached! in contrib.jl for the new approach.
 
         branch_stamp = quote
-            # Evaluate the branch current
-            I_branch = $sum_expr
+            # Evaluate the branch current. Per the Verilog-A LRM, $mfactor scales
+            # *all* of a module's contributions (I()<+ and Q()<+ alike); models
+            # only reference $mfactor explicitly for terms that must NOT scale
+            # with multiplicity (e.g. gmin blending). Scaling the combined dual
+            # here (rather than each contribution site) covers both the
+            # resistive and reactive (ddt) parts, since real-scalar * Dual
+            # distributes over value and partials recursively.
+            I_branch = _mna_mfactor_ * ($sum_expr)
 
             if I_branch isa ForwardDiff.Dual{Cadnip.MNA.ContributionTag}
                 # Has ddt: ContributionTag wraps JacobianTag duals
@@ -3477,7 +3483,7 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
                                  _mna_t_::Real=0.0, _mna_mode_::Symbol=:dcop, _mna_x_::AbstractVector=Cadnip.MNA.ZERO_VECTOR,
                                  _mna_spec_::Cadnip.MNA.MNASpec=Cadnip.MNA.MNASpec(),
                                  _mna_instance_::Symbol=Symbol(""),
-                                 _mna_h_=nothing, _mna_h_p_=nothing)
+                                 _mna_h_=nothing, _mna_h_p_=nothing, _mna_mfactor_::Real=1.0)
         $stamp_body
     end)
 

--- a/test/mna/vadistiller_integration.jl
+++ b/test/mna/vadistiller_integration.jl
@@ -103,6 +103,20 @@ D1 da 0 diode_b
 .END
 """i
 
+# Same topology with instance-level `m=` (SPICE parallel multiplicity). `m`
+# diodes in parallel conduct `m` times the current of one at the same
+# voltage - physically equivalent to an m-times-larger saturation current.
+# Exercises $mfactor threading through spicecall/stamp! (see removal of the
+# dead ParallelInstances wrapper).
+const sp_diode_divider_m5 = sp"""
+* diode current limiter, m=5 parallel diodes
+.model diode_a d is=1e-14 rs=0
+V1 vcc 0 DC 1.0
+R1 vcc da 1k
+D1 da 0 diode_a m=5
+.END
+"""i
+
 @testset "VADistiller Integration Tests" begin
 
     #==========================================================================#
@@ -257,6 +271,20 @@ D1 da 0 diode_b
                 # saturation current lowers the forward drop at the same current.
                 sol_big = dc!(MNACircuit(sp_diode_divider_bigis))
                 @test sol_big[:da] < v_da
+
+                # Instance-level m= (parallel multiplicity) must reach $mfactor:
+                # 5 parallel diodes conduct ~5x the current at the same voltage,
+                # so for the same series-resistor current, the forward drop drops.
+                sol_m5 = dc!(MNACircuit(sp_diode_divider_m5))
+                @test sol_m5[:da] < v_da
+                # Quantitatively: at fixed current I, V = Vt*ln(I/(m*Is)), so
+                # 5 diodes in parallel should reproduce the same operating point
+                # as 1 diode with is scaled up by 5 (both are is*m = 5e-14).
+                i_m5 = (v_vcc - sol_m5[:da]) / 1000.0
+                is_effective = 1e-14 * 5
+                vt = 8.617333262e-5 * (27 + 273.15)  # k*T/q at default 27C
+                v_predicted = vt * log(i_m5 / is_effective)
+                @test isapprox(sol_m5[:da], v_predicted; atol=1e-3)
             end
         end
 


### PR DESCRIPTION
ParallelInstances.device had no type parameter, so every VA-model
instance (diode/MOSFET/BJT/OSDI) constructed via spicecall() got
heap-boxed on every stamp!() call (every Newton iteration, every
timestep), and stamp! itself became a dynamic dispatch on the
resulting Any-typed value. Profiling the vacask graetz benchmark
showed the sp_diode struct as the dominant allocation site, at
~66MB per 10ms of simulated time.

ParallelInstances existed solely to carry the SPICE "m" instance
multiplier, but nothing ever read the .multiplier field back out -
spicecall's callers always did `.device` and discarded it. Since VA
models already have a real mechanism for multiplicity ($mfactor),
ParallelInstances was dead weight standing in for a feature that was
itself wired to nothing: $mfactor read a nonexistent `mfactor` field
off MNASpec and silently always evaluated to 1.0.

Fix:
- Delete ParallelInstances and simplify spicecall to return the
  device directly, so it stays concretely typed end-to-end and
  stamp! dispatches statically.
- Thread the instance-level "m=" parameter through to stamp! as a new
  _mna_mfactor_ kwarg (mirroring _mna_t_/_mna_spec_/etc.), for the
  Diode/MOSFET/BJT/OSDIDevice codegen paths that use spicecall.
- Make $mfactor resolve to that kwarg instead of the dead
  MNASpec lookup.
- Scale the combined per-branch current/charge dual by _mna_mfactor_
  at the point contributions are summed, matching the Verilog-A LRM
  (compilers scale *all* of a module's contributions by $mfactor;
  models only reference it explicitly for terms that must NOT scale,
  like gmin blending - which is exactly what these VADistiller
  models do).

Adds a regression test verifying that instance-level m= on a diode
reproduces the same operating point as scaling `is` by the same
factor.