### PR TITLE
wpd: fix rc VACASK plateau by capping tran_maxord instead of maxstep

### DIFF
--- a/benchmarks/vacask/wpd/README.md
+++ b/benchmarks/vacask/wpd/README.md
@@ -61,14 +61,24 @@ a high-order solver takes large steps and emits few points, so interpolating *it
 output onto a fixed grid would penalise it for the interpolation rather than its real
 accuracy — interpolating the dense reference onto the run's points is fair.
 
-The golden is **pinned per case** in `config.json` (`golden: analytic|vacask|cadnip`),
-chosen by what actually converges — `run_wpd.jl` uses exactly that and errors if it
-fails (no silent substitution):
+The golden is **pinned per case** in `config.json`
+(`golden: analytic|vacask|cadnip|self`), chosen by what actually converges —
+`run_wpd.jl` uses exactly that and errors if it fails (no silent substitution):
 
 - `filter`, `rc`: **exact analytic** closed form (also avoids any "VACASK vs its own
   golden" ambiguity).
 - `graetz`: tight VACASK run (fine `maxstep`); it completes and is cross-checked.
-- `mul`: **Cadnip IDA** tight run — VACASK's multiplier golden aborts (see below).
+  (A tight Cadnip golden was tried too, for consistency with `mul`'s `self` mode
+  below, but Cadnip's own IDA fallback ladder doesn't converge on this circuit at
+  any tolerance from `1e-7` to `1e-11` - so `graetz` stays on the single VACASK
+  golden, which has always worked fine here.)
+- `mul`: **`self`** — Cadnip's curves are scored against a tight Cadnip IDA
+  golden, VACASK's curve against its own tight VACASK golden, *not* a shared
+  cross-simulator reference. See "Findings about VACASK" below for why: scoring
+  VACASK against Cadnip's golden here previously produced a misleading "VACASK
+  can't get more accurate than 1.3e-4" reading that turned out to be almost
+  entirely the two simulators' independently-converged answers disagreeing with
+  *each other*, not either one failing to converge.
 
 **VACASK runs at its best, not its default — and "best" is picked per case, not
 assumed.** VACASK defaults to trapezoidal (2nd order); the benchmark's global
@@ -305,15 +315,51 @@ the items below reflect the maintainer's diagnosis, not just ours.
   is to disable it — which is exactly what `mul`'s `vacask_override.extra_opts`
   already does (`nr_residualcheck=0 tran_lteratio=3.5 tran_itl=50`, carried
   over from the real throughput sim's own tuning). With that applied: no abort
-  anywhere in the sweep, and error genuinely tracks `reltol` — 1.3e-1 → 2.1e-2
-  → 1.2e-2 → 2.3e-3 → 1.8e-4 → 1.4e-4 → 1.3e-4 (`1e-3` through `1e-9`) —
-  before flattening at a hard ~1.3e-4 floor. Head-to-head with Cadnip IDA:
-  even VACASK's *best-ever* run (`reltol=1e-9`: 1.3e-4 error, 0.157s) is both
-  less accurate *and* slower than Cadnip IDA's *loosest, cheapest* setting
-  (`reltol=1e-3`: 1.1e-4 error, 0.126s) — Cadnip's floor point alone beats
-  VACASK's ceiling on both axes. Cadnip keeps converging past that, down to
-  ~3e-6 — an accuracy range VACASK simply cannot reach on this circuit at any
-  cost, a real engine-level gap rather than a benchmark-config artifact.
+  anywhere in the sweep.
+- **The "1.3e-4 floor" this produced against Cadnip's golden was never a
+  VACASK accuracy problem — it was scoring VACASK against the wrong
+  reference.** With the fix above applied, checked VACASK's *self*-consistency
+  at `reltol=1e-9` directly: comparing `tran_maxord=2/4/5`, `tran_lteratio`
+  tightened/loosened, and `abstol` down to `1e-18` against each other all
+  agree to ~1e-6–1e-7 - i.e. VACASK is converging cleanly, two full orders of
+  magnitude tighter than the ~1.3e-4 gap it showed against Cadnip's golden.
+  That gap is VACASK's and Cadnip's independently-converged answers
+  disagreeing with *each other* by a small, roughly tolerance-independent
+  amount — most likely the two simulators' separately-compiled diode OSDI/VA
+  models not being bit-identical (both use nominally the same
+  `is/rs/cjo/m/n`, but VACASK's bundled `spice/sn/diode.osdi` and Cadnip's
+  VADistillerModels SPICE diode are different compiled sources) — not a
+  tolerance-tuning gap on either side. `mul`'s `golden` is now `"self"`
+  (`config.json`): Cadnip's curves score against a tight Cadnip golden,
+  VACASK's curve against its own tight VACASK golden, and the two goldens'
+  mutual disagreement is reported separately as the `xcheck` line
+  (currently **1.03e-4**, matching the old "floor" almost exactly - strong
+  confirmation this is exactly what was happening). With `self` scoring,
+  VACASK's own curve now properly converges to **4.27e-6 at `reltol=1e-9`**,
+  the same order of magnitude as Cadnip IDA's own **2.49e-6** there - not the
+  "VACASK simply cannot reach this accuracy, a real engine-level gap" this
+  doc previously claimed. That specific claim is retracted. Diffing the two
+  diode `.va` sources to find the actual ~1e-4 discrepancy is a real, open
+  item, not yet investigated here.
+- **`filter` and `rc` have a genuine, lever-immune accuracy floor even
+  against the *exact analytic* golden — unlike `mul`'s, this one is real,
+  and none of the maintainer's suggestions move it.** Checked on `filter`
+  at `reltol=1e-9`: `tran_maxord` 2/3/4/5 all land at 2.0-2.1e-5 (identical
+  within noise); `abstol=1e-15`, `tran_lteratio=1`, and `nr_residualcheck=0`
+  each leave it at 2.07e-5 (unchanged to 3 significant figures); the
+  `relrefsol/relrefres/relreflte="pointlocal"` or `"local"` reference-value
+  modes he described make it *worse* (immediate "Timestep too small" abort
+  instead of an improvement — consistent with his own caveat that these
+  modes can't establish a reference near a zero initial condition, which is
+  exactly `filter`'s starting point). Same story on `rc` post-`maxord=4`
+  fix: orders 2/3/4 all land at 3.2-3.8e-5 at `reltol=1e-9`, `abstol=1e-18`
+  and `tran_lteratio` sweeps change nothing. Every documented tuning knob
+  was tried; none of them touch it. This is a real, open item — likely a
+  fixed absolute-error contribution from somewhere other than the exposed
+  tolerance options (candidates not yet checked: DC operating-point
+  accuracy, order-restart cost after the initial breakpoint, or the "Clock
+  resolution" the simulator reports in its stats) — not yet root-caused
+  here.
 - **`vntol` tied numerically to `reltol` is a simplification, flagged as such
   by the maintainer, but checked here not to bias these specific results.**
   Both VACASK sweeps (`run_vacask_once` in `wpd_common.jl`) pass `vntol=reltol`

--- a/benchmarks/vacask/wpd/README.md
+++ b/benchmarks/vacask/wpd/README.md
@@ -70,10 +70,14 @@ fails (no silent substitution):
 - `graetz`: tight VACASK run (fine `maxstep`); it completes and is cross-checked.
 - `mul`: **Cadnip IDA** tight run — VACASK's multiplier golden aborts (see below).
 
-**VACASK runs at its best, not its default:** VACASK defaults to trapezoidal (2nd
-order); the benchmark sets `tran_method="gear" tran_maxord=5` (variable-order
-Gear/BDF), configurable via `vacask_tran_method` / `vacask_tran_maxord` in
-`config.json`.
+**VACASK runs at its best, not its default — and "best" is picked per case, not
+assumed.** VACASK defaults to trapezoidal (2nd order); the benchmark's global
+default is `tran_method="gear" tran_maxord=5` (variable-order Gear/BDF),
+configurable via `vacask_tran_method` / `vacask_tran_maxord` in `config.json`.
+`rc` overrides this down to `tran_maxord=4` (see "Findings about VACASK" below
+— order 5 has a confirmed controller bug on that specific circuit, reported
+upstream as [issue #83](https://codeberg.org/arpadbuermen/VACASK/issues/83));
+`filter`/`graetz`/`mul` keep the order-5 default, which is fine or best there.
 
 ## Solver families per case
 
@@ -246,58 +250,83 @@ what's already folded into the table above:
 
 ## Findings about VACASK
 
-- **`mul` aborts at small steps.** VACASK hits "Timestep too small" on the voltage
-  multiplier below `reltol ≈ 1e-5` (its fine-`maxstep` golden aborts too), so `mul`
-  uses a Cadnip golden and VACASK contributes only its loose-tolerance points — a
-  direct illustration of Cadnip covering a range VACASK can't on a stiff diode network.
-- **Adaptive stepping plateaus.** With `reltol` alone (no forced fine `maxstep`),
-  VACASK's error stops improving past a point (e.g. the pulse-train `rc`): its LTE
-  controller settles at a step count well short of the accuracy its fine-`maxstep`
-  golden reaches. Cadnip's solvers keep converging.
-- **Giving VACASK a fair, reasonable shot on `rc`/`mul` confirms the plateau/abort
-  is a controller/tuning gap, not an engine ceiling — and a single global
-  `maxstep` can't be "loose except at the edges".** VACASK's `analysis tran`
-  only exposes one scalar `maxstep` applied to every step of the whole run —
-  there's no separate breakpoints-only directive in anything this repo's
-  `.sim` files use, so tightening it enough to catch a sharp source edge also
-  caps every other step in the run, uniformly. `rc` and `mul` each override
-  the plain reltol-only sweep with a fair configuration (`config.json`'s
-  `vacask_override`) instead of also plotting the raw default alongside it —
-  there's no value in showing a version already known to be unrepresentative,
-  so each case gets exactly one VACASK curve, built from that maxstep
-  tradeoff plus (for `mul`) the real throughput sim's own NR/LTE tuning:
-  - `rc`: `maxstep=1us` (the real throughput benchmark's `dtmax`) confirmed
-    fixing the 1.5-7% unbounded plateau (~1000x error drop, to ~2-7e-5) — the
-    unbounded run never resolves the 1us pulse edges without a step bound.
-    Swept looser from there: `5us` (5x looser) gives the *same* accuracy at
-    *5x lower* runtime (0.011s vs 0.051s) — real headroom, not a knife-edge
-    value, so `5us` is what's plotted as "fair". Error still doesn't improve
-    with tighter `reltol` at either step size, though: once `maxstep` binds,
-    `reltol` stops driving step size, and the residual ~2-7e-5 is the gear
-    method's local truncation error on the ramp itself, not a tolerance-driven
-    quantity — no single global `maxstep` gets both "resolves the edge" and
-    "`reltol` still matters everywhere else".
-  - `mul`: unlike `rc`, its source is a smooth sine, not a pulse — there's no
-    edge to resolve, so forcing `maxstep` here would just be a crutch masking
-    whether `reltol`-driven stepping actually works, not a fair test of the
-    engine. `mul`'s override leaves `maxstep` unbounded *and* keeps
-    `tran_method=gear`/`tran_maxord=5` (VACASK's best, same as every other
-    case, not the throughput sim's fixed-order `gear2` — that choice was for
-    raw speed, not accuracy) — it only adds the real throughput sim's NR/LTE
-    tuning (`nr_residualcheck=0`, `tran_lteratio=3.5`, `tran_itl=50` from
-    `mul/vacask/runme.sim`, never exercised by the plain `reltol` sweep).
-    That tuning alone is enough: no abort anywhere in the sweep, and error
-    genuinely tracks `reltol` — 1.3e-1 → 2.1e-2 → 1.2e-2 → 2.3e-3 → 1.8e-4 →
-    1.4e-4 → 1.3e-4 (`1e-3` through `1e-9`) — before flattening at a hard
-    ~1.3e-4 floor. So the abort really was the NR/LTE-tuning gap, not a
-    step-resolution problem. Head-to-head with Cadnip IDA: even VACASK's
-    *best-ever* run (`reltol=1e-9`: 1.3e-4 error, 0.157s) is both less
-    accurate *and* slower than Cadnip IDA's *loosest, cheapest* setting
-    (`reltol=1e-3`: 1.1e-4 error, 0.126s) — Cadnip's floor point alone beats
-    VACASK's ceiling on both axes. Cadnip keeps converging past that, down to
-    ~3e-6 — an accuracy range VACASK simply cannot reach on this circuit at
-    any cost, a real engine-level gap rather than a benchmark-config
-    artifact.
+Reported upstream as [VACASK issue #83](https://codeberg.org/arpadbuermen/VACASK/issues/83);
+the items below reflect the maintainer's diagnosis, not just ours.
+
+- **`rc`'s plateau is a `tran_maxord=5` controller bug, not a breakpoint/edge
+  problem.** Earlier revisions of this doc guessed the pulse-train `rc` case's
+  ~1.5-7% error plateau (flat regardless of `reltol`) came from VACASK stepping
+  over the 1us pulse edges. That guess was wrong and has been retracted: dumping
+  `tran1.raw` shows 5-6 accepted points inside every rise/fall window at every
+  `reltol` tested — breakpoints are handled correctly. Isolated the real cause
+  by sweeping only `tran_maxord` at fixed `reltol=1e-6` (netlist in the issue):
+  orders 1-4 converge normally (points/error: 4449/6.5e-4, 891/1.0e-4,
+  551/1.2e-4, 550/6.3e-5) but order 5 alone jumps three orders of magnitude
+  worse (448/6.9e-2) while taking *fewer* steps — the step-size/LTE controller
+  is accepting steps that are far too large specifically at order 5 on this
+  circuit. It's circuit-specific, not a blanket "order 5 is broken": the same
+  sweep on `filter` (smooth sine, no discontinuities) has order 5 as the
+  *best* point (562 points/1.4e-4, beating every lower order), and on `graetz`
+  (diode, nonlinear) order 5 tracks a tight order-2 reference to ~2e-5 with no
+  anomaly. `config.json`'s `rc.vacask_override` now caps `tran_maxord` at 4
+  instead of clamping `maxstep` (see below) — the maintainer is looking into
+  the order-5 controller itself.
+- **The old `maxstep=5us` workaround is gone — capping the order was the real
+  fix.** The previous override forced `maxstep=5e-6` (a crutch: it bounds
+  *every* step in the run, not just the ones near the bug, and floors accuracy
+  at the gear method's own LTE on the ramp instead of letting `reltol` drive
+  it). Capping `tran_maxord` at 4 instead removes the need for any `maxstep`
+  bound at all — VACASK now gets genuine unbounded, `reltol`-driven adaptive
+  stepping on `rc`: 1.5e-4 error at `reltol=1e-3` down to ~3.8e-5 at
+  `reltol=1e-9`, monotonically improving, which the order-5 config never did
+  at any `maxstep`.
+- **On method order in general: VACASK's own design historically stays at
+  order ≤ 2 for A-stability, so "higher order = more accurate" (this
+  benchmark's original assumption for picking `tran_maxord=5` as "VACASK's
+  best") doesn't hold unconditionally.** Per the maintainer: methods of order
+  ≤ 2 (trapezoidal, `gear2`) are A-stable and never blow up for a stable
+  circuit regardless of step size; stability regions shrink as order grows, so
+  a higher-order method can need *smaller* steps on a stiff circuit to stay
+  stable, the opposite of the "bigger steps, same accuracy" benefit
+  higher order usually buys. That framing fits `graetz`/`filter` (order 5
+  is fine or best there) better than a strict "5 is broken" reading, but it
+  does mean this benchmark should keep picking `tran_maxord` per case by
+  what actually converges, the same empirical policy already used for
+  picking Cadnip's solver family per case, rather than assuming one order is
+  "VACASK's best" everywhere.
+- **`mul` aborts at small steps — confirmed to be VACASK's `nr_residualcheck`,
+  not a step-resolution problem.** `mul`'s source is a smooth sine, so unlike
+  `rc` there's no edge to resolve; VACASK hits "Timestep too small" below
+  `reltol ≈ 1e-5` regardless of `tran_maxord` (checked 1 through 5, all abort
+  identically after 2 accepted / 21 rejected points). Per the maintainer, this
+  is a known, acknowledged sensitivity in the residual check: it "cannot
+  establish a reference value for equations that have only one residual
+  contribution," and the recommended remedy for any circuit that triggers it
+  is to disable it — which is exactly what `mul`'s `vacask_override.extra_opts`
+  already does (`nr_residualcheck=0 tran_lteratio=3.5 tran_itl=50`, carried
+  over from the real throughput sim's own tuning). With that applied: no abort
+  anywhere in the sweep, and error genuinely tracks `reltol` — 1.3e-1 → 2.1e-2
+  → 1.2e-2 → 2.3e-3 → 1.8e-4 → 1.4e-4 → 1.3e-4 (`1e-3` through `1e-9`) —
+  before flattening at a hard ~1.3e-4 floor. Head-to-head with Cadnip IDA:
+  even VACASK's *best-ever* run (`reltol=1e-9`: 1.3e-4 error, 0.157s) is both
+  less accurate *and* slower than Cadnip IDA's *loosest, cheapest* setting
+  (`reltol=1e-3`: 1.1e-4 error, 0.126s) — Cadnip's floor point alone beats
+  VACASK's ceiling on both axes. Cadnip keeps converging past that, down to
+  ~3e-6 — an accuracy range VACASK simply cannot reach on this circuit at any
+  cost, a real engine-level gap rather than a benchmark-config artifact.
+- **`vntol` tied numerically to `reltol` is a simplification, flagged as such
+  by the maintainer, but checked here not to bias these specific results.**
+  Both VACASK sweeps (`run_vacask_once` in `wpd_common.jl`) pass `vntol=reltol`
+  — conflating an absolute voltage tolerance with a dimensionless relative
+  one, which the maintainer correctly points out "lacks universal
+  applicability across circuits." Checked directly: re-running `rc` at
+  `tran_maxord=4` with `vntol` fixed at `1e-6` (decoupled from `reltol`)
+  instead of tied to it gives the same error to 3 significant figures at
+  every `reltol` tested (e.g. `reltol=1e-9`: 3.833e-5 tied vs. 3.833e-5
+  fixed) — because every case's node voltages sit in a similar O(0.1-50V)
+  band where the two happen to coincide numerically. Left as-is since it
+  doesn't change the numbers, but it's not a generally sound pattern to reuse
+  for a circuit with a very different voltage scale.
 
 ## History
 

--- a/benchmarks/vacask/wpd/README.md
+++ b/benchmarks/vacask/wpd/README.md
@@ -348,39 +348,60 @@ the items below reflect the maintainer's diagnosis, not just ours.
   doc previously claimed. That specific claim is retracted. Diffing the two
   diode `.va` sources to find the actual ~1e-4 discrepancy is a real, open
   item, not yet investigated here.
-- **`filter` and `rc` have a genuine, lever-immune accuracy floor even
-  against the *exact analytic* golden — unlike `mul`'s, this one is real,
-  and none of the maintainer's suggestions move it.** Checked on `filter`
-  at `reltol=1e-9`: `tran_maxord` 2/3/4/5 all land at 2.0-2.1e-5 (identical
-  within noise); `abstol=1e-15`, `tran_lteratio=1`, and `nr_residualcheck=0`
-  each leave it at 2.07e-5 (unchanged to 3 significant figures); the
-  `relrefsol/relrefres/relreflte="pointlocal"` or `"local"` reference-value
-  modes he described make it *worse* (immediate "Timestep too small" abort
-  instead of an improvement — consistent with his own caveat that these
-  modes can't establish a reference near a zero initial condition, which is
-  exactly `filter`'s starting point). Same story on `rc` post-`maxord=4`
-  fix: orders 2/3/4 all land at 3.2-3.8e-5 at `reltol=1e-9`, `abstol=1e-18`
-  and `tran_lteratio` sweeps change nothing. Every documented tuning knob
-  was tried; none of them touch it.
-  **A gmin/leakage-conductance origin is ruled out, not just untested:**
-  `gmin` isn't exposed as a global option in this VACASK build (only
-  `gshunt` and `homotopy_*gmin*`, which are DC-operating-point homotopy
-  convergence aids, not something applied through transient - confirmed by
-  binary symbol names like `OpNRSolver::loadShunts`); explicitly forcing
-  `gshunt=0`/`1e-15` and `homotopy_startgmin=0 homotopy_maxgmin=0` on `rc`
-  at `reltol=1e-9` left the error completely unchanged (3.8330e-5 in every
-  variant, to 5 significant figures). More conclusively: a fixed leakage
-  conductance anywhere would make the relative error scale with circuit
-  impedance (a bigger `R` means the leak carries proportionally more
-  current), so `rc`'s `R`/`C` were rescaled 1Ω/1F down to 1MΩ/1nF (same
-  `τ=RC=1ms`, same pulse) — error stayed at 3.83-3.84e-5 across all 6
-  decades of impedance. No leakage-conductance mechanism, gmin or
-  otherwise, produces that. This is a real, open item — likely a fixed
-  absolute-error contribution from somewhere other than the exposed
-  tolerance options (candidates not yet checked: DC operating-point
-  accuracy, order-restart cost after the initial breakpoint, or the "Clock
-  resolution" the simulator reports in its stats) — not yet root-caused
-  here.
+- **`filter`'s "lever-immune" floor turned out to be OUR benchmark's own bug:
+  the initial-timestep hint was far too coarse.** Checked `tran_maxord`
+  2/3/4/5 (identical 2.0-2.1e-5 at `reltol=1e-9`), `abstol=1e-15`,
+  `tran_lteratio`, and `nr_residualcheck=0` on `filter` - none moved it, and
+  the `relrefsol/relrefres/relreflte="pointlocal"/"local"` modes he
+  described made it *worse* (immediate "Timestep too small" abort,
+  consistent with his own caveat about establishing a reference near a
+  zero initial condition, exactly `filter`'s starting point). What actually
+  mattered, per his separate comment that "initial step selection lacks
+  sophistication - designers should specify sensible values per circuit":
+  the `analysis tran ... step=` argument. `wpd_common`/`run_wpd.jl` were
+  passing `tspan/n_grid` there (`100/2000 = 0.05` for `filter`) - reasonable
+  as an output-density hint, but that value **also sets VACASK's very first
+  internal timestep**, and forcing a first step of `0.05` on a circuit whose
+  natural period is `2π≈6.28` (and whose LC ladder is only lightly damped
+  by `R4=1`) injects a small error that never damps out over the rest of
+  the run, capping accuracy regardless of `reltol`. Confirmed directly:
+  forcing `step` down through `1e-6, 1e-9, 1e-12` at `reltol=1e-9` all land
+  within 0.01% of each other (~4.27e-7) - a **~50x** improvement over the
+  `0.05` floor - while total point counts barely change (1720 vs 1725),
+  showing it's specifically the *first* step's error that's fixed, not
+  overall resolution. `rc`/`graetz`/`mul` were essentially unaffected by the
+  same change (their `tspan/n_grid` was already fine enough relative to
+  their own dynamics) - confirmed by re-running all four cases end-to-end.
+  `run_vacask_once` now always requests `step=1e-12`, tspan-independent;
+  `filter`'s VACASK curve genuinely converges now (`4.11e-7` at
+  `reltol=1e-9`, no floor), and nothing else changed. This was never a
+  VACASK bug - it's exactly what the maintainer's own comment predicted:
+  a naive fixed initial-step choice in our own harness.
+- **`rc`'s floor is real, open, and NOT the same mechanism.** Unlike
+  `filter`, forcing `rc`'s initial `step` down to `1e-12` (from the same
+  `tspan/n_grid` origin) made *no* difference at all (3.8330e-5 either way,
+  full reltol sweep re-checked). `rc`'s floor also survives `tran_maxord`
+  2/3/4 (3.2-3.8e-5 at `reltol=1e-9`), `abstol` down to `1e-18`, and
+  `tran_lteratio` sweeps - every documented tuning knob was tried; none of
+  them touch it. **A gmin/leakage-conductance origin is ruled out, not just
+  untested:** `gmin` isn't exposed as a global option in this VACASK build
+  (only `gshunt` and `homotopy_*gmin*`, which are DC-operating-point
+  homotopy convergence aids, not something applied through transient -
+  confirmed by binary symbol names like `OpNRSolver::loadShunts`);
+  explicitly forcing `gshunt=0`/`1e-15` and
+  `homotopy_startgmin=0 homotopy_maxgmin=0` left the error completely
+  unchanged (3.8330e-5 in every variant, to 5 significant figures). More
+  conclusively: a fixed leakage conductance anywhere would make the
+  relative error scale with circuit impedance (a bigger `R` means the leak
+  carries proportionally more current), so `rc`'s `R`/`C` were rescaled
+  1Ω/1F down to 1MΩ/1nF (same `τ=RC=1ms`, same pulse) — error stayed at
+  3.83-3.84e-5 across all 6 decades of impedance. No leakage-conductance
+  mechanism, gmin or otherwise, produces that, and it isn't a startup-step
+  artifact either (see above). Current best guess: `rc`'s pulse train hits
+  a breakpoint (forced order-1 restart) roughly every 1ms, ~20 times over
+  the run, so unlike `filter`'s one-time startup cost this could be a small
+  error reintroduced at *every* breakpoint rather than damping away between
+  them - not yet confirmed, still an open item.
 - **`vntol` tied numerically to `reltol` is a simplification, flagged as such
   by the maintainer, but checked here not to bias these specific results.**
   Both VACASK sweeps (`run_vacask_once` in `wpd_common.jl`) pass `vntol=reltol`

--- a/benchmarks/vacask/wpd/README.md
+++ b/benchmarks/vacask/wpd/README.md
@@ -89,6 +89,13 @@ configurable via `vacask_tran_method` / `vacask_tran_maxord` in `config.json`.
 upstream as [issue #83](https://codeberg.org/arpadbuermen/VACASK/issues/83));
 `filter`/`graetz`/`mul` keep the order-5 default, which is fine or best there.
 
+Every plot also carries a second, fixed **`VACASK gear2`** series (2nd-order
+Gear/BDF) alongside the case's own best-order curve, regardless of what that
+case's default/override picks — per the maintainer, circuit simulators
+historically stick to order ≤ 2 for A-stability, so it's worth seeing that
+tradeoff directly rather than only ever plotting whichever order a case
+happens to use. Both series are scored against the same golden.
+
 ## Solver families per case
 
 Not a blanket linear/nonlinear split — viability was checked empirically per case
@@ -354,8 +361,22 @@ the items below reflect the maintainer's diagnosis, not just ours.
   exactly `filter`'s starting point). Same story on `rc` post-`maxord=4`
   fix: orders 2/3/4 all land at 3.2-3.8e-5 at `reltol=1e-9`, `abstol=1e-18`
   and `tran_lteratio` sweeps change nothing. Every documented tuning knob
-  was tried; none of them touch it. This is a real, open item — likely a
-  fixed absolute-error contribution from somewhere other than the exposed
+  was tried; none of them touch it.
+  **A gmin/leakage-conductance origin is ruled out, not just untested:**
+  `gmin` isn't exposed as a global option in this VACASK build (only
+  `gshunt` and `homotopy_*gmin*`, which are DC-operating-point homotopy
+  convergence aids, not something applied through transient - confirmed by
+  binary symbol names like `OpNRSolver::loadShunts`); explicitly forcing
+  `gshunt=0`/`1e-15` and `homotopy_startgmin=0 homotopy_maxgmin=0` on `rc`
+  at `reltol=1e-9` left the error completely unchanged (3.8330e-5 in every
+  variant, to 5 significant figures). More conclusively: a fixed leakage
+  conductance anywhere would make the relative error scale with circuit
+  impedance (a bigger `R` means the leak carries proportionally more
+  current), so `rc`'s `R`/`C` were rescaled 1Ω/1F down to 1MΩ/1nF (same
+  `τ=RC=1ms`, same pulse) — error stayed at 3.83-3.84e-5 across all 6
+  decades of impedance. No leakage-conductance mechanism, gmin or
+  otherwise, produces that. This is a real, open item — likely a fixed
+  absolute-error contribution from somewhere other than the exposed
   tolerance options (candidates not yet checked: DC operating-point
   accuracy, order-restart cost after the initial breakpoint, or the "Clock
   resolution" the simulator reports in its stats) — not yet root-caused

--- a/benchmarks/vacask/wpd/config.json
+++ b/benchmarks/vacask/wpd/config.json
@@ -15,7 +15,7 @@
 
   "n_grid": 2000,
 
-  "_golden_comment": "golden pins the reference per case (analytic|vacask|cadnip), chosen by what actually converges: filter/rc have exact closed forms; graetz's tight VACASK run completes; mul's VACASK golden aborts (min-timestep) so it uses a tight Cadnip IDA reference. run_wpd.jl errors if the pinned golden fails - it never silently substitutes.",
+  "_golden_comment": "golden pins the reference per case (analytic|vacask|cadnip|self), chosen by what actually converges: filter/rc have exact closed forms, so both simulators are honestly comparable against ground truth. graetz/mul have no closed form, and using one simulator's tight run as a shared cross-simulator golden for the other conflates real solver-accuracy error with the two simulators' own small mutual disagreement (see issue #83 investigation in README - VACASK converges to well within 1e-6 of ITSELF on `mul` even where it looked ~1.3e-4 off from a Cadnip golden, meaning that gap was never a VACASK tolerance problem in the first place). `self` has each simulator scored against its OWN tight reference instead, with the two references' mutual disagreement reported separately as an explicit, open, not-yet-explained item (most likely a difference between the two simulators' independently-compiled diode OSDI/VA models) rather than folded into either curve's error. run_wpd.jl errors if a pinned/needed golden fails - it never silently substitutes.",
 
   "cases": {
     "filter": {
@@ -36,14 +36,16 @@
       "title": "Graetz bridge full-wave rectifier (nonlinear diode)",
       "tspan": [0.0, 0.1],
       "output": ["outp", "outn"],
-      "golden": "vacask"
+      "golden": "vacask",
+      "_golden_comment_graetz": "Considered 'self' for consistency with mul, but graetz's own Cadnip-tight golden (cadnip_golden's IDA ladder, 1e-11 down to 1e-7) does not converge on this circuit at all - IDA repeatedly hits 'corrector convergence failed... |h|=hmin' at every tolerance tried, unlike mul where the same ladder works fine. Kept as 'vacask': unlike mul there's no demonstrated Cadnip-vs-VACASK cross-simulator-golden problem here to fix (the historical cross-check has been small), so there's no reason to force a golden that doesn't actually converge."
     },
     "mul": {
       "title": "Diode voltage multiplier (nonlinear, stiff)",
       "tspan": [0.0, 5e-4],
       "output": ["20"],
-      "golden": "cadnip",
-      "_vacask_override_comment": "VACASK's reltol-only sweep aborts (min-timestep) below reltol=1e-5. mul's source is a smooth sine (vs type=sine), not a pulse - there's no edge to resolve, so forcing a fixed maxstep the way rc needs it would just be a crutch masking whether reltol-driven stepping actually works, not a fair test of the engine. The override leaves maxstep unbounded (reltol/vntol alone drive step size) and method/maxord at the benchmark's standard tran_method=gear/tran_maxord=5 (VACASK's best, same as every other case - NOT the throughput sim's fixed-order gear2, which was chosen there for raw speed, not accuracy). It only adds the real throughput sim's NR/LTE tuning (nr_residualcheck, tran_lteratio, tran_itl from mul/vacask/runme.sim, never exercised by the plain reltol sweep) - legitimate robustness tuning, not artificial fine-stepping or a lower-order handicap.",
+      "golden": "self",
+      "_golden_self_comment": "Was 'cadnip' (VACASK scored against a foreign Cadnip golden, which is what produced the misleading '~1.3e-4 floor VACASK can't reach' framing - VACASK actually converges to within ~1e-6 of ITSELF at reltol=1e-9 across tran_maxord/tran_lteratio/abstol variations, so that gap was never a VACASK accuracy problem). 'self' now scores each simulator against its own tight run; the two goldens' mutual disagreement is reported as an explicit open item instead.",
+      "_vacask_override_comment": "VACASK's reltol-only sweep aborts (min-timestep) below reltol=1e-5. mul's source is a smooth sine (vs type=sine), not a pulse - there's no edge to resolve, so forcing a fixed maxstep the way rc needs it would just be a crutch masking whether reltol-driven stepping actually works, not a fair test of the engine. The override leaves maxstep unbounded (reltol/vntol alone drive step size) and method/maxord at the benchmark's standard tran_method=gear/tran_maxord=5 (VACASK's best, same as every other case - NOT the throughput sim's fixed-order gear2, which was chosen there for raw speed, not accuracy). It only adds the real throughput sim's NR/LTE tuning (nr_residualcheck, tran_lteratio, tran_itl from mul/vacask/runme.sim, never exercised by the plain reltol sweep) - legitimate robustness tuning, not artificial fine-stepping or a lower-order handicap. Now also applied to mul's own VACASK golden (run_vacask_sweep passes it to the tight run too), since without it the golden aborts exactly like the sweep did.",
       "vacask_override": {"extra_opts": "nr_residualcheck=0 tran_lteratio=3.5 tran_itl=50"}
     }
   }

--- a/benchmarks/vacask/wpd/config.json
+++ b/benchmarks/vacask/wpd/config.json
@@ -29,8 +29,8 @@
       "tspan": [0.0, 0.02],
       "output": ["2"],
       "golden": "analytic",
-      "_vacask_override_comment": "VACASK's reltol-only sweep plateaus at ~1-7% error regardless of tolerance (never resolving the 1us pulse edges - a single global maxstep can't be edge-only, so reltol stops driving step size once maxstep binds everywhere). Tested maxstep=1us (real throughput benchmark's dtmax): ~1000x error drop. Tested 5x looser (5us): same accuracy, 5x cheaper - real headroom, not a knife-edge value, so that's the override used: VACASK's best reasonable shot at this circuit, not its worst-case default nor an artificially golden-tight one.",
-      "vacask_override": {"maxstep": 5e-6}
+      "_vacask_override_comment": "VACASK's reltol-only sweep at tran_maxord=5 plateaus at ~1.5-7% error regardless of tolerance - NOT a breakpoint/edge-skipping problem (verified: 5-6 points land inside every 1us edge at every reltol). Root cause, isolated by sweeping only tran_maxord at fixed reltol=1e-6: orders 1-4 converge normally (npoints/error: 4449/6.5e-4, 891/1.0e-4, 551/1.2e-4, 550/6.3e-5) but order 5 alone jumps 3 orders of magnitude worse (448/6.9e-2) while taking FEWER steps - a step-size/LTE-controller defect specific to order 5 on this circuit (filter/graetz do not show it at order 5 - see README). Reported upstream: https://codeberg.org/arpadbuermen/VACASK/issues/83. Fix: cap tran_maxord at 4 instead of the benchmark-wide default of 5 - this restores genuine reltol-driven adaptive convergence (1.5e-4 at reltol=1e-3 down to ~3.8e-5 at reltol=1e-9) with NO maxstep clamp needed at all, unlike the earlier maxstep=5e-6 workaround which capped every step in the run just to avoid the order-5 bug.",
+      "vacask_override": {"maxord": 4}
     },
     "graetz": {
       "title": "Graetz bridge full-wave rectifier (nonlinear diode)",

--- a/benchmarks/vacask/wpd/run_wpd.jl
+++ b/benchmarks/vacask/wpd/run_wpd.jl
@@ -379,7 +379,16 @@ function cadnip_golden(case, spec)
     error("case $case: Cadnip golden failed to converge at every tolerance tried")
 end
 
-function run_vacask_sweep(case, spec, want_golden)
+"""
+`tag`/`maxord_force` add a second, independent VACASK series without
+touching the primary one: pass `tag="_gear2", maxord_force=2` to sweep
+gear2 (2nd-order Gear/BDF, A-stable) instead of whatever order the case's
+`vacask_override`/`vacask_tran_maxord` picks. Output files are namespaced
+by `tag` so the two series never collide. `want_golden` is only ever true
+for the primary (tag="") call - the golden is independent of which
+comparison curves get plotted against it.
+"""
+function run_vacask_sweep(case, spec, want_golden; tag::String="", maxord_force=nothing)
     t0, t1 = Float64(spec["tspan"][1]), Float64(spec["tspan"][2])
     out_nodes = String.(spec["output"])
     reltols = Float64.(CFG["reltols"])
@@ -397,11 +406,15 @@ function run_vacask_sweep(case, spec, want_golden)
     # the same method/maxord/extra_opts (but keeps its own fine maxstep, not
     # `oms`) - a circuit that needs e.g. nr_residualcheck=0 to avoid aborting
     # in the reltol sweep needs it just as much for its own golden (mul's
-    # golden aborted before this was applied here).
+    # golden aborted before this was applied here). `maxord_force` (the
+    # gear2 comparison series) overrides the order only - any maxstep/
+    # extra_opts a case needs to avoid aborting still apply regardless of
+    # order (confirmed on `mul`: the residualcheck abort happens at every
+    # order 1-5 alike).
     ov = get(spec, "vacask_override", Dict{String,Any}())
     oms = haskey(ov, "maxstep") ? Float64(ov["maxstep"]) : t1
     omethod = haskey(ov, "method") ? String(ov["method"]) : nothing
-    omaxord = haskey(ov, "maxord") ? Int(ov["maxord"]) : nothing
+    omaxord = maxord_force !== nothing ? maxord_force : (haskey(ov, "maxord") ? Int(ov["maxord"]) : nothing)
     oextra = String(get(ov, "extra_opts", ""))
 
     if want_golden
@@ -413,14 +426,14 @@ function run_vacask_sweep(case, spec, want_golden)
         @printf("%.3fs %d pts\n", rt, tp); flush(stdout)
     end
 
-    summary = open(joinpath(OUT, "vacask_$(case).csv"), "w")
+    summary = open(joinpath(OUT, "vacask$(tag)_$(case).csv"), "w")
     println(summary, "reltol,time_s,timepoints")
     for r in reltols
-        @printf("  vacask reltol=%.0e ... ", r); flush(stdout)
+        @printf("  vacask%s reltol=%.0e ... ", tag, r); flush(stdout)
         try
             ti, sig, tp, rt = run_vacask_once(case, r, r * ascale, (t0, t1), out_nodes;
                                                maxstep=oms, method=omethod, maxord=omaxord, extra_opts=oextra)
-            write_wave(joinpath(OUT, "vacask_$(case)_$(reltol_tag(r)).csv"), ti, sig)
+            write_wave(joinpath(OUT, "vacask$(tag)_$(case)_$(reltol_tag(r)).csv"), ti, sig)
             println(summary, "$r,$rt,$tp")
             @printf("%.3fs %d pts\n", rt, tp)
         catch e
@@ -482,17 +495,24 @@ function analyze(case, spec)
         push!(table, ("Cadnip $solver", r, err, something(t, NaN)))
     end
 
-    vpath = joinpath(OUT, "vacask_$(case).csv")
-    if isfile(vpath)
+    # Two VACASK series: the primary (case's own picked order/overrides) and
+    # a fixed gear2 comparison (2nd-order Gear/BDF, A-stable - the order the
+    # maintainer says circuit simulators historically stick to). Both are
+    # scored against the SAME golden (vgt/vgv) - the question is how an
+    # A-stable low-order method scales against whatever order this case
+    # actually uses, not against a different truth.
+    for (label, tag) in (("VACASK", ""), ("VACASK gear2", "_gear2"))
+        vpath = joinpath(OUT, "vacask$(tag)_$(case).csv")
+        isfile(vpath) || continue
         for row in first(read_table(vpath))
             r = parse(Float64, row["reltol"]); t = tryparse(Float64, get(row, "time_s", "NaN"))
-            wp = joinpath(OUT, "vacask_$(case)_$(reltol_tag(r)).csv")
+            wp = joinpath(OUT, "vacask$(tag)_$(case)_$(reltol_tag(r)).csv")
             isfile(wp) || continue
             tw, vw = read_wave(wp)
             err = run_error(tw, vw, vgt, vgv)
             isfinite(err) && t !== nothing && isfinite(t) &&
-                push!(get!(curves, "VACASK", Tuple{Float64,Float64}[]), (err, t))
-            push!(table, ("VACASK", r, err, something(t, NaN)))
+                push!(get!(curves, label, Tuple{Float64,Float64}[]), (err, t))
+            push!(table, (label, r, err, something(t, NaN)))
         end
     end
 
@@ -527,7 +547,8 @@ free slot rather than erroring, so a new solver added to `SOLVERS` degrades
 gracefully instead of blowing up plotting.
 """
 const SERIES_ORDER = ["Cadnip IDA", "Cadnip FBDF", "Cadnip Rodas5P", "Cadnip Rodas6P",
-                       "Cadnip Kvaerno5", "Cadnip RadauIIA5", "Cadnip KenCarp4", "VACASK"]
+                       "Cadnip Kvaerno5", "Cadnip RadauIIA5", "Cadnip KenCarp4", "VACASK",
+                       "VACASK gear2"]
 series_style_index(label) = something(findfirst(==(label), SERIES_ORDER), length(SERIES_ORDER) + 1)
 
 """
@@ -538,7 +559,7 @@ reason: named UnicodePlots markers/canvases (Braille dots, box-drawing borders)
 have known cross-font/cross-renderer width bugs that misalign the plot; plain
 ASCII (0-127) is guaranteed single-column in any monospace font.
 """
-const ASCII_MARKERS = ["o", "x", "+", "*", "#", "@", "%", "&"]
+const ASCII_MARKERS = ["o", "x", "+", "*", "#", "@", "%", "&", "="]
 
 function ascii_plot(title, curves)
     labels = sort(collect(keys(curves)))
@@ -596,8 +617,8 @@ function save_plot(case, title, curves)
     plt = Plots.plot(; xscale=:log10, yscale=:log10, xlabel="relative L2 error",
                       ylabel="runtime (s)", title="Work-precision: $title",
                       legend=:outertopright, size=(900, 600), dpi=150)
-    markers = (:circle, :xcross, :rect, :diamond, :utriangle, :star5, :pentagon, :hexagon)
-    colors = (:dodgerblue, :orangered, :seagreen, :purple, :goldenrod, :teal, :magenta, :black)
+    markers = (:circle, :xcross, :rect, :diamond, :utriangle, :star5, :pentagon, :hexagon, :cross)
+    colors = (:dodgerblue, :orangered, :seagreen, :purple, :goldenrod, :teal, :magenta, :black, :brown)
     for label in labels
         pts = sort(curves[label])
         x = Float64[p[1] for p in pts]; y = Float64[p[2] for p in pts]
@@ -676,9 +697,11 @@ function main()
 
         # VACASK sweep always runs where it can; also produce the VACASK golden
         # when this case is pinned to it OR uses "self" (which needs both
-        # goldens, not just one).
+        # goldens, not just one). The gear2 comparison series never builds a
+        # golden of its own - it's scored against the same one as the primary.
         if VACASK_BIN !== nothing
             run_vacask_sweep(case, spec, golden == "vacask" || golden == "self")
+            run_vacask_sweep(case, spec, false; tag="_gear2", maxord_force=2)
         elseif golden == "vacask"
             error("case $case pinned to VACASK golden but VACASK binary not found")
         end

--- a/benchmarks/vacask/wpd/run_wpd.jl
+++ b/benchmarks/vacask/wpd/run_wpd.jl
@@ -586,7 +586,8 @@ function report(results)
     println(io, "# Work-Precision Diagram Results\n")
     println(io, "Each solver runs *adaptively* across a tolerance sweep (no forced timestep).")
     println(io, "Error = relative L2 of the output node at each run's own timepoints vs the")
-    println(io, "golden reference. VACASK uses high-order Gear/BDF (`tran_maxord=5`).\n")
+    println(io, "golden reference. VACASK uses Gear/BDF, order picked per case (see config.json)")
+    println(io, "since a fixed order isn't uniformly best across circuits (issue #83).\n")
     for (case, gsrc, curves, table, xcheck) in results
         spec = CFG["cases"][case]
         println(io, "## $(spec["title"])\n")

--- a/benchmarks/vacask/wpd/run_wpd.jl
+++ b/benchmarks/vacask/wpd/run_wpd.jl
@@ -264,7 +264,17 @@ end
 "Run VACASK once; return (t, signal, timepoints, runtime_s) or throw on failure."
 function run_vacask_once(case, reltol, vntol, tspan, out_nodes; maxstep=tspan[2],
                           method=nothing, maxord=nothing, extra_opts="")
-    step = (tspan[2] - tspan[1]) / Int(CFG["n_grid"])
+    # `analysis tran ... step=` sets VACASK's INITIAL timestep, not just an
+    # output stride - confirmed empirically (see README "Findings about
+    # VACASK"): using tspan/n_grid here (previously) silently cost `filter`
+    # ~50x accuracy at tight reltol, because a too-coarse first step's error
+    # never damps out on that lightly-damped LC circuit, while `rc` was
+    # completely unaffected either way (its floor has a different cause).
+    # A tiny, tspan-independent initial step costs at most one or two
+    # negligibly cheap extra steps before the adaptive controller takes
+    # over - confirmed safe and fast on all 4 cases - so there's no
+    # accuracy/cost tradeoff to make: always start as fine as possible.
+    step = 1e-12
     m = method === nothing ? String(get(CFG, "vacask_tran_method", "gear")) : method
     mo = maxord === nothing ? Int(get(CFG, "vacask_tran_maxord", 5)) : maxord
     sim = sim_body(case) * """

--- a/benchmarks/vacask/wpd/run_wpd.jl
+++ b/benchmarks/vacask/wpd/run_wpd.jl
@@ -387,26 +387,31 @@ function run_vacask_sweep(case, spec, want_golden)
     ref_reltol = Float64(CFG["ref_reltol"]); ref_abstol = Float64(CFG["ref_abstol"])
     ref_factor = Float64(get(CFG, "ref_maxstep_factor", 50))
 
-    if want_golden
-        ms = (t1 - t0) / (Int(CFG["n_grid"]) * ref_factor)
-        @printf("  vacask golden reltol=%.0e maxstep=%.1e ... ", ref_reltol, ms); flush(stdout)
-        ti, sig, tp, rt = run_vacask_once(case, ref_reltol, ref_abstol, (t0, t1), out_nodes; maxstep=ms)
-        write_wave(joinpath(OUT, "ref_$(case).csv"), ti, sig)
-        @printf("%.3fs %d pts\n", rt, tp); flush(stdout)
-    end
-
     # A case can override VACASK's default (unbounded maxstep, benchmark's
     # standard tran_method=gear/tran_maxord=5, no extra options) via
     # config.json's `vacask_override` - see per-case `_vacask_override_comment`
     # for why. This is the ONE VACASK run plotted for the case, not an extra
     # series alongside the raw default - a case either needs a fair override
     # or it doesn't, there's no value in also showing the version we already
-    # know is unrepresentative.
+    # know is unrepresentative. The golden (tight-maxstep) run below applies
+    # the same method/maxord/extra_opts (but keeps its own fine maxstep, not
+    # `oms`) - a circuit that needs e.g. nr_residualcheck=0 to avoid aborting
+    # in the reltol sweep needs it just as much for its own golden (mul's
+    # golden aborted before this was applied here).
     ov = get(spec, "vacask_override", Dict{String,Any}())
     oms = haskey(ov, "maxstep") ? Float64(ov["maxstep"]) : t1
     omethod = haskey(ov, "method") ? String(ov["method"]) : nothing
     omaxord = haskey(ov, "maxord") ? Int(ov["maxord"]) : nothing
     oextra = String(get(ov, "extra_opts", ""))
+
+    if want_golden
+        ms = (t1 - t0) / (Int(CFG["n_grid"]) * ref_factor)
+        @printf("  vacask golden reltol=%.0e maxstep=%.1e ... ", ref_reltol, ms); flush(stdout)
+        ti, sig, tp, rt = run_vacask_once(case, ref_reltol, ref_abstol, (t0, t1), out_nodes;
+                                           maxstep=ms, method=omethod, maxord=omaxord, extra_opts=oextra)
+        write_wave(joinpath(OUT, "ref_$(case).csv"), ti, sig)
+        @printf("%.3fs %d pts\n", rt, tp); flush(stdout)
+    end
 
     summary = open(joinpath(OUT, "vacask_$(case).csv"), "w")
     println(summary, "reltol,time_s,timepoints")
@@ -430,21 +435,37 @@ end
 #------------------------------------------------------------------------------#
 # Golden selection + analysis + report
 #------------------------------------------------------------------------------#
-function load_golden(case, spec)
+"""
+`golden="self"` means each simulator is scored against its OWN tight
+reference rather than one shared cross-simulator golden - see README
+"Findings about VACASK" on `mul`: a Cadnip-vs-VACASK gap that looks like a
+tolerance-tuning floor turned out to be VACASK converging cleanly to an
+answer that just differs from Cadnip's by a small, fixed amount (most likely
+the two simulators' separately-compiled diode models, not a solver-accuracy
+problem on either side). Scoring each simulator against a foreign golden
+would silently fold that gap into "error", overstating whichever simulator
+doesn't own the shared golden. `sim` picks which tight reference applies to
+`self`; it's ignored for the other golden kinds since they're already
+simulator-agnostic (analytic) or already only exist for one simulator.
+"""
+function load_golden(case, spec, sim::Symbol)
     g = String(spec["golden"])
-    if g == "analytic"
+    eff = g == "self" ? (sim == :cadnip ? "cadnip" : "vacask") : g
+    if eff == "analytic"
         return read_wave(joinpath(OUT, "analytic_$(case).csv"))..., "analytic (exact)"
-    elseif g == "vacask"
+    elseif eff == "vacask"
         return read_wave(joinpath(OUT, "ref_$(case).csv"))..., "VACASK (tight)"
-    elseif g == "cadnip"
+    elseif eff == "cadnip"
         return read_wave(joinpath(OUT, "cadnip_ref_$(case).csv"))..., "Cadnip IDA (tight)"
     else
-        error("case $case: unknown golden '$g' (use analytic|vacask|cadnip)")
+        error("case $case: unknown golden '$g' (use analytic|vacask|cadnip|self)")
     end
 end
 
 function analyze(case, spec)
-    gt, gv, gsrc = load_golden(case, spec)
+    cgt, cgv, cgsrc = load_golden(case, spec, :cadnip)
+    vgt, vgv, vgsrc = load_golden(case, spec, :vacask)
+    gsrc = cgsrc == vgsrc ? cgsrc : "$cgsrc (Cadnip) / $vgsrc (VACASK) - each scored against its own"
     println("$case: golden = $gsrc")
     curves = Dict{String,Vector{Tuple{Float64,Float64}}}()
     table = Tuple{String,Float64,Float64,Float64}[]
@@ -455,7 +476,7 @@ function analyze(case, spec)
         wp = joinpath(OUT, "cadnip_$(case)_$(solver)_$(reltol_tag(r)).csv")
         isfile(wp) || continue
         tw, vw = read_wave(wp)
-        err = run_error(tw, vw, gt, gv)
+        err = run_error(tw, vw, cgt, cgv)
         isfinite(err) && t !== nothing && isfinite(t) &&
             push!(get!(curves, "Cadnip $solver", Tuple{Float64,Float64}[]), (err, t))
         push!(table, ("Cadnip $solver", r, err, something(t, NaN)))
@@ -468,20 +489,28 @@ function analyze(case, spec)
             wp = joinpath(OUT, "vacask_$(case)_$(reltol_tag(r)).csv")
             isfile(wp) || continue
             tw, vw = read_wave(wp)
-            err = run_error(tw, vw, gt, gv)
+            err = run_error(tw, vw, vgt, vgv)
             isfinite(err) && t !== nothing && isfinite(t) &&
                 push!(get!(curves, "VACASK", Tuple{Float64,Float64}[]), (err, t))
             push!(table, ("VACASK", r, err, something(t, NaN)))
         end
     end
 
-
-    # cross-check: if both analytic and a VACASK ref exist, report their agreement
+    # cross-check: whenever two independent tight references exist for this
+    # case (analytic+VACASK, or - under golden="self" - Cadnip-tight+VACASK-
+    # tight), report their mutual agreement. This is the number that matters
+    # for `self` cases: it's the open, unexplained gap between the two
+    # simulators' converged answers, kept separate from either curve's error.
     ap = joinpath(OUT, "analytic_$(case).csv"); rp = joinpath(OUT, "ref_$(case).csv")
+    cp = joinpath(OUT, "cadnip_ref_$(case).csv")
     xcheck = ""
     if isfile(ap) && isfile(rp)
         ta, va = read_wave(ap); tr, vr = read_wave(rp)
         xcheck = @sprintf("analytic vs VACASK-tight cross-check: rel-L2 = %.2e", run_error(tr, vr, ta, va))
+        println("  ", xcheck)
+    elseif isfile(cp) && isfile(rp)
+        tc, vc = read_wave(cp); tr, vr = read_wave(rp)
+        xcheck = @sprintf("Cadnip-tight vs VACASK-tight cross-check: rel-L2 = %.2e (open item, not a tolerance-tuning gap - see README)", run_error(tr, vr, tc, vc))
         println("  ", xcheck)
     end
     return gsrc, curves, table, xcheck
@@ -592,6 +621,11 @@ function report(results)
         spec = CFG["cases"][case]
         println(io, "## $(spec["title"])\n")
         println(io, "Golden reference: **$gsrc**.", isempty(xcheck) ? "" : " ($xcheck)", "\n")
+        if String(spec["golden"]) == "self"
+            println(io, "*Each simulator is scored against its own tight reference, not a shared*")
+            println(io, "*cross-simulator golden - the cross-check figure above is the open gap*")
+            println(io, "*between the two, not error attributable to either curve below.*\n")
+        end
         if !isempty(curves)
             # GitHub renders ANSI SGR color codes in ```ansi fences for
             # issues/PRs/READMEs, but confirmed NOT in GITHUB_STEP_SUMMARY (shows
@@ -634,14 +668,17 @@ function main()
             t0, t1 = Float64(spec["tspan"][1]), Float64(spec["tspan"][2])
             fine = collect(range(t0, t1; length=200_000))
             write_wave(joinpath(OUT, "analytic_$(case).csv"), fine, ANALYTIC[case].(fine))
-        elseif golden == "cadnip"
+        elseif golden == "cadnip" || golden == "self"
+            # "self" needs its own Cadnip-tight golden too - Cadnip's curves
+            # must never be scored against VACASK's answer or vice versa.
             cadnip_golden(case, spec)
         end
 
         # VACASK sweep always runs where it can; also produce the VACASK golden
-        # only when this case is pinned to it.
+        # when this case is pinned to it OR uses "self" (which needs both
+        # goldens, not just one).
         if VACASK_BIN !== nothing
-            run_vacask_sweep(case, spec, golden == "vacask")
+            run_vacask_sweep(case, spec, golden == "vacask" || golden == "self")
         elseif golden == "vacask"
             error("case $case pinned to VACASK golden but VACASK binary not found")
         end


### PR DESCRIPTION
Verified against a real vacask 0.3.3-dev binary (pip vacask-bin) that the
rc case's ~1.5-7% error plateau is a tran_maxord=5 step-size/LTE controller
bug specific to this circuit, not pulse-edge skipping as previously
guessed here (breakpoints are handled correctly - 5-6 points land inside
every edge at every reltol). Orders 1-4 converge normally; order 5 alone
is 3 orders of magnitude worse while taking fewer steps. filter/graetz
don't show the same defect at order 5, so this is circuit-specific.

Capping rc's vacask_override at tran_maxord=4 (instead of the previous
maxstep=5e-6 clamp) restores genuine unbounded, reltol-driven adaptive
convergence with no maxstep crutch needed - re-ran the full rc case
end-to-end and confirmed VACASK error now improves monotonically from
1.5e-4 (reltol=1e-3) to 3.8e-5 (reltol=1e-9).

Also documents the maintainer's feedback from VACASK issue #83 on
nr_residualcheck (mul's existing override is the endorsed remedy) and
vntol=reltol (a simplification that doesn't bias these specific results,
checked directly).