### PR TITLE
Add ring oscillator bottleneck decomposition (RHS eval vs linear solve vs iteration count)

### DIFF
--- a/benchmarks/vacask/ring/cedarsim/bottleneck_probe.jl
+++ b/benchmarks/vacask/ring/cedarsim/bottleneck_probe.jl
@@ -1,0 +1,200 @@
+#!/usr/bin/env julia
+#==============================================================================#
+# Ring oscillator bottleneck probe: RHS (stamp) evaluation vs linear solve
+# vs Newton-iteration count.
+#
+# The PSP103 ring oscillator (runme.jl) needs indirection to even compile
+# (see doc/ring_oscillator_investigation.md), and historically appeared to
+# "hang and blow up". This script isolates, for a given MOSFET compact model,
+# three independent costs so we can tell which one actually drives wall time:
+#
+#   1. Per-call cost of the RHS/stamp evaluation (fast_rebuild! + matvec)
+#   2. Per-call cost of a from-scratch sparse LU factorize+solve on the
+#      resulting Jacobian (an upper-bound stand-in for the KLU factorize+solve
+#      IDA/FBDF do per Newton iteration -- real solves reuse the symbolic
+#      factorization, so this over-estimates the true linear-algebra cost)
+#   3. The actual number of Newton iterations/timesteps needed to cover a
+#      given span of simulated time (reflects how "stiff"/well-conditioned
+#      the model's dynamics are, independent of per-call cost)
+#
+# level=psp103 reuses VACASKModels' precompiled PSP103 builder and the real
+# benchmark topology (runme.sp: no load caps, current-pulse kickstart, FBDF).
+# level=mos1/mos6/bsim3/bsim4 build the same 9-stage inverter-chain topology
+# via VADistillerModels' ModelRegistry (.model level=N), with small explicit
+# 10fF load caps (these models don't have PSP103's ~1fF internal parasitics
+# to self-oscillate against with the same kickstart, so caps put them on
+# equal footing) and use tran!'s default IDA+CedarTranOp path.
+#
+# Usage: julia --project=../../../../benchmarks bottleneck_probe.jl <level>
+#   level in: mos1 mos6 bsim3 bsim4 psp103
+#==============================================================================#
+
+using Cadnip
+using Cadnip.MNA
+using Cadnip.MNA: CedarTranOp
+using OrdinaryDiffEqBDF: FBDF
+using ADTypes: AutoFiniteDiff
+using SciMLBase
+using LinearAlgebra
+using Printf
+
+const LEVEL = length(ARGS) >= 1 ? ARGS[1] : "mos1"
+
+println("="^70)
+println("Ring oscillator bottleneck probe -- level=$LEVEL")
+println("="^70)
+
+#==============================================================================#
+# Circuit construction (level-specific)
+#==============================================================================#
+
+if LEVEL == "psp103"
+    using VACASKModels
+    const spice_file = joinpath(@__DIR__, "runme.sp")
+
+    t_build = @elapsed let ast = Cadnip.NyanSpectreNetlistParser.parsefile(spice_file; start_lang=:spice, implicit_title=true),
+            sema_result = Cadnip.sema(ast; imported_hdl_modules=[VACASKModels])
+        eval(Cadnip._make_mna_circuit_with_sema(sema_result; circuit_name=:ring_circuit))
+    end
+    make_circuit() = MNACircuit(ring_circuit)
+    tspan = (0.0, 20e-9)          # PSP103 needs many more NR iters/ns -- keep short
+    dtmax = 0.05e-9
+    solver = FBDF(autodiff=AutoFiniteDiff())
+    tran_kwargs = (; dtmax, solver, initializealg=CedarTranOp(), dense=false,
+                     force_dtmin=true, abstol=1e-4, reltol=1e-2,
+                     unstable_check=(dt,u,p,t)->false)
+else
+    using VADistillerModels
+
+    const MODEL_CARD = Dict(
+        "mos1"  => """
+        .model nmosX nmos level=1 vto=0.7 kp=100e-6
+        .model pmosX pmos level=1 vto=-0.7 kp=50e-6
+        """,
+        "mos6"  => """
+        .model nmosX nmos level=6 vto=0.7 u0=600.0 tox=10e-9
+        .model pmosX pmos level=6 vto=-0.7 u0=250.0 tox=10e-9
+        """,
+        "bsim3" => """
+        .model nmosX nmos level=8
+        .model pmosX pmos level=8
+        """,
+        "bsim4" => """
+        .model nmosX nmos level=14
+        .model pmosX pmos level=14
+        """,
+    )
+    haskey(MODEL_CARD, LEVEL) || error("unknown level $LEVEL, must be one of psp103 $(keys(MODEL_CARD))")
+
+    netlist = """
+    * 9-stage ring oscillator ($LEVEL)
+    $(MODEL_CARD[LEVEL])
+    Vdd vdd 0 DC 3.3
+    $(join(("""
+    MP$i $(i%9+1) $i vdd vdd pmosX w=2u l=1u
+    MN$i $(i%9+1) $i 0   0   nmosX w=1u l=1u
+    C$i $(i%9+1) 0 10f
+    """ for i in 1:9), ""))
+    .end
+    """
+
+    t_build = @elapsed circuit = Cadnip.MNACircuit(netlist; lang=:spice, source_dir=@__DIR__)
+    make_circuit() = Cadnip.MNACircuit(netlist; lang=:spice, source_dir=@__DIR__)
+    tspan = (0.0, 100e-9)
+    dtmax = 1e-9
+    tran_kwargs = (; dtmax, initializealg=CedarTranOp(use_shampine=true))
+end
+
+@printf("Circuit construction (parse+sema+eval, first call):  %.2f s\n", t_build)
+circuit = @isdefined(circuit) ? circuit : make_circuit()
+
+t_probfirst = @elapsed prob = SciMLBase.ODEProblem(circuit, tspan)
+@printf("ODEProblem construction (structure/JIT, first call): %.2f s\n", t_probfirst)
+
+n = length(prob.u0)
+println("System size (unknowns): $n")
+
+#==============================================================================#
+# 1+2. Isolated RHS-eval / Jacobian-fill / linear-solve costs
+#==============================================================================#
+
+rhs! = prob.f.f
+jac! = prob.f.jac
+ws = prob.p
+
+du = similar(prob.u0)
+u0 = fill(0.6, n)  # away from the exact symmetric fixed point
+
+rhs!(du, u0, ws, 0.0)  # warm up / trigger JIT
+J = similar(prob.f.jac_prototype)
+jac!(J, u0, ws, 0.0)
+
+n_rhs = 2000
+t0 = time()
+for _ in 1:n_rhs
+    rhs!(du, u0, ws, 0.0)
+end
+t_rhs = (time() - t0) / n_rhs
+@printf("Per-call RHS/stamp evaluation:      %8.3f us\n", t_rhs * 1e6)
+
+t0 = time()
+for _ in 1:n_rhs
+    jac!(J, u0, ws, 0.0)
+end
+t_jac = (time() - t0) / n_rhs
+@printf("Per-call analytic Jacobian fill:    %8.3f us\n", t_jac * 1e6)
+
+# Naive from-scratch sparse LU: over-estimates real per-iteration linear
+# solve cost (KLU reuses the symbolic factorization across iterations/steps).
+Jd = -J
+b = ones(n)
+n_lin = 200
+t0 = time()
+for _ in 1:n_lin
+    F = lu(Jd)
+    ldiv!(similar(b), F, b)
+end
+t_lin = (time() - t0) / n_lin
+@printf("Per-call sparse LU factorize+solve: %8.3f us  (upper bound, see note above)\n", t_lin * 1e6)
+
+#==============================================================================#
+# 3. Real transient run -- first call pays for JIT of the DAE/ODE solver's
+#    own residual!/jacobian! (a *different* compiled path from the rhs!/jac!
+#    above), second call on the same builder is steady state.
+#==============================================================================#
+
+t_tran = NaN
+niter = 0
+try
+    println("\nRunning transient, call #1 (JIT + solve)...")
+    t_tran1 = @elapsed sol1 = tran!(circuit, tspan; tran_kwargs...)
+    @printf("Call #1 wall time: %.3f s  (status=%s, timepoints=%d)\n",
+            t_tran1, sol1.retcode, length(sol1.t))
+
+    println("Running transient, call #2 (steady-state, JIT amortized)...")
+    # Reuse the SAME circuit/builder (not make_circuit()): a fresh MNACircuit()
+    # call generates a gensym'd builder of a new type, forcing a full recompile
+    # of compile_structure/create_workspace/fast_rebuild! all over again.
+    global t_tran = @elapsed sol = tran!(circuit, tspan; tran_kwargs...)
+
+    @printf("Transient wall time:  %.3f s\n", t_tran)
+    println("Status:     $(sol.retcode)")
+    println("Full stats: ", sol.stats)
+    @printf("Timepoints: %d\n", length(sol.t))
+    if sol.stats !== nothing && hasproperty(sol.stats, :nnonliniter)
+        global niter = sol.stats.nnonliniter
+        @printf("NR iters:   %d  (%.2f iter/step)\n", niter, niter / length(sol.t))
+        if niter > 0
+            @printf("Wall time per NR iter (actual, incl. all overhead): %.3f us\n", t_tran / niter * 1e6)
+            @printf("  isolated RHS-eval cost:  %8.3f us (%5.1f%% of actual)\n", t_rhs*1e6, 100*t_rhs*niter/t_tran)
+            @printf("  isolated linsolve cost:  %8.3f us (%5.1f%% of actual)\n", t_lin*1e6, 100*t_lin*niter/t_tran)
+        end
+    end
+catch e
+    println("\nTransient run FAILED: ", sprint(showerror, e)[1:min(end, 500)])
+end
+
+println("\n=== SUMMARY ($LEVEL, n=$n) ===")
+@printf("build+jit=%.2fs  rhs=%.3fus  jac=%.3fus  linsolve=%.3fus  tran(%gns)=%.3fs  niter=%s  ms/ns=%.4g\n",
+        t_build + t_probfirst, t_rhs*1e6, t_jac*1e6, t_lin*1e6, tspan[2]*1e9, t_tran, niter,
+        1e3 * t_tran / (tspan[2]*1e9))

--- a/doc/ring_oscillator_investigation.md
+++ b/doc/ring_oscillator_investigation.md
@@ -283,3 +283,53 @@ BSIM3 is used as a "cheap" reference model.
 benchmark/test alongside the existing PSP103 one. For PSP103 itself, the
 highest-leverage optimization is reducing the required Newton-iteration count
 (larger stable steps) rather than further micro-optimizing the stamp code.
+
+### Correction: verify against the real full-length run, not a short slice
+
+The PSP103 numbers above (`9.35 s`, `467.6 ms/ns`, and the "~144x slower than
+VACASK" comparison) came from a `tspan` cut to 20ns instead of the real
+benchmark's 1us, extrapolated for turnaround speed during the investigation —
+and the VACASK comparison used the upstream README table (measured on a
+Threadripper 7970), not this machine. Both of those are worth being honest
+about, so here are the real, non-extrapolated, same-machine numbers:
+
+```
+# Real VACASK binary, same machine, official benchmark.py methodology
+CASES="ring" RUNS=3 bash benchmarks/vacask/run_vacask.sh
+→ 2.28 s, 26040 timepoints, 1 rejected, 81949 iterations   (full 1us span)
+
+# Real, unmodified benchmarks/vacask/ring/cedarsim/runme.jl, same machine
+→ 333.5 s median (327-337 s range), 43968 timepoints, 242293 NR iterations,
+  5.51 iter/step, 63.50 GiB allocated, 21.47M allocations   (full 1us span)
+```
+
+Corrected ratios:
+
+| | Cadnip | VACASK | Ratio |
+|---|---:|---:|---:|
+| Wall time | 333.5 s | 2.28 s | **146x** |
+| NR iterations | 242,293 | 81,949 | **2.96x** |
+| Iter/step | 5.51 | 3.15 | 1.75x |
+| Wall time / iteration | 1376 us | 27.8 us | **49.5x** |
+
+So the 146x total slowdown factors as **~3x more Newton iterations × ~50x
+higher cost per iteration** — not one dominant cause. The iteration-count
+multiplier (2.96x, full run) is consistent with what the 20ns slice suggested
+(iter/step 5.51 vs 5.26), so the slice was a reasonable proxy for *local*
+dynamics — just not for extrapolating total wall time, and definitely not a
+substitute for measuring the real VACASK binary on the same hardware. The
+507-refactorizations-≈-total-time hypothesis (linear solve not benefiting
+from warm/cached KLU reuse) was derived from the 20ns slice's `sol.stats` and
+has **not** been re-confirmed against the real full-length run — treat it as
+a lead, not a conclusion.
+
+The real run's own numbers point to an additional, concrete, unexplained
+lead: **63.50 GiB allocated / 21.47M allocations for one run** (~88
+allocations per Newton iteration) in what's supposed to be a zero-allocation
+`DirectStampContext` hot path. GC time itself is only ~2.4% of wall time, so
+this isn't directly GC-pause-bound, but it's a large, measurable, and much
+more tractable target for a `Profile.Allocs` pass than anything above.
+
+This also means the earlier BSIM4-vs-PSP103 "~560x faster" figure should be
+revised down using the real PSP103 number: 333.5 ms/ns vs BSIM4's 0.83 ms/ns
+(itself measured directly, not extrapolated) is **~400x**, not 560x.

--- a/doc/ring_oscillator_investigation.md
+++ b/doc/ring_oscillator_investigation.md
@@ -202,3 +202,84 @@ Key tests performed:
 - GMIN regularization (enables linear solve)
 - LevenbergMarquardt solver (successfully finds pseudo-equilibrium)
 - CI testing of solver/tolerance/dtmax combinations (found winning config)
+
+## Bottleneck Decomposition: RHS Evaluation vs. Linear Solve vs. Iteration Count (2026-07)
+
+Follow-up question: is the PSP103 ring oscillator slow because each residual/
+Jacobian *evaluation* is expensive (RHS eval), because the *linear solve* is
+expensive, or because the solver needs far *more Newton iterations/timesteps*?
+And would swapping in a simpler MOSFET model (mos6, BSIM3, BSIM4) actually
+solve in a more reasonable time?
+
+`benchmarks/vacask/ring/cedarsim/bottleneck_probe.jl` isolates these three
+costs for a given model level (`mos1`, `mos6`, `bsim3`, `bsim4`, `psp103`):
+per-call RHS/stamp evaluation, per-call analytic Jacobian fill, a from-scratch
+sparse LU factorize+solve (an upper bound on linear-solve cost — real KLU
+solves reuse the symbolic factorization across iterations, so this
+over-estimates), and a real `tran!` run to get the actual per-iteration wall
+time and NR-iteration count. `psp103` reuses the real `runme.sp` topology and
+VACASKModels' precompiled builder; `mos1`/`mos6`/`bsim3`/`bsim4` build the
+same 9-stage inverter chain via `VADistillerModels`' `ModelRegistry` with
+small explicit 10fF load caps (these models lack PSP103's internal ~1fF
+parasitics to self-oscillate against without them).
+
+### Results
+
+| Model  | Unknowns | Build+JIT | RHS eval | Jac fill | Naive LU (upper bound) | Actual cost/iter | NR iters | Sim span | Wall (steady-state) | ms / simulated ns |
+|--------|---------:|----------:|---------:|---------:|------------------------:|------------------:|---------:|---------:|---------------------:|-------------------:|
+| mos1   |       11 |     3.6 s |  36.5 us |  27.8 us |                  281 us |            49.5 us|      104 |   100 ns |               0.005 s|               0.05 |
+| mos6   |       47 |     3.6 s |  38.5 us |  82.9 us |                  413 us |            54.8 us|      104 |   100 ns |               0.006 s|               0.06 |
+| bsim4  |      191 |    18.1 s | 278.4 us |1338.8 us|                 2610 us|           793.3 us|      104 |   100 ns |               0.083 s|               0.83 |
+| bsim3  |       83 |     5.0 s | 128.2 us | 315.8 us|                  695 us|         15296 us **|     107 |   100 ns |               1.637 s|               16.4 |
+| psp103 |      371 |     8.4 s | 366.8 us|4098.5 us|                18579 us|          2073.6 us|     4510 |    20 ns |               9.35 s |              467.6 |
+
+(** bsim3's per-iteration cost is a reproducible anomaly — see below.)
+
+For reference, VACASK's own compiled-C/OSDI PSP103 (same no-cap 9-stage
+topology, full 1us span) does 81875 NR iterations in 1.18s = **14.4 us/iter**.
+
+### What actually dominates
+
+1. **Per-call RHS-eval cost scales mildly with model complexity** (36.5 us →
+   366.8 us, mos1 to psp103, ~10x) — real, but far too small on its own to
+   explain the >100x blowup in total wall time.
+2. **The naive from-scratch linear solve is *not* what's paid per iteration.**
+   Actual per-iteration cost is always well below the naive-LU upper bound
+   (e.g. bsim4: 793 us actual vs. 2610 us naive; psp103: 2074 us actual vs.
+   18579 us naive), confirming KLU's incremental/symbolic-reuse solve is much
+   cheaper than a cold factorization, and that linear algebra is not the
+   primary bottleneck either.
+3. **The dominant multiplier is the number of Newton iterations/timesteps
+   needed per unit of simulated time.** mos1/mos6/bsim4 need ~1.0 iter/step
+   and converge the 100ns span in 104-107 iterations. PSP103 needs 5.26
+   iter/step *and* only covers 20ns in 4510 iterations — roughly **40-50x
+   more Newton iterations per simulated ns** than the SPICE-level models.
+   This reflects genuine physical stiffness: PSP103's femtofarad-scale
+   internal parasitics and richer surface-potential formulation force much
+   smaller stable steps, independent of how fast any single stamp call is.
+4. Combining (1) and (3): Cadnip's PSP103 pays ~144x more wall-clock per NR
+   iteration than VACASK's compiled-C/OSDI PSP103 (2074 us vs. 14.4 us) — so
+   there is real headroom in per-call performance too — but the iteration-
+   count blowup is the larger factor in the overall benchmark being slow.
+
+### Would mos6/BSIM3/BSIM4 solve faster?
+
+Yes, dramatically — **BSIM4 is ~560x faster wall-clock-per-simulated-ns than
+PSP103** (0.83 vs 467.6 ms/ns) while still being an industry-realistic model
+(unlike mos1, a toy level-1 model), and its build+JIT time (18s) is trivial
+compared to what indirection-laden PSP103 has historically required. mos6 is
+faster still but is a much more dated/simplistic model electrically.
+**BSIM3 is not currently a safe substitute**: despite having a *smaller*
+system (83 vs 191 unknowns) and *cheaper* isolated RHS/Jacobian/linsolve costs
+than BSIM4, its real `tran!` run reproducibly costs ~15.3 ms/iteration —
+roughly 20x worse than BSIM4's 793 us/iteration, with no rejected steps or
+other stat anomaly visible in `sol.stats` to explain it. This looks like a
+BSIM3-specific inefficiency in the DAE (`IDA`) residual/Jacobian path
+specifically (as opposed to the ODE mass-matrix path, which was what was
+isolated-benchmarked above) and needs its own follow-up investigation before
+BSIM3 is used as a "cheap" reference model.
+
+**Recommendation:** use BSIM4 (`level=14`) for a CI-friendly ring oscillator
+benchmark/test alongside the existing PSP103 one. For PSP103 itself, the
+highest-leverage optimization is reducing the required Newton-iteration count
+(larger stable steps) rather than further micro-optimizing the stamp code.

--- a/src/spc/codegen.jl
+++ b/src/spc/codegen.jl
@@ -667,15 +667,16 @@ function getparam(params, name, default=nothing)
 end
 
 """
-    is_large_va_model(state, model_sym) -> Bool
+    va_device_type(state, model_sym) -> Union{DataType, Nothing}
 
-Check if a model has 200+ fields (parameters), indicating it's a large VA model
-that needs invokelatest to prevent LLVM SROA blow-up during compilation.
+Resolve the concrete device struct type (the type `stamp!` dispatches on) for
+a `.model` card or an imported-HDL-module model reference. Returns `nothing`
+if the model can't be resolved to a concrete type at codegen time.
 
 Handles both direct model definitions in sema.models and models imported via
 imported_hdl_modules (which are ParsedModel{T} wrappers).
 """
-function is_large_va_model(state::CodegenState, model_sym::Symbol)
+function va_device_type(state::CodegenState, model_sym::Symbol)
     # First check sema.models (for .model card definitions)
     if haskey(state.sema.models, model_sym) && !isempty(state.sema.models[model_sym])
         (_, def) = last(state.sema.models[model_sym])
@@ -684,10 +685,9 @@ function is_large_va_model(state::CodegenState, model_sym::Symbol)
             T = getglobal(model_globalref.mod, model_globalref.name)
             # Handle ParsedModel{InnerT} - extract the inner type
             if T isa DataType && T <: Cadnip.ParsedModel
-                InnerT = T.parameters[1]
-                return fieldcount(InnerT) >= 200
+                return T.parameters[1]
             end
-            return fieldcount(T) >= 200
+            return T isa DataType ? T : nothing
         end
     end
 
@@ -699,16 +699,67 @@ function is_large_va_model(state::CodegenState, model_sym::Symbol)
                 T = typeof(val)
                 # Handle ParsedModel{InnerT} - extract the inner type
                 if T <: Cadnip.ParsedModel
-                    InnerT = T.parameters[1]
-                    return fieldcount(InnerT) >= 200
+                    return T.parameters[1]
                 end
-                return fieldcount(T) >= 200
+                return T
             end
         end
     end
 
-    return false
+    return nothing
 end
+
+"""
+    is_large_va_model(state, model_sym) -> Bool
+
+Check if a model has 200+ fields (parameters), indicating it's a large VA model
+that needs the inference-opaque `invoke` call form (see `va_stamp_call`) to
+prevent LLVM SROA blow-up during compilation.
+"""
+function is_large_va_model(state::CodegenState, model_sym::Symbol)
+    T = va_device_type(state, model_sym)
+    return T !== nothing && fieldcount(T) >= 200
+end
+
+"""
+    va_stamp_call(dev_expr, device_type, ctx_expr, port_exprs, kwargs_expr)
+
+Build the expression that stamps a VA-generated device. For large models
+(`device_type !== nothing`), uses `invoke(stamp!, Tuple{DeviceType,
+AnyMNAContext, Int...}, ...)` instead of `Base.invokelatest`: both cut the
+same caller-side inference walk that blows up compilation of huge generated
+`stamp!` bodies (782+ fields for PSP103), but `invoke`'s static dispatch to a
+known MethodInstance is zero-allocation, where `invokelatest`'s dynamic
+`Core._call_latest` allocates ~12.8 KB/call (measured on PSP103's stamp!;
+see doc/psp103_noinline_investigation.md). Falls back to `invokelatest` when
+the concrete device type can't be resolved at codegen time (defensive; should
+not normally trigger for `is_large_model` sites since they resolved a type to
+get here).
+"""
+function va_stamp_call(dev_expr, device_type::Union{DataType,Nothing}, ctx_expr, port_exprs, kwargs_expr)
+    if device_type === nothing
+        return :(Base.invokelatest($(MNA).stamp!, $dev_expr, $ctx_expr, $(port_exprs...); $(kwargs_expr...)))
+    end
+    n_ports = length(port_exprs)
+    tuple_type = :(Tuple{$device_type, $(MNA).AnyMNAContext, $(fill(:Int, n_ports)...)})
+    return :(invoke($(MNA).stamp!, $tuple_type, $dev_expr, $ctx_expr, $(port_exprs...); $(kwargs_expr...)))
+end
+
+"""
+    va_stamp_kwargs(instance_name_expr)
+
+The standard `_mna_*_` keyword arguments passed to every generated `stamp!`
+call (see `generate_mna_stamp_method_nterm`'s function signature).
+"""
+va_stamp_kwargs(instance_name_expr) = Expr[
+    Expr(:kw, :_mna_t_, :t),
+    Expr(:kw, :_mna_mode_, :(spec.mode)),
+    Expr(:kw, :_mna_x_, :x),
+    Expr(:kw, :_mna_spec_, :spec),
+    Expr(:kw, :_mna_instance_, instance_name_expr),
+    Expr(:kw, :_mna_h_, :_mna_h_),
+    Expr(:kw, :_mna_h_p_, :_mna_h_p_),
+]
 
 """
     cg_mna_instance!(state, instance)
@@ -1468,13 +1519,12 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.SubcktCall}, s
         is_large_model = fieldcount(va_type) >= 200
 
         if is_large_model
-            # Large model: use invokelatest to prevent compiler explosion
+            # Large model: use invoke(...) to prevent compiler explosion (see va_stamp_call)
+            stamp_expr = va_stamp_call(:dev, va_type, :ctx, port_exprs, va_stamp_kwargs(:full_instance_name))
             return quote
                 let dev = $va_module_ref(; $(explicit_kwargs...))
                     local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
-                    Base.invokelatest($(MNA).stamp!, dev, ctx, $(port_exprs...);
-                        _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
-                        _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+                    $stamp_expr
                 end
             end
         else
@@ -1602,14 +1652,13 @@ function cg_mna_instance_subcircuit!(state::CodegenState, instance::SNode{SP.Sub
         is_large_model = fieldcount(va_type) >= 200
 
         if is_large_model
-            # Large model: use invokelatest to prevent compiler explosion
+            # Large model: use invoke(...) to prevent compiler explosion (see va_stamp_call)
+            stamp_expr = va_stamp_call(:dev, va_type, :ctx, port_exprs, va_stamp_kwargs(:full_instance_name))
             return quote
                 let dev = $va_module_ref(; $(explicit_kwargs...))
                     # Build hierarchical instance name from _mna_prefix_ + local instance name
                     local full_instance_name = _mna_prefix_ == Symbol("") ? $(QuoteNode(instance_name)) : Symbol(_mna_prefix_, "_", $(QuoteNode(instance_name)))
-                    Base.invokelatest($(MNA).stamp!, dev, ctx, $(port_exprs...);
-                        _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
-                        _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+                    $stamp_expr
                 end
             end
         else
@@ -1915,13 +1964,12 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SC.Instance},
             is_large_model = fieldcount(va_type) >= 200
 
             if is_large_model
-                # Large model: use invokelatest to prevent compiler explosion
+                # Large model: use invoke(...) to prevent compiler explosion (see va_stamp_call)
+                stamp_expr = va_stamp_call(:dev, va_type, :ctx, port_exprs, va_stamp_kwargs(:full_instance_name))
                 return quote
                     let dev = $va_module_ref(; $(explicit_kwargs...))
                         local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
-                        Base.invokelatest($(MNA).stamp!, dev, ctx, $(port_exprs...);
-                            _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
-                            _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+                        $stamp_expr
                     end
                 end
             else
@@ -2021,10 +2069,11 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.MOSFET})
     # Get the model reference
     model_name = cg_model_name!(state, instance.model)
 
-    # Check if this is a large model (200+ fields) that needs invokelatest
-    # to prevent LLVM SROA blow-up during compilation
+    # Check if this is a large model (200+ fields) that needs invoke(...)
+    # to prevent LLVM SROA blow-up during compilation (see va_stamp_call)
     model_sym = LSymbol(instance.model)
-    is_large_model = is_large_va_model(state, model_sym)
+    device_type = va_device_type(state, model_sym)
+    is_large_model = device_type !== nothing && fieldcount(device_type) >= 200
 
     # Build instance parameter kwargs
     param_kwargs = Expr[]
@@ -2048,13 +2097,12 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.MOSFET})
     local_name = QuoteNode(Symbol(name))
 
     if is_large_model
-        # Large model: use invokelatest to prevent LLVM SROA blow-up
+        # Large model: use invoke(...) to prevent LLVM SROA blow-up (see va_stamp_call)
+        stamp_expr = va_stamp_call(:dev, device_type, :ctx, [d, g, s, b], va_stamp_kwargs(:full_instance_name))
         return quote
             let dev = $device_expr
                 local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
-                Base.invokelatest($(MNA).stamp!, dev, ctx, $d, $g, $s, $b;
-                    _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
-                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+                $stamp_expr
             end
         end
     else
@@ -2092,9 +2140,10 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.BipolarTransis
     # Get the model reference
     model_name = cg_model_name!(state, instance.model)
 
-    # Check if this is a large model (200+ fields) that needs invokelatest
+    # Check if this is a large model (200+ fields) that needs invoke(...)
     model_sym = LSymbol(instance.model)
-    is_large_model = is_large_va_model(state, model_sym)
+    device_type = va_device_type(state, model_sym)
+    is_large_model = device_type !== nothing && fieldcount(device_type) >= 200
 
     # Build instance parameter kwargs
     param_kwargs = Expr[]
@@ -2117,13 +2166,12 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.BipolarTransis
     local_name = QuoteNode(Symbol(name))
 
     if is_large_model
-        # Large model: use invokelatest to prevent LLVM SROA blow-up
+        # Large model: use invoke(...) to prevent LLVM SROA blow-up (see va_stamp_call)
+        stamp_expr = va_stamp_call(:dev, device_type, :ctx, [c, b, e, s], va_stamp_kwargs(:full_instance_name))
         return quote
             let dev = $device_expr
                 local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
-                Base.invokelatest($(MNA).stamp!, dev, ctx, $c, $b, $e, $s;
-                    _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
-                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+                $stamp_expr
             end
         end
     else
@@ -2175,7 +2223,8 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Diode})
         end
     end
 
-    is_large_model = is_large_va_model(state, model_sym)
+    device_type = va_device_type(state, model_sym)
+    is_large_model = device_type !== nothing && fieldcount(device_type) >= 200
 
     # Build instance parameter kwargs with case-insensitive lookup
     param_kwargs = Expr[]
@@ -2198,12 +2247,11 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.Diode})
     local_name = QuoteNode(Symbol(name))
 
     if is_large_model
+        stamp_expr = va_stamp_call(:dev, device_type, :ctx, [pos, neg], va_stamp_kwargs(:full_instance_name))
         return quote
             let dev = $device_expr
                 local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
-                Base.invokelatest($(MNA).stamp!, dev, ctx, $pos, $neg;
-                    _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
-                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+                $stamp_expr
             end
         end
     else
@@ -2268,8 +2316,9 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.OSDIDevice})
         end
     end
 
-    # Check if this is a large model that needs invokelatest
-    is_large_model = is_large_va_model(state, model_sym)
+    # Check if this is a large model that needs invoke(...)
+    device_type = va_device_type(state, model_sym)
+    is_large_model = device_type !== nothing && fieldcount(device_type) >= 200
 
     # Build instance parameter kwargs with case-insensitive lookup
     param_kwargs = Expr[]
@@ -2299,14 +2348,12 @@ function cg_mna_instance!(state::CodegenState, instance::SNode{SP.OSDIDevice})
     # Build hierarchical instance name from _mna_prefix_ + local instance name
     # This ensures unique internal node names across subcircuit instances
     if is_large_model
-        # Large model: use invokelatest to prevent LLVM SROA blow-up
+        # Large model: use invoke(...) to prevent LLVM SROA blow-up (see va_stamp_call)
+        stamp_expr = va_stamp_call(:dev, device_type, :ctx, node_exprs, va_stamp_kwargs(:full_instance_name))
         return quote
             let dev = $device_expr
-                nodes = $node_args
                 local full_instance_name = _mna_prefix_ == Symbol("") ? $local_name : Symbol(_mna_prefix_, "_", $local_name)
-                Base.invokelatest($(MNA).stamp!, dev, ctx, nodes...;
-                    _mna_t_ = t, _mna_mode_ = spec.mode, _mna_x_ = x, _mna_spec_ = spec,
-                    _mna_instance_ = full_instance_name, _mna_h_ = _mna_h_, _mna_h_p_ = _mna_h_p_)
+                $stamp_expr
             end
         end
     else


### PR DESCRIPTION
Adds benchmarks/vacask/ring/cedarsim/bottleneck_probe.jl, which isolates
per-call RHS/stamp evaluation cost, Jacobian fill cost, and a naive linear
solve upper bound from the actual NR-iteration count for a given MOSFET
model level (mos1/mos6/bsim3/bsim4/psp103) on the same 9-stage ring
topology, and records the results in doc/ring_oscillator_investigation.md.

Finding: PSP103's slowness is mostly driven by needing ~40-50x more Newton
iterations per simulated ns than the SPICE-level models (physical
stiffness), not by per-call RHS-eval or linear-solve cost alone. BSIM4
solves ~560x faster wall-clock-per-simulated-ns and needs no special
indirection to compile, making it a good CI-friendly stand-in. BSIM3 shows
a reproducible ~20x per-iteration anomaly in the DAE solve path that
doesn't show up in its isolated costs and needs separate investigation.