### PR TITLE
doc: c6288 -O0 clears RAGreedy but hits CedarUICOp warmup sparse-insert hang

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -60,9 +60,19 @@ jobs:
         # default -O2, so it needs its own `julia -O0` invocation rather than
         # sharing the process the other circuits benchmark in above. See
         # doc/c6288_bottleneck_findings.md.
+        #
+        # All three solvers runme.jl supports: IDA (DAE path, Sundials),
+        # FBDF and Rodas5P (both ODE/mass-matrix path). Looped with an
+        # inline fallback so one solver failing doesn't stop the others --
+        # the -O0 pkgimage cache is shared across invocations in this job,
+        # so only the first pays full JIT.
         continue-on-error: true
         run: |
-          julia -O0 --project=benchmarks benchmarks/vacask/c6288/cedarsim/runme.jl Rodas5P | tee c6288_cadnip.log
+          for solver in IDA FBDF Rodas5P; do
+            echo "=== $solver ===" | tee -a c6288_cadnip.log
+            julia -O0 --project=benchmarks benchmarks/vacask/c6288/cedarsim/runme.jl "$solver" 2>&1 | tee -a c6288_cadnip.log \
+              || echo "($solver FAILED, continuing to next solver)" | tee -a c6288_cadnip.log
+          done
 
       - name: Publish benchmark results
         if: always()
@@ -71,7 +81,7 @@ jobs:
           echo >> $GITHUB_STEP_SUMMARY
           cat vacask_reference.md >> $GITHUB_STEP_SUMMARY
           echo >> $GITHUB_STEP_SUMMARY
-          echo '## C6288 Multiplier (Cadnip, `-O0`)' >> $GITHUB_STEP_SUMMARY
+          echo '## C6288 Multiplier (Cadnip, `-O0`, IDA/FBDF/Rodas5P)' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           cat c6288_cadnip.log >> $GITHUB_STEP_SUMMARY 2>/dev/null || echo "(no output captured)" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -54,13 +54,30 @@ jobs:
         run: |
           julia --project=benchmarks benchmarks/vacask/run_benchmarks.jl benchmark_results.md
 
+      - name: Run Cadnip c6288 benchmark (-O0)
+        # Separate process/step deliberately: c6288's generated builder (2419
+        # inlined subckt calls) hits LLVM RAGreedy's super-linear blowup at
+        # default -O2, so it needs its own `julia -O0` invocation rather than
+        # sharing the process the other circuits benchmark in above. See
+        # doc/c6288_bottleneck_findings.md.
+        continue-on-error: true
+        run: |
+          julia -O0 --project=benchmarks benchmarks/vacask/c6288/cedarsim/runme.jl Rodas5P | tee c6288_cadnip.log
+
       - name: Publish benchmark results
+        if: always()
         run: |
           cat benchmark_results.md >> $GITHUB_STEP_SUMMARY
           echo >> $GITHUB_STEP_SUMMARY
           cat vacask_reference.md >> $GITHUB_STEP_SUMMARY
+          echo >> $GITHUB_STEP_SUMMARY
+          echo '## C6288 Multiplier (Cadnip, `-O0`)' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat c6288_cadnip.log >> $GITHUB_STEP_SUMMARY 2>/dev/null || echo "(no output captured)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload benchmark results
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-results-julia-${{ matrix.version }}
@@ -68,4 +85,5 @@ jobs:
             benchmark_results.md
             vacask_reference.md
             vacask_reference.tsv
+            c6288_cadnip.log
           retention-days: 30

--- a/benchmarks/vacask/c6288/cedarsim/runme.jl
+++ b/benchmarks/vacask/c6288/cedarsim/runme.jl
@@ -58,7 +58,7 @@ function setup_simulation()
     return circuit
 end
 
-function run_benchmark(solver; reltol=1e-3, maxiters=10_000_000)
+function run_benchmark(solver; reltol=1e-3, abstol=1e-6, maxiters=10_000_000)
     tspan = (0.0, 2e-9)  # 2ns simulation (same as ngspice)
     solver_name = nameof(typeof(solver))
 
@@ -73,15 +73,30 @@ function run_benchmark(solver; reltol=1e-3, maxiters=10_000_000)
     # single step. See doc/c6288_bottleneck_findings.md.
     init = CedarDCOp()
 
-    # Benchmark the actual simulation (not setup)
-    println("\nBenchmarking transient analysis with $solver_name (reltol=$reltol)...")
-    bench = @benchmark tran!($circuit, $tspan; solver=$solver, reltol=$reltol, maxiters=$maxiters, initializealg=$init, dense=false) samples=3 evals=1 seconds=300
+    # abstol/force_dtmin/unstable_check match the settings proven for the
+    # ring oscillator benchmark (benchmarks/vacask/ring/cedarsim/runme.jl),
+    # another PSP103-heavy no-easy-DC-point circuit. Without a loosened
+    # abstol, tran!'s default (1e-10) is unreachable for a 212k-variable
+    # digital circuit and drives dt down toward the femtosecond scale --
+    # IDA gives up with a hmin corrector-convergence failure, and FBDF's
+    # per-step Jacobian/mass-matrix recombination (see
+    # doc/c6288_bottleneck_findings.md) OOMs from sheer step count before
+    # ever reaching t=2ns. force_dtmin=true lets a solver push through a
+    # step that doesn't fully converge rather than aborting outright, and
+    # unstable_check is disabled because this digital circuit's large but
+    # legitimate voltage swings would otherwise trip the default heuristic.
+    println("\nBenchmarking transient analysis with $solver_name (reltol=$reltol, abstol=$abstol)...")
+    bench = @benchmark tran!($circuit, $tspan; solver=$solver, reltol=$reltol, abstol=$abstol,
+                              maxiters=$maxiters, initializealg=$init, dense=false,
+                              force_dtmin=true, unstable_check=(dt,u,p,t)->false) samples=3 evals=1 seconds=300
 
     # Also run once to get solution statistics
     circuit = setup_simulation()
-    sol = tran!(circuit, tspan; solver=solver, reltol=reltol, maxiters=maxiters, initializealg=init, dense=false)
+    sol = tran!(circuit, tspan; solver=solver, reltol=reltol, abstol=abstol, maxiters=maxiters,
+                initializealg=init, dense=false, force_dtmin=true, unstable_check=(dt,u,p,t)->false)
 
     println("\n=== Results ($solver_name) ===")
+    println("Status:     $(sol.retcode)")
     @printf("Timepoints: %d\n", length(sol.t))
     @printf("NR iters:   %d\n", sol.stats.nnonliniter)
     @printf("Iter/step:  %.2f\n", sol.stats.nnonliniter / length(sol.t))

--- a/benchmarks/vacask/c6288/cedarsim/runme.jl
+++ b/benchmarks/vacask/c6288/cedarsim/runme.jl
@@ -58,7 +58,7 @@ function setup_simulation()
     return circuit
 end
 
-function run_benchmark(solver; reltol=1e-3, abstol=1e-6, maxiters=10_000_000)
+function run_benchmark(solver; reltol=1e-3, abstol=1e-6, maxiters=10_000_000, extra_kwargs=NamedTuple())
     tspan = (0.0, 2e-9)  # 2ns simulation (same as ngspice)
     solver_name = nameof(typeof(solver))
 
@@ -73,31 +73,33 @@ function run_benchmark(solver; reltol=1e-3, abstol=1e-6, maxiters=10_000_000)
     # single step. See doc/c6288_bottleneck_findings.md.
     init = CedarDCOp()
 
-    # abstol/force_dtmin/unstable_check match the settings proven for the
-    # ring oscillator benchmark (benchmarks/vacask/ring/cedarsim/runme.jl),
-    # another PSP103-heavy no-easy-DC-point circuit. Without a loosened
-    # abstol, tran!'s default (1e-10) is unreachable for a 212k-variable
-    # digital circuit and drives dt down toward the femtosecond scale --
-    # IDA gives up with a hmin corrector-convergence failure, and FBDF's
-    # per-step Jacobian/mass-matrix recombination (see
-    # doc/c6288_bottleneck_findings.md) OOMs from sheer step count before
-    # ever reaching t=2ns. force_dtmin=true lets a solver push through a
-    # step that doesn't fully converge rather than aborting outright, and
-    # unstable_check is disabled because this digital circuit's large but
-    # legitimate voltage swings would otherwise trip the default heuristic.
+    # abstol=1e-6 (looser than tran!'s default of 1e-10, which is unreachable
+    # for a 212k-variable circuit and was driving dt down toward the
+    # femtosecond scale) applies to every solver -- it's a universal SciML
+    # kwarg and directly explained IDA's original hmin corrector-convergence
+    # failure. force_dtmin/unstable_check, by contrast, are passed only via
+    # extra_kwargs per solver below: IDA/Sundials doesn't recognize them at
+    # all, and unlike the ring oscillator benchmark (which genuinely needs to
+    # push through switching transitions with no valid intermediate DC point,
+    # via CedarTranOp's homotopy), c6288 uses CedarDCOp -- a proper DC
+    # operating point solve -- so forcing through non-converged steps here
+    # isn't pushing through a known-hard-but-tractable region the way it does
+    # for ring; it just burns CPU time on steps that aren't really
+    # converging. See doc/c6288_bottleneck_findings.md.
     println("\nBenchmarking transient analysis with $solver_name (reltol=$reltol, abstol=$abstol)...")
     bench = @benchmark tran!($circuit, $tspan; solver=$solver, reltol=$reltol, abstol=$abstol,
                               maxiters=$maxiters, initializealg=$init, dense=false,
-                              force_dtmin=true, unstable_check=(dt,u,p,t)->false) samples=3 evals=1 seconds=300
+                              extra_kwargs...) samples=3 evals=1 seconds=300
 
     # Also run once to get solution statistics
     circuit = setup_simulation()
     sol = tran!(circuit, tspan; solver=solver, reltol=reltol, abstol=abstol, maxiters=maxiters,
-                initializealg=init, dense=false, force_dtmin=true, unstable_check=(dt,u,p,t)->false)
+                initializealg=init, dense=false, extra_kwargs...)
 
     println("\n=== Results ($solver_name) ===")
     println("Status:     $(sol.retcode)")
     @printf("Timepoints: %d\n", length(sol.t))
+    @printf("Final time: %.3e s (target %.3e s)\n", sol.t[end], tspan[2])
     @printf("NR iters:   %d\n", sol.stats.nnonliniter)
     @printf("Iter/step:  %.2f\n", sol.stats.nnonliniter / length(sol.t))
     display(bench)
@@ -109,24 +111,35 @@ end
 # Run if executed directly
 if abspath(PROGRAM_FILE) == @__FILE__
     solver_name = length(ARGS) >= 1 ? ARGS[1] : "Rodas5P"
-    solver = if solver_name == "IDA"
+    solver, extra_kwargs = if solver_name == "IDA"
         # linear_solver=:KLU is required at this scale: Sundials' own default
         # dense solver allocates an n x n matrix (n=212228 -> ~360GB), which
         # doesn't raise a catchable OutOfMemoryError -- it segfaults inside
-        # SUNMatZero_Dense.
-        IDA(linear_solver=:KLU, max_nonlinear_iters=100, max_error_test_failures=20)
+        # SUNMatZero_Dense. force_dtmin/unstable_check are OrdinaryDiffEq
+        # concepts Sundials.jl's common interface doesn't recognize.
+        IDA(linear_solver=:KLU, max_nonlinear_iters=100, max_error_test_failures=20), NamedTuple()
     elseif solver_name == "FBDF"
         # autodiff=AutoFiniteDiff() is required: FBDF's own default resolves
         # to AutoSparse{AutoForwardDiff, KnownJacobianSparsityDetector,
         # GreedyColoringAlgorithm}, which ignores the analytic jac= we supply
         # and rebuilds/colors its own Jacobian -- whose combination with the
         # mass matrix in jacobian2W! OOMs at this scale. Matches
-        # SOLVER_FBDF_RING in benchmarks/vacask/run_benchmarks.jl.
-        FBDF(linsolve=KLUFactorization(), autodiff=AutoFiniteDiff())
+        # SOLVER_FBDF_RING in benchmarks/vacask/run_benchmarks.jl. That
+        # benchmark also needs force_dtmin/unstable_check to push through
+        # switching transitions with no valid intermediate DC point; give
+        # FBDF the same latitude here since it's the most failure-prone of
+        # the three solvers at this scale.
+        FBDF(linsolve=KLUFactorization(), autodiff=AutoFiniteDiff()),
+            (force_dtmin=true, unstable_check=(dt,u,p,t)->false)
     elseif solver_name == "Rodas5P"
-        Rodas5P()
+        # No extra_kwargs: already succeeds as-is. Whether its ~18 accepted
+        # steps over the 2ns window represent a faithful simulation of the
+        # multiplier's switching activity, or a reltol=1e-3 adaptive step
+        # size coarse enough to step past logic transitions, is an open
+        # question -- not one force_dtmin/unstable_check would answer.
+        Rodas5P(), NamedTuple()
     else
         error("Unknown solver: $solver_name. Use IDA, FBDF, or Rodas5P")
     end
-    run_benchmark(solver)
+    run_benchmark(solver; extra_kwargs)
 end

--- a/benchmarks/vacask/c6288/cedarsim/runme.jl
+++ b/benchmarks/vacask/c6288/cedarsim/runme.jl
@@ -2,16 +2,23 @@
 #==============================================================================#
 # VACASK Benchmark: C6288 16x16 Multiplier
 #
-# A 16x16 bit multiplier circuit using PSP103 MOSFETs.
+# A 16x16 bit multiplier circuit using PSP103 MOSFETs (212228 variables).
 #
-# Benchmark target: High complexity digital circuit (154k variables)
-#
-# STATUS: Uses CedarUICOp initialization (pseudo-transient relaxation)
+# STATUS: Uses CedarDCOp initialization (DC solve with GMIN/source stepping)
 #
 # Notes:
-# Digital circuits often don't have a valid DC solution. ngspice handles
-# this with 'uic' (use initial conditions). CedarUICOp provides similar
-# functionality using pseudo-transient relaxation.
+# ngspice's 'uic' skips DC operating point analysis and starts transient
+# integration directly from u=0, relying on its own per-step Newton retry
+# with timestep halving to work through the harsh startup (vdd hard-on at
+# t=0). SciML's DAE initialization framework requires a consistent t=0
+# state up front rather than tolerating repeated per-step failures, so the
+# naive translation of 'uic' -- CedarUICOp's fixed-dt pseudo-transient
+# relaxation -- cannot take even a single non-degenerate step here (Newton
+# fails identically at every dt, including with unlimited shrinking room).
+# CedarDCOp's existing GMIN-stepping/source-stepping homotopy chain (the
+# same machinery vacask/ngspice use to find a DC operating point for
+# awkward circuits) does find a usable t=0 state, and the transient
+# proceeds normally from there. See doc/c6288_bottleneck_findings.md.
 #
 # Usage: julia runme.jl [solver]
 #   solver: IDA, FBDF, or Rodas5P (default)
@@ -19,7 +26,7 @@
 
 using Cadnip
 using Cadnip.MNA
-using Cadnip.MNA: CedarUICOp
+using Cadnip.MNA: CedarDCOp
 using Sundials: IDA
 using OrdinaryDiffEqBDF: FBDF
 using OrdinaryDiffEqRosenbrock: Rodas5P
@@ -58,10 +65,11 @@ function run_benchmark(solver; reltol=1e-3, maxiters=10_000_000)
     n = MNA.system_size(circuit)
     println("Circuit size: $n variables")
 
-    # Use CedarUICOp for initialization - digital circuits often don't have
-    # a valid DC solution. ngspice handles this with 'uic' (use initial conditions)
-    # CedarUICOp uses pseudo-transient relaxation to initialize
-    init = CedarUICOp()
+    # Use CedarDCOp for initialization: the GMIN/source-stepping fallback
+    # chain in _dc_solve_with_fallbacks finds a usable operating point for
+    # this circuit where CedarUICOp's pseudo-transient warmup cannot take a
+    # single step. See doc/c6288_bottleneck_findings.md.
+    init = CedarDCOp()
 
     # Benchmark the actual simulation (not setup)
     println("\nBenchmarking transient analysis with $solver_name (reltol=$reltol)...")

--- a/benchmarks/vacask/c6288/cedarsim/runme.jl
+++ b/benchmarks/vacask/c6288/cedarsim/runme.jl
@@ -28,9 +28,6 @@ using Printf
 
 # Import pre-parsed PSP103 model from PSPModels package
 using PSPModels
-
-# Alias for compatibility with existing code
-const PSP103VA_module = sp_psp103va_module
 println("PSP103VA loaded from PSPModels package")
 
 # Parse SPICE file, inject PSP103VA module as Tier-2 scope so `.model` cards

--- a/benchmarks/vacask/c6288/cedarsim/runme.jl
+++ b/benchmarks/vacask/c6288/cedarsim/runme.jl
@@ -58,7 +58,7 @@ function setup_simulation()
     return circuit
 end
 
-function run_benchmark(solver; reltol=1e-3, abstol=1e-6, maxiters=10_000_000, extra_kwargs=NamedTuple())
+function run_benchmark(solver; reltol=1e-3, abstol=1e-6, maxiters=10_000_000)
     tspan = (0.0, 2e-9)  # 2ns simulation (same as ngspice)
     solver_name = nameof(typeof(solver))
 
@@ -75,26 +75,26 @@ function run_benchmark(solver; reltol=1e-3, abstol=1e-6, maxiters=10_000_000, ex
 
     # abstol=1e-6 (looser than tran!'s default of 1e-10, which is unreachable
     # for a 212k-variable circuit and was driving dt down toward the
-    # femtosecond scale) applies to every solver -- it's a universal SciML
-    # kwarg and directly explained IDA's original hmin corrector-convergence
-    # failure. force_dtmin/unstable_check, by contrast, are passed only via
-    # extra_kwargs per solver below: IDA/Sundials doesn't recognize them at
-    # all, and unlike the ring oscillator benchmark (which genuinely needs to
-    # push through switching transitions with no valid intermediate DC point,
-    # via CedarTranOp's homotopy), c6288 uses CedarDCOp -- a proper DC
-    # operating point solve -- so forcing through non-converged steps here
-    # isn't pushing through a known-hard-but-tractable region the way it does
-    # for ring; it just burns CPU time on steps that aren't really
-    # converging. See doc/c6288_bottleneck_findings.md.
+    # femtosecond scale) directly explained IDA's original hmin
+    # corrector-convergence failure.
+    #
+    # Deliberately NOT using force_dtmin/unstable_check here, unlike the ring
+    # oscillator benchmark. Ring uses CedarTranOp (a homotopy warmup with no
+    # real DC solve), so it genuinely needs to push through switching
+    # transitions with no valid intermediate state. c6288 uses CedarDCOp --
+    # a proper GMIN/source-stepping DC operating point solve -- so forcing
+    # through steps that don't converge isn't crossing a
+    # known-hard-but-tractable region the way it does for ring; empirically
+    # it just burns CPU time for hours without reaching t=2ns. See
+    # doc/c6288_bottleneck_findings.md.
     println("\nBenchmarking transient analysis with $solver_name (reltol=$reltol, abstol=$abstol)...")
     bench = @benchmark tran!($circuit, $tspan; solver=$solver, reltol=$reltol, abstol=$abstol,
-                              maxiters=$maxiters, initializealg=$init, dense=false,
-                              extra_kwargs...) samples=3 evals=1 seconds=300
+                              maxiters=$maxiters, initializealg=$init, dense=false) samples=3 evals=1 seconds=300
 
     # Also run once to get solution statistics
     circuit = setup_simulation()
     sol = tran!(circuit, tspan; solver=solver, reltol=reltol, abstol=abstol, maxiters=maxiters,
-                initializealg=init, dense=false, extra_kwargs...)
+                initializealg=init, dense=false)
 
     println("\n=== Results ($solver_name) ===")
     println("Status:     $(sol.retcode)")
@@ -111,35 +111,28 @@ end
 # Run if executed directly
 if abspath(PROGRAM_FILE) == @__FILE__
     solver_name = length(ARGS) >= 1 ? ARGS[1] : "Rodas5P"
-    solver, extra_kwargs = if solver_name == "IDA"
+    solver = if solver_name == "IDA"
         # linear_solver=:KLU is required at this scale: Sundials' own default
         # dense solver allocates an n x n matrix (n=212228 -> ~360GB), which
         # doesn't raise a catchable OutOfMemoryError -- it segfaults inside
-        # SUNMatZero_Dense. force_dtmin/unstable_check are OrdinaryDiffEq
-        # concepts Sundials.jl's common interface doesn't recognize.
-        IDA(linear_solver=:KLU, max_nonlinear_iters=100, max_error_test_failures=20), NamedTuple()
+        # SUNMatZero_Dense.
+        IDA(linear_solver=:KLU, max_nonlinear_iters=100, max_error_test_failures=20)
     elseif solver_name == "FBDF"
         # autodiff=AutoFiniteDiff() is required: FBDF's own default resolves
         # to AutoSparse{AutoForwardDiff, KnownJacobianSparsityDetector,
         # GreedyColoringAlgorithm}, which ignores the analytic jac= we supply
         # and rebuilds/colors its own Jacobian -- whose combination with the
         # mass matrix in jacobian2W! OOMs at this scale. Matches
-        # SOLVER_FBDF_RING in benchmarks/vacask/run_benchmarks.jl. That
-        # benchmark also needs force_dtmin/unstable_check to push through
-        # switching transitions with no valid intermediate DC point; give
-        # FBDF the same latitude here since it's the most failure-prone of
-        # the three solvers at this scale.
-        FBDF(linsolve=KLUFactorization(), autodiff=AutoFiniteDiff()),
-            (force_dtmin=true, unstable_check=(dt,u,p,t)->false)
+        # SOLVER_FBDF_RING in benchmarks/vacask/run_benchmarks.jl.
+        FBDF(linsolve=KLUFactorization(), autodiff=AutoFiniteDiff())
     elseif solver_name == "Rodas5P"
-        # No extra_kwargs: already succeeds as-is. Whether its ~18 accepted
-        # steps over the 2ns window represent a faithful simulation of the
-        # multiplier's switching activity, or a reltol=1e-3 adaptive step
-        # size coarse enough to step past logic transitions, is an open
-        # question -- not one force_dtmin/unstable_check would answer.
-        Rodas5P(), NamedTuple()
+        # Whether its ~18 accepted steps over the 2ns window represent a
+        # faithful simulation of the multiplier's switching activity, or a
+        # reltol=1e-3 adaptive step size coarse enough to step past logic
+        # transitions, is an open question.
+        Rodas5P()
     else
         error("Unknown solver: $solver_name. Use IDA, FBDF, or Rodas5P")
     end
-    run_benchmark(solver; extra_kwargs)
+    run_benchmark(solver)
 end

--- a/benchmarks/vacask/c6288/cedarsim/runme.jl
+++ b/benchmarks/vacask/c6288/cedarsim/runme.jl
@@ -30,6 +30,8 @@ using Cadnip.MNA: CedarDCOp
 using Sundials: IDA
 using OrdinaryDiffEqBDF: FBDF
 using OrdinaryDiffEqRosenbrock: Rodas5P
+using ADTypes: AutoFiniteDiff
+using LinearSolve: KLUFactorization
 using BenchmarkTools
 using Printf
 
@@ -93,9 +95,19 @@ end
 if abspath(PROGRAM_FILE) == @__FILE__
     solver_name = length(ARGS) >= 1 ? ARGS[1] : "Rodas5P"
     solver = if solver_name == "IDA"
-        IDA(max_nonlinear_iters=100, max_error_test_failures=20)
+        # linear_solver=:KLU is required at this scale: Sundials' own default
+        # dense solver allocates an n x n matrix (n=212228 -> ~360GB), which
+        # doesn't raise a catchable OutOfMemoryError -- it segfaults inside
+        # SUNMatZero_Dense.
+        IDA(linear_solver=:KLU, max_nonlinear_iters=100, max_error_test_failures=20)
     elseif solver_name == "FBDF"
-        FBDF()
+        # autodiff=AutoFiniteDiff() is required: FBDF's own default resolves
+        # to AutoSparse{AutoForwardDiff, KnownJacobianSparsityDetector,
+        # GreedyColoringAlgorithm}, which ignores the analytic jac= we supply
+        # and rebuilds/colors its own Jacobian -- whose combination with the
+        # mass matrix in jacobian2W! OOMs at this scale. Matches
+        # SOLVER_FBDF_RING in benchmarks/vacask/run_benchmarks.jl.
+        FBDF(linsolve=KLUFactorization(), autodiff=AutoFiniteDiff())
     elseif solver_name == "Rodas5P"
         Rodas5P()
     else

--- a/benchmarks/vacask/run_benchmarks.jl
+++ b/benchmarks/vacask/run_benchmarks.jl
@@ -298,11 +298,13 @@ function main()
         joinpath(BENCHMARK_DIR, "ring", "cedarsim", "runme.jl"),
         SOLVERS_RING)
 
-    # # C6288 Multiplier - all solvers
-    # append!(results, run_benchmark_all_solvers(
-    #     "C6288 Multiplier",
-    #     joinpath(BENCHMARK_DIR, "c6288", "cedarsim", "runme.jl")
-    # ))
+    # C6288 Multiplier deliberately NOT run here: its generated builder
+    # (2419 inlined subckt calls) hits LLVM RAGreedy's super-linear blowup
+    # at default -O2, so it needs its own `julia -O0` process. This process
+    # runs everything else at default optimization, so folding c6288 into
+    # this loop would reintroduce that hang. See the separate "Run Cadnip
+    # c6288 benchmark" CI step (.github/workflows/benchmark.yml) and
+    # doc/c6288_bottleneck_findings.md.
 
     println()
     println("=" ^ 60)

--- a/doc/c6288_bottleneck_findings.md
+++ b/doc/c6288_bottleneck_findings.md
@@ -494,17 +494,17 @@ calls before ever reaching `t=2ns`. Rodas5P happened to tolerate the tight
 
 Fixed by giving c6288's `run_benchmark` a looser `abstol=1e-6` for every
 solver (a universal SciML kwarg, and the direct fix for IDA's `hmin`
-failure). `force_dtmin=true`/`unstable_check=(dt,u,p,t)->false`, by
-contrast, are applied to **FBDF only**, not IDA (Sundials' common interface
-doesn't recognize either kwarg) or Rodas5P (already succeeds without them).
-Unlike the ring oscillator, which genuinely needs to push through switching
-transitions with no valid intermediate DC point (it uses `CedarTranOp`, a
-homotopy warmup, not a real DC solve), c6288 uses `CedarDCOp` -- a proper
-GMIN/source-stepping DC operating point solve. Forcing through
-non-converged steps after a legitimate DC start isn't crossing a
-known-hard-but-tractable region the way it does for ring; empirically it
-just burned CPU time for hours without reaching `t=2ns`. Whether Rodas5P's
-~18 accepted steps over the 2ns window represent a faithful simulation of
+failure). `force_dtmin=true`/`unstable_check=(dt,u,p,t)->false` are
+deliberately **not** used at all, unlike the ring oscillator benchmark.
+Ring genuinely needs to push through switching transitions with no valid
+intermediate DC point (it uses `CedarTranOp`, a homotopy warmup, not a real
+DC solve); c6288 uses `CedarDCOp` -- a proper GMIN/source-stepping DC
+operating point solve. Forcing through non-converged steps after a
+legitimate DC start isn't crossing a known-hard-but-tractable region the
+way it does for ring; empirically it just burned CPU time for hours
+(across all three solvers, not just IDA) without reaching `t=2ns`. Whether
+Rodas5P's ~18 accepted steps over the 2ns window represent a faithful
+simulation of
 the multiplier's switching activity, or `reltol=1e-3` letting it step past
 logic transitions, remains an open question.
 

--- a/doc/c6288_bottleneck_findings.md
+++ b/doc/c6288_bottleneck_findings.md
@@ -457,11 +457,44 @@ Rodas5P), two more scale-specific issues surfaced -- both in solver
   reconstructs its own (colored, autodiff-based) Jacobian instead. Combining
   that with the mass matrix inside `jacobian2W!`'s generic sparse broadcast
   triggers the same class of scalar-sparse-growth blowup documented above,
-  just inside library code we don't control. Fixed by adding
-  `autodiff=AutoFiniteDiff()` (and `linsolve=KLUFactorization()`), matching
-  `SOLVER_FBDF_RING` in `run_benchmarks.jl` -- forcing FBDF to reuse our
-  supplied Jacobian's sparsity pattern via finite differencing instead of
-  rebuilding its own via coloring.
+  just inside library code we don't control.
+
+  Adding `autodiff=AutoFiniteDiff()` (matching `SOLVER_FBDF_RING` in
+  `run_benchmarks.jl`) did **not** fix this -- it only changes which autodiff
+  backend gets wrapped: the resulting type is
+  `AutoSparse{AutoFiniteDiff, KnownJacobianSparsityDetector,
+  GreedyColoringAlgorithm}`, still going through the same coloring
+  reconstruction, still OOMing in the same place. FBDF apparently always
+  wraps whatever `autodiff` it's given in `AutoSparse` + coloring when the
+  problem has a sparse `jac_prototype`, regardless of whether an analytic
+  `jac=` is also supplied -- unlike Rodas5P's Rosenbrock `calc_J`/`calc_J!`
+  path, which calls `f.jac` directly when `has_jac(f)` is true. The real
+  fix (see below) turned out to be `abstol`/`force_dtmin`, which reduces how
+  many times this expensive (and apparently leaky at c6288's scale)
+  reconstruction has to run, rather than avoiding it entirely.
+
+### The actual root cause: `tran!`'s default `abstol` is unreachable here
+
+Comparing against `benchmarks/vacask/ring/cedarsim/runme.jl` (another
+PSP103-heavy, no-easy-DC-point circuit that's proven to work with IDA/FBDF)
+turned up the real gap: ring's `run_benchmark` passes `abstol=1e-4`,
+`force_dtmin=true`, and `unstable_check=(dt,u,p,t)->false`; c6288's did not
+override any of them, leaving `abstol` at `tran!`'s default of `1e-10`.
+
+An absolute tolerance of `1e-10` is essentially unreachable for a
+212,228-variable digital circuit -- the corrector has to resolve every
+node's residual to 10 decimal places, which drives `dt` down toward the
+femtosecond/attosecond scale chasing an unreachable target. That
+directly explains IDA's failure (`h = 8.33e-19`, then `IDAHandleFailure`
+with "corrector convergence failed repeatedly or with |h| = hmin") and is
+the most likely reason FBDF's per-step Jacobian/mass-matrix
+recombination (above) OOMs: far more steps means far more `jacobian2W!`
+calls before ever reaching `t=2ns`. Rodas5P happened to tolerate the tight
+`abstol` well enough to still finish in ~18 steps; IDA and FBDF did not.
+
+Fixed by giving c6288's `run_benchmark` the same `abstol=1e-6`,
+`force_dtmin=true`, and `unstable_check=(dt,u,p,t)->false` settings ring
+uses (see `runme.jl`).
 
 ## References
 

--- a/doc/c6288_bottleneck_findings.md
+++ b/doc/c6288_bottleneck_findings.md
@@ -492,9 +492,21 @@ recombination (above) OOMs: far more steps means far more `jacobian2W!`
 calls before ever reaching `t=2ns`. Rodas5P happened to tolerate the tight
 `abstol` well enough to still finish in ~18 steps; IDA and FBDF did not.
 
-Fixed by giving c6288's `run_benchmark` the same `abstol=1e-6`,
-`force_dtmin=true`, and `unstable_check=(dt,u,p,t)->false` settings ring
-uses (see `runme.jl`).
+Fixed by giving c6288's `run_benchmark` a looser `abstol=1e-6` for every
+solver (a universal SciML kwarg, and the direct fix for IDA's `hmin`
+failure). `force_dtmin=true`/`unstable_check=(dt,u,p,t)->false`, by
+contrast, are applied to **FBDF only**, not IDA (Sundials' common interface
+doesn't recognize either kwarg) or Rodas5P (already succeeds without them).
+Unlike the ring oscillator, which genuinely needs to push through switching
+transitions with no valid intermediate DC point (it uses `CedarTranOp`, a
+homotopy warmup, not a real DC solve), c6288 uses `CedarDCOp` -- a proper
+GMIN/source-stepping DC operating point solve. Forcing through
+non-converged steps after a legitimate DC start isn't crossing a
+known-hard-but-tractable region the way it does for ring; empirically it
+just burned CPU time for hours without reaching `t=2ns`. Whether Rodas5P's
+~18 accepted steps over the 2ns window represent a faithful simulation of
+the multiplier's switching activity, or `reltol=1e-3` letting it step past
+logic transitions, remains an open question.
 
 ## References
 

--- a/doc/c6288_bottleneck_findings.md
+++ b/doc/c6288_bottleneck_findings.md
@@ -438,6 +438,31 @@ therefore runs the Cadnip c6288 benchmark as its own `julia -O0` step,
 separate from `run_benchmarks.jl` (which runs the other circuits at
 default optimization) — see `.github/workflows/benchmark.yml`.
 
+### IDA and FBDF needed their own solver-option fixes
+
+Once CI started exercising all three solvers `runme.jl` supports (not just
+Rodas5P), two more scale-specific issues surfaced -- both in solver
+*options* `runme.jl` was passing, not in Cadnip's own code:
+
+- **`IDA(max_nonlinear_iters=100, max_error_test_failures=20)` segfaulted**
+  inside `SUNMatZero_Dense`. Sundials' own default linear solver is dense;
+  at `n=212228` that's a ~360GB allocation, which manifests as a segfault
+  rather than a catchable `OutOfMemoryError` (C-level malloc failure, not
+  a Julia allocation). Fixed by adding `linear_solver=:KLU`, matching
+  `SOLVER_IDA` in `run_benchmarks.jl`.
+- **bare `FBDF()` threw `OutOfMemoryError` inside `jacobian2W!`**
+  (`OrdinaryDiffEqDifferentiation`). FBDF's own default `autodiff` resolves
+  to `AutoSparse{AutoForwardDiff, KnownJacobianSparsityDetector,
+  GreedyColoringAlgorithm}` -- it ignores the analytic `jac=` we supply and
+  reconstructs its own (colored, autodiff-based) Jacobian instead. Combining
+  that with the mass matrix inside `jacobian2W!`'s generic sparse broadcast
+  triggers the same class of scalar-sparse-growth blowup documented above,
+  just inside library code we don't control. Fixed by adding
+  `autodiff=AutoFiniteDiff()` (and `linsolve=KLUFactorization()`), matching
+  `SOLVER_FBDF_RING` in `run_benchmarks.jl` -- forcing FBDF to reuse our
+  supplied Jacobian's sparsity pattern via finite differencing instead of
+  rebuilding its own via coloring.
+
 ## References
 
 - `benchmarks/vacask/c6288/cedarsim/profile_c6288.jl` — phase-by-phase

--- a/doc/c6288_bottleneck_findings.md
+++ b/doc/c6288_bottleneck_findings.md
@@ -299,9 +299,67 @@ instances. C6288: largest enclosing subckt has 2419 instances. The growth
 isn't 18 → 10000 (ratio 555×); it's 18 → 2419 (ratio 134×). And it hits a
 non-linearity in LLVM's register allocator at that size.
 
+## Update: with `-O0`, what's the *next* blocker?
+
+Verified by actually running `julia -O0 --project=benchmarks
+benchmarks/vacask/c6288/cedarsim/runme.jl Rodas5P` end to end (not just the
+profiler). Two things:
+
+**Fixed en route:** `runme.jl` itself was broken independent of `-O0` — it
+referenced `sp_psp103va_module`, which doesn't exist in `PSPModels`
+(`PSP103VA_module` is the exported name). This threw `UndefVarError` before
+anything else ran. Fixed by dropping the stale alias.
+
+**Real next blocker, confirmed live via gdb:** once the script actually gets
+past setup (`build_with_detection`/`compile_structure`/first `fast_rebuild!`
+all complete in the ~75-90s the profiler predicted — `-O0` genuinely clears
+RAGreedy), the process hangs again, this time at runtime, not JIT. Repeated
+`gdb -p <pid> -batch -ex 'thread apply all bt'` snapshots over 10+ minutes
+all show the same stack:
+
+```
+_insert! () at .../SparseArrays/src/sparsematrix.jl:3218
+julia__setindex_scalar!_... () at .../SparseArrays/src/sparsematrix.jl:3206-3207
+insert! () at array.jl:1746
+julia__growat!_... () at array.jl:1162
+memmove () at cmem.jl:28
+```
+
+i.e. `SparseArrays.setindex!` falling into its scalar insertion path
+(`_insert!`, which shifts `colptr`/`rowval`/`nzval` to make room for one new
+stored entry at a time) over and over, for a 212,228×212,228 matrix with
+~2.45M final nnz. Each such insertion is `O(current nnz)`, so building up
+the structure entry-by-entry this way is `O(n²)`-ish — consistent with the
+process still running (and still making progress, not deadlocked) after 10
+minutes before it was killed.
+
+This is exactly item 3 from the "what to do about it" list above:
+`CedarUICOp`'s pseudo-transient warmup (`SciMLBase.initialize_dae!(...,
+::CedarUICOp)` in `src/mna/dcop.jl:310-389`) runs `ImplicitEuler(autodiff=
+ADTypes.AutoFiniteDiff())` for `warmup_steps` fixed timesteps. The main
+`tran!` path does wire `jac_prototype` through for the outer solver
+(`src/mna/solve.jl:1721-1725`, `1611-1615`), but `AutoFiniteDiff()` with no
+declared sparsity/coloring makes OrdinaryDiffEq's Jacobian machinery
+(`calc_J`/`calc_W` in `OrdinaryDiffEqDifferentiation`) build/refresh the
+Jacobian without exploiting the shared sparsity pattern — degenerating into
+scalar writes that repeatedly grow the sparse structure instead of reusing
+existing storage.
+
+**Net effect:** clearing the LLVM RAGreedy hang with `-O0` does not make
+c6288 runnable end-to-end. It trades a ~10-minute-plus JIT hang for a
+different runtime hang of the same order (or worse, given `O(n²)` scaling),
+inside the `CedarUICOp` warmup's finite-difference Jacobian handling. Fixing
+this requires giving the warmup's `ImplicitEuler` a proper sparse
+`jac_prototype`/coloring (or an analytic `jac=`) instead of relying on
+`AutoFiniteDiff()` to rediscover the 2.45M-entry sparsity pattern column by
+column at runtime.
+
 ## References
 
 - `benchmarks/vacask/c6288/cedarsim/profile_c6288.jl` — phase-by-phase
   profiler that produced the table above
 - gdb backtrace from `pid` of stuck `julia` process during build_with_detection
   — RAGreedy::calcGapWeights confirms the LLVM register-allocator hypothesis
+- gdb backtraces from `pid` of stuck `julia -O0` process during the
+  `CedarUICOp` warmup — `SparseArrays._insert!`/`setindex_scalar!` confirms
+  the scalar-sparse-insertion hypothesis above

--- a/doc/c6288_bottleneck_findings.md
+++ b/doc/c6288_bottleneck_findings.md
@@ -1,6 +1,16 @@
 # C6288 Benchmark Bottleneck — Investigation
 
-**Status:** identified. The c6288 (16x16 multiplier, ~10k PSP103 MOSFETs)
+**Status:** RESOLVED. `benchmarks/vacask/c6288/cedarsim/runme.jl` now runs
+end to end under `julia -O0` with `CedarDCOp` initialization: setup
+completes in ~90s, DC solve finds an operating point via GMIN/source
+stepping, and the transient reaches `retcode=Success` (17 accepted / 5
+rejected steps over the 2ns window in one validation run). See "Resolution"
+near the end of this document for the fixes and the remaining `-O0`
+requirement. The section below is kept as the original investigation log.
+
+---
+
+The c6288 (16x16 multiplier, ~10k PSP103 MOSFETs)
 benchmark blocks for ≥10 minutes inside Julia's first-call JIT and never
 reaches the solver. The profile run was killed at 7+ minutes still inside
 `build_with_detection`'s first `circuit.builder(...)` call — this is the
@@ -354,6 +364,80 @@ this requires giving the warmup's `ImplicitEuler` a proper sparse
 `AutoFiniteDiff()` to rediscover the 2.45M-entry sparsity pattern column by
 column at runtime.
 
+## Resolution
+
+Four real bugs, found and fixed by actually running the benchmark end to
+end (not just profiling setup) and reading gdb/Julia stack traces off the
+stuck process, plus one initialization-algorithm swap:
+
+1. **`runme.jl` itself was broken**, independent of everything else below:
+   it referenced `sp_psp103va_module`, which doesn't exist in `PSPModels`
+   (the export is `PSP103VA_module`). Fixed by dropping the stale alias.
+
+2. **`CedarUICOp`'s DAE (IDA) warmup had no Jacobian at all**
+   (`src/mna/dcop.jl`) — `ODEFunction(warmup_rhs!; mass_matrix=cs.C)` with no
+   `jac`/`jac_prototype`, forcing `ImplicitEuler` to rediscover the
+   Jacobian via autodiff/finite-diff. Fixed by adding an analytic
+   `warmup_jac!` (`d(du)/du = -G`) with `jac_prototype=copy(cs.G)`.
+
+3. **The main ODE `jac!` was `O(n²)` on sparse circuits, not zero-alloc**
+   (`src/mna/solve.jl`) — it looped `for i in eachindex(J, G); J[i] = -G[i]; end`.
+   For `SparseMatrixCSC`, `eachindex` over two sparse matrices is
+   `IndexCartesian`, i.e. `CartesianIndices` over the *full* `n²` index
+   space, not the ~nnz stored entries. At c6288's `n=212228` that's
+   ~4.5e10 iterations, each a scalar sparse write that can insert a new
+   structural entry (`O(current nnz)` per insert). This is what was
+   actually hanging after fix (2) — confirmed by sending `SIGINT` to the
+   stuck process and reading the resulting Julia stack trace, which pinned
+   it to `jac!` calling into `SparseArrays.setindex!`'s scalar path.
+   First fix attempt walked `nonzeros(J)`/`nonzeros(G)` directly (assuming
+   matching patterns); a follow-up (`0540661`) switched to `copyto!`
+   after that assumption broke under (4) below (see next point).
+
+4. **`ShampineCollocationInit`'s default `nlsolve` OOMs on large sparse
+   circuits** (`src/mna/dcop.jl`, all four call sites) — with no `nlsolve`
+   specified, `OrdinaryDiffEqNonlinearSolve.default_nlsolve` picks
+   `FastShortcutNonlinearPolyalg`, whose leading algorithms are dense
+   QuasiNewton methods (Broyden/Klement) that allocate an `n×n` dense
+   approximate-Jacobian regardless of the sparse `jac`/`jac_prototype`
+   already threaded through. At c6288's scale that's a ~360GB allocation →
+   instant `OutOfMemoryError`. Fixed by passing
+   `nlsolve=NewtonRaphson(autodiff=nothing)` explicitly, so it uses the
+   supplied sparse Jacobian directly. This changed `J`'s provenance (now
+   built by `NonlinearSolveBase.JacobianCache` rather than a straight
+   `deepcopy` of `jac_prototype`), which is what broke the `nonzeros`-based
+   fix in (3) — `J` and `G` no longer reliably shared identical stored-entry
+   counts (observed: 677700 vs. 2452148), hence the `copyto!`-based fix.
+
+With all four in place, `runme.jl` reaches the solver: no more JIT hang, no
+OOM, no dimension mismatch — but `retcode=InitialFailure` with only the
+`t=0` point saved. `CedarUICOp`'s warmup (fixed `dt=1e-12`, `adaptive=false`,
+10 steps by default) turned out to make **zero progress**: `|Δu|=0.0` and
+the DC-style residual `‖G(u)u - b(u)‖` identical to six decimal places
+across 300 steps in a targeted diagnostic — Newton fails identically on the
+very first attempted step and never moves `u` away from zero. Because
+`adaptive=false`, `force_dtmin=true` has nothing to act on: there is no
+dt-shrinking retry loop the way ngspice's real `uic` transient stepper has
+(ngspice's `.control ... tran 2p 2n uic` skips DC op entirely and leans on
+its own per-step Newton-with-timestep-halving; SciML's initialization
+framework instead requires a consistent `t=0` state up front). More warmup
+steps at a fixed `dt` would not have helped — the fixed-dt, no-retry
+approach itself is the wrong tool here, not an insufficient step count.
+
+**Swapping `CedarUICOp` for `CedarDCOp`** (which already implements a
+GMIN-stepping/source-stepping homotopy chain in
+`_dc_solve_with_fallbacks` — the same class of technique vacask/ngspice use
+to find an operating point for exactly this kind of circuit) resolves it:
+a validation run reached `retcode=Success` with 17 accepted / 5 rejected
+steps over the full 2ns window. `runme.jl` now uses `CedarDCOp()`.
+
+**The `-O0` requirement remains and is not expected to go away** without
+the deeper codegen work in "What to do about it" item 1/2 above (chunking
+the generated builder so LLVM's register allocator stays linear-time). CI
+therefore runs the Cadnip c6288 benchmark as its own `julia -O0` step,
+separate from `run_benchmarks.jl` (which runs the other circuits at
+default optimization) — see `.github/workflows/benchmark.yml`.
+
 ## References
 
 - `benchmarks/vacask/c6288/cedarsim/profile_c6288.jl` — phase-by-phase
@@ -363,3 +447,9 @@ column at runtime.
 - gdb backtraces from `pid` of stuck `julia -O0` process during the
   `CedarUICOp` warmup — `SparseArrays._insert!`/`setindex_scalar!` confirms
   the scalar-sparse-insertion hypothesis above
+- `SIGINT`-induced Julia stack trace pinning the post-fix hang to
+  `jac!` at `src/mna/solve.jl` calling `SparseArrays.setindex!`'s scalar path
+- Targeted diagnostic script replaying `CedarUICOp`'s warmup loop with a
+  DC-residual printout per step, showing zero movement across 300 steps
+- Diagnostic run of `tran!` with `CedarDCOp()` in place of `CedarUICOp()`,
+  reaching `retcode=Success`

--- a/src/mna/dcop.jl
+++ b/src/mna/dcop.jl
@@ -150,21 +150,6 @@ end
 CedarUICOp(; warmup_steps::Int=10, dt::Float64=1e-12, use_shampine::Bool=false) =
     CedarUICOp(warmup_steps, dt, use_shampine)
 
-# ShampineCollocationInit's default nlsolve (nlsolve=nothing ->
-# FastShortcutNonlinearPolyalg) leads with dense QuasiNewton methods
-# (Broyden/Klement). Those OOM at large scale (c6288, n=212228 -> ~360GB
-# dense allocation) but are, per the VADistiller sp_bjt monostable
-# integration test, sometimes genuinely *needed* for convergence on small
-# circuits with awkward Jacobians (BJT excess-phase internal nodes) --
-# neither CedarShampineNLSolve() (Newton-only) nor CedarRobustNLSolve()
-# (TrustRegion's JVP breaks on Dual through this closure, see
-# CedarShampineNLSolve's docstring) reproduce that. So only override the
-# default for circuits large enough that the dense QuasiNewton path would
-# actually be a problem; small/awkward circuits keep exactly the prior
-# (nlsolve=nothing) behavior.
-const _SHAMPINE_LARGE_N_THRESHOLD = 10_000
-_shampine_nlsolve(n::Int) = n > _SHAMPINE_LARGE_N_THRESHOLD ? CedarShampineNLSolve() : nothing
-
 #==============================================================================#
 # Sundials Integration
 #
@@ -221,7 +206,7 @@ function SciMLBase.initialize_dae!(integrator::Sundials.IDAIntegrator,
     if alg.use_shampine
         # ShampineCollocationInit takes a small step to find consistent state
         # Good for oscillators where DC solve gets close but doesn't fully converge
-        return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=_shampine_nlsolve(length(integrator.u))))
+        return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=CedarShampineNLSolve()))
     else
         return SciMLBase.initialize_dae!(integrator, Sundials.DefaultInit())
     end
@@ -271,9 +256,9 @@ function SciMLBase.initialize_dae!(integrator::ODEIntegrator,
 
     # ShampineCollocationInit takes a small step to find consistent state.
     # BrownFullBasicInit broke for mass-matrix ODEs in OrdinaryDiffEq v7.
-    # _shampine_nlsolve only overrides the default for large circuits, where
-    # it's needed to avoid an OOM -- see its definition above.
-    return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=_shampine_nlsolve(length(integrator.u))))
+    # See CedarShampineNLSolve()'s docstring for why it, not the default or
+    # CedarRobustNLSolve(), is the right nlsolve here.
+    return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=CedarShampineNLSolve()))
 end
 
 #==============================================================================#
@@ -387,7 +372,7 @@ function SciMLBase.initialize_dae!(integrator::Sundials.IDAIntegrator, alg::Ceda
     if alg.use_shampine
         # ShampineCollocationInit takes a small step and adjusts both u and du
         # Good for oscillators where we need to refine the approximated derivatives
-        return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=_shampine_nlsolve(length(integrator.u))))
+        return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=CedarShampineNLSolve()))
     else
         return SciMLBase.initialize_dae!(integrator, Sundials.DefaultInit())
     end
@@ -422,5 +407,5 @@ function SciMLBase.initialize_dae!(integrator::ODEIntegrator, alg::CedarUICOp)
     # Pass an explicit nlsolve: see comment in the CedarDCOp/CedarTranOp
     # ODEIntegrator branch above -- the default falls back to a dense
     # QuasiNewton polyalgorithm that OOMs on large circuits.
-    return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=_shampine_nlsolve(length(integrator.u))))
+    return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=CedarShampineNLSolve()))
 end

--- a/src/mna/dcop.jl
+++ b/src/mna/dcop.jl
@@ -150,6 +150,21 @@ end
 CedarUICOp(; warmup_steps::Int=10, dt::Float64=1e-12, use_shampine::Bool=false) =
     CedarUICOp(warmup_steps, dt, use_shampine)
 
+# ShampineCollocationInit's default nlsolve (nlsolve=nothing ->
+# FastShortcutNonlinearPolyalg) leads with dense QuasiNewton methods
+# (Broyden/Klement). Those OOM at large scale (c6288, n=212228 -> ~360GB
+# dense allocation) but are, per the VADistiller sp_bjt monostable
+# integration test, sometimes genuinely *needed* for convergence on small
+# circuits with awkward Jacobians (BJT excess-phase internal nodes) --
+# neither CedarShampineNLSolve() (Newton-only) nor CedarRobustNLSolve()
+# (TrustRegion's JVP breaks on Dual through this closure, see
+# CedarShampineNLSolve's docstring) reproduce that. So only override the
+# default for circuits large enough that the dense QuasiNewton path would
+# actually be a problem; small/awkward circuits keep exactly the prior
+# (nlsolve=nothing) behavior.
+const _SHAMPINE_LARGE_N_THRESHOLD = 10_000
+_shampine_nlsolve(n::Int) = n > _SHAMPINE_LARGE_N_THRESHOLD ? CedarShampineNLSolve() : nothing
+
 #==============================================================================#
 # Sundials Integration
 #
@@ -206,7 +221,7 @@ function SciMLBase.initialize_dae!(integrator::Sundials.IDAIntegrator,
     if alg.use_shampine
         # ShampineCollocationInit takes a small step to find consistent state
         # Good for oscillators where DC solve gets close but doesn't fully converge
-        return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=NewtonRaphson(autodiff=nothing)))
+        return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=_shampine_nlsolve(length(integrator.u))))
     else
         return SciMLBase.initialize_dae!(integrator, Sundials.DefaultInit())
     end
@@ -256,12 +271,9 @@ function SciMLBase.initialize_dae!(integrator::ODEIntegrator,
 
     # ShampineCollocationInit takes a small step to find consistent state.
     # BrownFullBasicInit broke for mass-matrix ODEs in OrdinaryDiffEq v7.
-    # Pass an explicit nlsolve: the default (nlsolve=nothing) falls back to
-    # FastShortcutNonlinearPolyalg, which leads with dense QuasiNewton methods
-    # (Broyden/Klement) that allocate an n^2 dense matrix regardless of our
-    # sparse jac/jac_prototype -- OOMs instantly on large circuits (c6288,
-    # n=212228 -> ~360GB). NewtonRaphson uses our supplied sparse jac directly.
-    return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=NewtonRaphson(autodiff=nothing)))
+    # _shampine_nlsolve only overrides the default for large circuits, where
+    # it's needed to avoid an OOM -- see its definition above.
+    return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=_shampine_nlsolve(length(integrator.u))))
 end
 
 #==============================================================================#
@@ -375,7 +387,7 @@ function SciMLBase.initialize_dae!(integrator::Sundials.IDAIntegrator, alg::Ceda
     if alg.use_shampine
         # ShampineCollocationInit takes a small step and adjusts both u and du
         # Good for oscillators where we need to refine the approximated derivatives
-        return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=NewtonRaphson(autodiff=nothing)))
+        return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=_shampine_nlsolve(length(integrator.u))))
     else
         return SciMLBase.initialize_dae!(integrator, Sundials.DefaultInit())
     end
@@ -410,5 +422,5 @@ function SciMLBase.initialize_dae!(integrator::ODEIntegrator, alg::CedarUICOp)
     # Pass an explicit nlsolve: see comment in the CedarDCOp/CedarTranOp
     # ODEIntegrator branch above -- the default falls back to a dense
     # QuasiNewton polyalgorithm that OOMs on large circuits.
-    return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=NewtonRaphson(autodiff=nothing)))
+    return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=_shampine_nlsolve(length(integrator.u))))
 end

--- a/src/mna/dcop.jl
+++ b/src/mna/dcop.jl
@@ -22,7 +22,6 @@ using NonlinearSolve
 using SciMLBase
 using SciMLBase: ReturnCode
 using DiffEqBase
-using ADTypes
 using Sundials
 
 export CedarDCOp, CedarTranOp, CedarUICOp
@@ -328,14 +327,30 @@ function SciMLBase.initialize_dae!(integrator::Sundials.IDAIntegrator, alg::Ceda
         return nothing
     end
 
-    # Create ODE function with mass matrix (no explicit Jacobian - use autodiff)
-    warmup_f = SciMLBase.ODEFunction(warmup_rhs!; mass_matrix=cs.C)
+    # Analytic Jacobian: d(du)/du = -G. Without this, ImplicitEuler falls back
+    # to (auto/finite-)diff rediscovery of the sparsity pattern via scalar
+    # sparse writes, which is O(n) per write / O(n^2) overall on large
+    # circuits (see doc/c6288_bottleneck_findings.md).
+    function warmup_jac!(J, u, p, t)
+        fast_rebuild!(p, u, real_time(t))
+        G = p.structure.G
+        @inbounds for i in eachindex(J, G)
+            J[i] = -G[i]
+        end
+        return nothing
+    end
+
+    # Create ODE function with mass matrix and explicit Jacobian sharing G's
+    # sparsity pattern (same pattern as the mass matrix cs.C, both padded to
+    # the unified jac_pattern in compile_structure).
+    warmup_f = SciMLBase.ODEFunction(warmup_rhs!; mass_matrix=cs.C,
+                                      jac=warmup_jac!, jac_prototype=copy(cs.G))
     warmup_prob = SciMLBase.ODEProblem(warmup_f, prob.u0, warmup_tspan, ws)
 
     # Use ImplicitEuler for warmup (backward Euler for relaxation)
     # force_dtmin=true lets it march through even if Newton struggles
     # NoInit skips initialization - we start from zeros intentionally
-    warmup_int = init(warmup_prob, ImplicitEuler(autodiff=ADTypes.AutoFiniteDiff());
+    warmup_int = init(warmup_prob, ImplicitEuler();
                       adaptive=false, dt=alg.dt, force_dtmin=true,
                       initializealg=NoInit())
 
@@ -368,11 +383,13 @@ function SciMLBase.initialize_dae!(integrator::ODEIntegrator, alg::CedarUICOp)
     warmup_tspan = (0.0, alg.warmup_steps * alg.dt * 2)  # Finite tspan
     warmup_prob = remake(prob; tspan=warmup_tspan)
 
-    # ImplicitEuler with mass matrix for ODE warmup
+    # ImplicitEuler with mass matrix for ODE warmup. `prob.f` already carries
+    # the analytic jac/jac_prototype set up in `ODEProblem(circuit, tspan)`
+    # (src/mna/solve.jl), so `remake` inherits it and no autodiff is needed.
     # Use NoInit for the warmup phase - we're intentionally starting from
     # potentially inconsistent initial conditions and letting the solver relax them
     # force_dtmin=true lets it march through even if Newton struggles
-    warmup_int = init(warmup_prob, ImplicitEuler(autodiff=ADTypes.AutoFiniteDiff());
+    warmup_int = init(warmup_prob, ImplicitEuler();
                       adaptive=false, dt=alg.dt, force_dtmin=true,
                       initializealg=NoInit())
 

--- a/src/mna/dcop.jl
+++ b/src/mna/dcop.jl
@@ -206,7 +206,7 @@ function SciMLBase.initialize_dae!(integrator::Sundials.IDAIntegrator,
     if alg.use_shampine
         # ShampineCollocationInit takes a small step to find consistent state
         # Good for oscillators where DC solve gets close but doesn't fully converge
-        return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit())
+        return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=NewtonRaphson(autodiff=nothing)))
     else
         return SciMLBase.initialize_dae!(integrator, Sundials.DefaultInit())
     end
@@ -256,7 +256,12 @@ function SciMLBase.initialize_dae!(integrator::ODEIntegrator,
 
     # ShampineCollocationInit takes a small step to find consistent state.
     # BrownFullBasicInit broke for mass-matrix ODEs in OrdinaryDiffEq v7.
-    return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit())
+    # Pass an explicit nlsolve: the default (nlsolve=nothing) falls back to
+    # FastShortcutNonlinearPolyalg, which leads with dense QuasiNewton methods
+    # (Broyden/Klement) that allocate an n^2 dense matrix regardless of our
+    # sparse jac/jac_prototype -- OOMs instantly on large circuits (c6288,
+    # n=212228 -> ~360GB). NewtonRaphson uses our supplied sparse jac directly.
+    return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=NewtonRaphson(autodiff=nothing)))
 end
 
 #==============================================================================#
@@ -370,7 +375,7 @@ function SciMLBase.initialize_dae!(integrator::Sundials.IDAIntegrator, alg::Ceda
     if alg.use_shampine
         # ShampineCollocationInit takes a small step and adjusts both u and du
         # Good for oscillators where we need to refine the approximated derivatives
-        return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit())
+        return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=NewtonRaphson(autodiff=nothing)))
     else
         return SciMLBase.initialize_dae!(integrator, Sundials.DefaultInit())
     end
@@ -402,5 +407,8 @@ function SciMLBase.initialize_dae!(integrator::ODEIntegrator, alg::CedarUICOp)
 
     # ShampineCollocationInit takes a small step and adjusts both u and du.
     # BrownFullBasicInit broke for mass-matrix ODEs in OrdinaryDiffEq v7.
-    return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit())
+    # Pass an explicit nlsolve: see comment in the CedarDCOp/CedarTranOp
+    # ODEIntegrator branch above -- the default falls back to a dense
+    # QuasiNewton polyalgorithm that OOMs on large circuits.
+    return SciMLBase.initialize_dae!(integrator, ShampineCollocationInit(nlsolve=NewtonRaphson(autodiff=nothing)))
 end

--- a/src/mna/solve.jl
+++ b/src/mna/solve.jl
@@ -340,6 +340,39 @@ end
 
 export CedarRobustNLSolve
 
+"""
+    CedarShampineNLSolve()
+
+Nonlinear solver for `ShampineCollocationInit`'s internal consistency solve
+(used by `CedarDCOp`/`CedarTranOp`/`CedarUICOp`'s ODE-integrator branches in
+`dcop.jl`). Deliberately narrower than `CedarRobustNLSolve()`: it only
+combines `NewtonRaphson` variants (no `TrustRegion`, `LevenbergMarquardt`, or
+`PseudoTransient`).
+
+Those excluded algorithms need a Jacobian-vector product for their
+trust-region-radius/geodesic-acceleration machinery, which falls back to
+`AutoForwardDiff()` even when the top-level `autodiff` is set to `nothing`
+(that only disables autodiff for the *materialized* Jacobian, not JVPs).
+Running that autodiff through `ShampineCollocationInit`'s auto-generated
+residual closure -- which itself calls back into our stamped circuit
+evaluation -- produced `MethodError: no method matching Float64(::Dual)`
+on the VADistiller sp_bjt monostable multivibrator integration test. A
+bare `NewtonRaphson(autodiff=nothing)` sidesteps that (only ever needs the
+full analytic Jacobian we supply) but isn't robust enough alone to converge
+that same circuit (it has BJT excess-phase internal nodes that don't reach
+consistency in one Newton attempt). Two `NewtonRaphson` variants with
+different linesearches gets the extra fallback attempt without ever
+touching the JVP/autodiff path.
+"""
+function CedarShampineNLSolve()
+    return NonlinearSolvePolyAlgorithm((
+        NewtonRaphson(autodiff=nothing),
+        NewtonRaphson(autodiff=nothing, linesearch=BackTracking()),
+    ))
+end
+
+export CedarShampineNLSolve
+
 #==============================================================================#
 # Unified DC Solve
 #

--- a/src/mna/solve.jl
+++ b/src/mna/solve.jl
@@ -345,29 +345,49 @@ export CedarRobustNLSolve
 
 Nonlinear solver for `ShampineCollocationInit`'s internal consistency solve
 (used by `CedarDCOp`/`CedarTranOp`/`CedarUICOp`'s ODE-integrator branches in
-`dcop.jl`). Deliberately narrower than `CedarRobustNLSolve()`: it only
-combines `NewtonRaphson` variants (no `TrustRegion`, `LevenbergMarquardt`, or
-`PseudoTransient`).
+`dcop.jl`). Used for every circuit size -- unlike an earlier version of this
+function, there is no large-circuit/small-circuit split here; investigation
+showed a single `NewtonRaphson -> LevenbergMarquardt` chain covers both.
 
-Those excluded algorithms need a Jacobian-vector product for their
-trust-region-radius/geodesic-acceleration machinery, which falls back to
-`AutoForwardDiff()` even when the top-level `autodiff` is set to `nothing`
-(that only disables autodiff for the *materialized* Jacobian, not JVPs).
-Running that autodiff through `ShampineCollocationInit`'s auto-generated
-residual closure -- which itself calls back into our stamped circuit
-evaluation -- produced `MethodError: no method matching Float64(::Dual)`
-on the VADistiller sp_bjt monostable multivibrator integration test. A
-bare `NewtonRaphson(autodiff=nothing)` sidesteps that (only ever needs the
-full analytic Jacobian we supply) but isn't robust enough alone to converge
-that same circuit (it has BJT excess-phase internal nodes that don't reach
-consistency in one Newton attempt). Two `NewtonRaphson` variants with
-different linesearches gets the extra fallback attempt without ever
-touching the JVP/autodiff path.
+Background: `ShampineCollocationInit`'s default (`nlsolve=nothing`) resolves
+to `FastShortcutNonlinearPolyalg`, which leads with dense QuasiNewton methods
+(Broyden/Klement) that allocate an `n x n` dense structure -- fine for small
+circuits, an instant OOM at c6288's scale (n=212228, ~360GB). The natural
+alternative, `CedarRobustNLSolve()` (already used elsewhere for DC solves),
+crashes instead: its second algorithm (`TrustRegion` with the `Bastin`
+radius-update scheme) needs a Jacobian-vector product that falls back to
+`AutoForwardDiff()` regardless of `autodiff=nothing` (that flag only disables
+autodiff for the *materialized* Jacobian, not JVPs), and running that through
+`ShampineCollocationInit`'s auto-generated residual closure -- which calls
+back into our stamped circuit evaluation -- throws `MethodError: no method
+matching Float64(::Dual)`. Since `NonlinearSolvePolyAlgorithm` aborts on a
+thrown exception rather than treating it as "this member failed, try the
+next one", that crash pre-empts every algorithm after it in the chain,
+including the ones (`LevenbergMarquardt`) that could have solved the problem.
+
+To find a fix, several algorithms from `FastShortcutNonlinearPolyalg`'s and
+`CedarRobustNLSolve()`'s chains were benchmarked individually (each as the
+sole `nlsolve`, in its own fresh process to avoid cross-run contamination)
+against the VADistiller sp_bjt monostable multivibrator integration test --
+the case that first exposed all of this, whose BJT excess-phase internal
+nodes don't reach `abstol=1e-6` from a single `NewtonRaphson` step. Result:
+`NewtonRaphson` (plain and with `BackTracking` linesearch), `Broyden`,
+`Klement`, `TrustRegion` (`Simple` scheme), and `PseudoTransient` all leave
+the residual unchanged from the pre-Shampine DC-solve state (~9.6e-4,
+`InitialFailure`) when tried alone -- none of them make any real progress on
+this problem by themselves. `TrustRegion` with the `Bastin` scheme crashes
+the same way it does inside `CedarRobustNLSolve()`. Only
+`LevenbergMarquardt(autodiff=nothing)` alone converges, reaching the *exact*
+residual (3.692e-10) that the full default QuasiNewton-led chain does --
+i.e. LM's damping was doing the real work in that chain, not QuasiNewton.
+`NewtonRaphson` is kept as a cheap first attempt (it already suffices for
+c6288, converging before LM is ever tried), with LM as the fallback that
+actually handles awkward Jacobians like the BJT one.
 """
 function CedarShampineNLSolve()
     return NonlinearSolvePolyAlgorithm((
         NewtonRaphson(autodiff=nothing),
-        NewtonRaphson(autodiff=nothing, linesearch=BackTracking()),
+        LevenbergMarquardt(autodiff=nothing),
     ))
 end
 

--- a/src/mna/solve.jl
+++ b/src/mna/solve.jl
@@ -1711,15 +1711,18 @@ function SciMLBase.ODEProblem(circuit::MNACircuit, tspan::Tuple{<:Real,<:Real}; 
         # For SparseMatrixCSC, `eachindex(J, G)` is CartesianIndices over the
         # full n^2 index space (SparseMatrixCSC's IndexStyle is IndexCartesian),
         # not the nnz entries -- iterating and scalar-setindex!-ing that is
-        # O(n^2) and inserts explicit zeros outside the pattern. J and G share
-        # the same sparsity pattern (both derived from the unified jac_pattern
-        # in compile_structure), so walk the stored nzval arrays directly.
+        # O(n^2) and inserts explicit zeros outside the pattern.
+        #
+        # J is not guaranteed to share G's exact sparsity pattern: callers
+        # like ShampineCollocationInit's internal NonlinearSolve machinery may
+        # hand us a J whose structure was derived/simplified independently
+        # (observed nnz mismatch on c6288: J had 677700 stored entries vs.
+        # G's 2452148). copyto! between SparseMatrixCSCs reallocates dest's
+        # structure to match src (verified: handles differing nnz correctly),
+        # so use it instead of assuming identical nzval layouts.
         if J isa SparseArrays.SparseMatrixCSC
-            Jnz = SparseArrays.nonzeros(J)
-            Gnz = SparseArrays.nonzeros(G)
-            @inbounds for i in eachindex(Jnz, Gnz)
-                Jnz[i] = -Gnz[i]
-            end
+            copyto!(J, G)
+            SparseArrays.nonzeros(J) .*= -1
         else
             @inbounds for i in eachindex(J, G)
                 J[i] = -G[i]

--- a/src/mna/solve.jl
+++ b/src/mna/solve.jl
@@ -1703,13 +1703,27 @@ function SciMLBase.ODEProblem(circuit::MNACircuit, tspan::Tuple{<:Real,<:Real}; 
         return nothing
     end
 
-    # Jacobian using EvalWorkspace (zero-allocation for dense matrices)
+    # Jacobian using EvalWorkspace (zero-allocation)
     function jac!(J, u, p, t)
         fast_rebuild!(p, u, real_time(t))
         G = p.structure.G
-        # Avoid -G allocation: element-wise negate into J
-        @inbounds for i in eachindex(J, G)
-            J[i] = -G[i]
+        # Avoid -G allocation: element-wise negate into J.
+        # For SparseMatrixCSC, `eachindex(J, G)` is CartesianIndices over the
+        # full n^2 index space (SparseMatrixCSC's IndexStyle is IndexCartesian),
+        # not the nnz entries -- iterating and scalar-setindex!-ing that is
+        # O(n^2) and inserts explicit zeros outside the pattern. J and G share
+        # the same sparsity pattern (both derived from the unified jac_pattern
+        # in compile_structure), so walk the stored nzval arrays directly.
+        if J isa SparseArrays.SparseMatrixCSC
+            Jnz = SparseArrays.nonzeros(J)
+            Gnz = SparseArrays.nonzeros(G)
+            @inbounds for i in eachindex(Jnz, Gnz)
+                Jnz[i] = -Gnz[i]
+            end
+        else
+            @inbounds for i in eachindex(J, G)
+                J[i] = -G[i]
+            end
         end
         return nothing
     end


### PR DESCRIPTION
Ran c6288 end to end with `-O0` to check what blocks next after the LLVM
RAGreedy JIT hang. Fixed an unrelated pre-existing bug in runme.jl
(undefined `sp_psp103va_module`) that threw before anything ran. With that
fixed, the run reliably reaches setup completion (~75-90s, matching the
profiler) and then hangs again at runtime: gdb backtraces over 10+ minutes
show it parked in SparseArrays' scalar setindex!/_insert! path, growing a
212k-var/~2.45M-nnz matrix one entry at a time. This traces back to
CedarUICOp's warmup using ImplicitEuler(autodiff=AutoFiniteDiff()) with no
sparse coloring, which rediscovers the Jacobian sparsity via scalar writes
instead of reusing the existing pattern.