### PR TITLE
Add per-class vector abstol for tran!, threaded through solve

### DIFF
--- a/doc/ring_oscillator_investigation.md
+++ b/doc/ring_oscillator_investigation.md
@@ -391,3 +391,85 @@ free-running ring oscillator has no source edges to derive breakpoints
 from - it's autonomous). The ring's problem is conditioning and
 error-weighting across mismatched variable units, not missed
 discontinuities.
+
+## Item 1 Tested and Refuted: Per-Class Vector `abstol` Makes Things Worse (2026-07)
+
+The top-ranked lead above — unit-aware error control via a vector `abstol`
+split by variable class (node voltage / branch current / charge) — was
+implemented and empirically tested on this exact circuit, per an explicit
+request to validate rather than just theorize. It was **not** a JUNCAP/PCNR
+side-quest that motivated this: a competing hypothesis (that PSP103's
+internal JUNCAP200 junction-diode submodel might implement its own
+NR-limiting, motivating a general Predictor/Corrector Newton-Raphson
+framework) was closed out by inspection first — JUNCAP does have a
+`VMAX`-based diode-current linearization functionally similar to ngspice's
+`pnjlim` (`models/PSPModels.jl/va/JUNCAP200_macrodefs.include:105-121,279-291`),
+but `SWJUNCAP` defaults to `0` and is never set in this benchmark's model
+card (`models/VACASKModels.jl/spice/models.inc`, loaded via `using
+VACASKModels`), so none of that code is active in the circuit that's failing
+to converge. PCNR itself remains pure proposal
+(`doc/compass_artifact_wf-c99b8a86-d31f-4e59-9c4f-6f69e4edd847_text_markdown.md`)
+with no code or precedent in the repo, and stays deferred.
+
+### What was implemented
+
+`MNA.state_abstol(sys::MNAData; vntol, iabstol, chgtol)` (`src/mna/build.jl`)
+builds a per-class tolerance vector from the node/current/charge index ranges
+`MNAData` already tracks. `tran!`'s `abstol` kwarg now accepts a
+`(vntol=, iabstol=, chgtol=)` NamedTuple, expanded via `state_abstol` using
+the `MNAData` the problem constructor attaches as `prob.f.sys`
+(`src/sweeps.jl`, `_resolve_abstol`). This works correctly end-to-end — a new
+`test/mna/oscillator_test.jl` testset confirms the small 3-stage inverter
+ring still converges and oscillates with the vector form. **The plumbing is
+not the problem; the numbers are.**
+
+### What happened on the real PSP103 ring (20ns slice, same methodology as
+### the Bottleneck Decomposition section above)
+
+| Configuration | Result |
+|---|---|
+| Baseline: scalar `abstol=1e-4, reltol=1e-2, force_dtmin=true` | **Success**, 842 timepoints, 5.30 iter/step, 39.9s |
+| Vector `(vntol=1e-6, iabstol=1e-12, chgtol=1e-14)`, `reltol=1e-2`, `force_dtmin=true` | **InitialFailure** — dies inside `CedarTranOp`'s consistency step (3 NR iters, 3.2s) |
+| Vector `(vntol=1e-6, iabstol=1e-12, chgtol=1e-14)`, `reltol=1e-3`, `force_dtmin=false` | **InitialFailure**, same as above (2.9s) |
+| Vector `(vntol=1e-4, iabstol=1e-9, chgtol=1e-12)` — vntol matched to baseline, currents/charges only "SPICE-realistic" | Init succeeds, but transient blows up: **MaxIters**, 66 timepoints (only reached 1.83ns of the 20ns span), **4,999,685 NR iterations = 74,622 iter/step** (14,000x worse than baseline's 5.3), 1628s wall |
+| Vector `(vntol=1e-5, ...)` | Killed after 27min+ of the same MaxIters trajectory as the row above — trend was already unambiguous |
+
+Two independent failure modes, both worse than the status quo:
+1. **Tightening `vntol` alone** (1e-6 vs. the baseline's blanket 1e-4) breaks
+   `CedarTranOp`'s DC/consistency initialization outright — the ring's
+   near-singular Jacobian (`cond(G) ≈ 6.6e18`) apparently can't reach a
+   node-voltage residual below 1e-6 during init, only below ~1e-4.
+2. **Tightening only the current/charge tolerances** to textbook SPICE
+   magnitudes (`1e-9` A / `1e-12` C) while leaving `vntol` at the baseline's
+   1e-4 causes a catastrophic ~14,000x blowup in Newton iterations per step
+   during the actual transient integration — the branch-current/charge
+   *magnitudes* this circuit's PSP103 stamping actually produces are
+   evidently far enough from `1e-9`/`1e-12` scale that demanding that level
+   of absolute accuracy on them is effectively demanding many more correct
+   digits than the ill-conditioned linear solves can deliver, so the
+   step-size controller thrashes instead of converging.
+
+### Conclusion
+
+**The "unit-aware error control" hypothesis, as formulated with
+SPICE-textbook-style default magnitudes, is refuted by direct measurement on
+this circuit — not just untested-but-plausible anymore.** The scalar
+`abstol=1e-4` "blunt workaround" isn't a symptom of a fixable unit mismatch;
+empirically it sits in the one narrow tolerance regime that actually works
+for this ill-conditioned system, and moving away from it in *either*
+direction (tighter node voltages, or tighter currents/charges while leaving
+node voltages alone) makes convergence dramatically worse, not better. This
+is consistent with `cond(G) ≈ 6.6e18` being the real, underlying constraint:
+no per-class reweighting fixes an 18-order-of-magnitude conditioning problem;
+it just changes where the error test starts failing. The next candidates
+from the ranked list above (item 3, always-on GMIN, or item 4, asymmetric
+initialization) target the conditioning/singularity directly rather than
+re-weighting the symptom, and are better-motivated next steps than any
+further tolerance tuning.
+
+**Disposition:** `MNA.state_abstol`/`tran!`'s NamedTuple `abstol` form is
+kept as a working, tested, general capability (it may be exactly right for
+circuits with real class-mismatched magnitudes that aren't this pathological)
+but is **not** adopted as the ring oscillator benchmark's default — the
+existing `force_dtmin=true, abstol=1e-4, reltol=1e-2` workaround remains the
+documented, working configuration for `benchmarks/vacask/ring/cedarsim/runme.jl`.

--- a/src/mna/build.jl
+++ b/src/mna/build.jl
@@ -8,7 +8,7 @@
 using SparseArrays
 using LinearAlgebra
 
-export MNAData, assemble!, assemble_G, assemble_C, get_rhs, get_rhs_ac
+export MNAData, assemble!, assemble_G, assemble_C, get_rhs, get_rhs_ac, state_abstol
 
 """
     MNAData{T}
@@ -257,6 +257,24 @@ current_variable_indices(sys::MNAData) = (sys.n_nodes + 1):(sys.n_nodes + sys.n_
 Return the indices in the solution vector corresponding to charge variables.
 """
 charge_variable_indices(sys::MNAData) = (sys.n_nodes + sys.n_currents + 1):(sys.n_nodes + sys.n_currents + sys.n_charges)
+
+"""
+    state_abstol(sys::MNAData; vntol=1e-6, iabstol=1e-12, chgtol=1e-14) -> Vector{Float64}
+
+Build a per-class absolute tolerance vector for the solution vector, mirroring
+SPICE's `vntol`/`abstol`/`chgtol` split: node voltages get `vntol`, branch
+currents get `iabstol`, and charge state variables get `chgtol`. A single
+scalar `abstol` mixes ~1V node voltages with µA currents and femto-scale
+charges, so the tiniest-unit variables dominate the error test; this gives
+each variable class its own natural scale instead.
+"""
+function state_abstol(sys::MNAData; vntol=1e-6, iabstol=1e-12, chgtol=1e-14)
+    tol = Vector{Float64}(undef, system_size(sys))
+    tol[node_voltage_indices(sys)] .= vntol
+    tol[current_variable_indices(sys)] .= iabstol
+    tol[charge_variable_indices(sys)] .= chgtol
+    return tol
+end
 
 """
     get_node_index(sys::MNAData, name::Symbol) -> Int

--- a/src/sweeps.jl
+++ b/src/sweeps.jl
@@ -518,7 +518,13 @@ iteration, ensuring correct handling of nonlinear devices.
 - `circuit`: The MNA circuit
 - `tspan`: Time span for simulation `(t0, tf)`
 - `solver`: Solver algorithm (default: IDA with tuned parameters for circuits)
-- `abstol`, `reltol`: Solver tolerances
+- `abstol`, `reltol`: Solver tolerances. `abstol` also accepts a per-class
+  NamedTuple `(vntol=..., iabstol=..., chgtol=...)` (see `MNA.state_abstol`),
+  expanded into a full-length vector so node voltages, branch currents, and
+  charge states each get their own natural scale instead of one scalar being
+  dominated by the tiniest-unit variable. `reltol` must stay scalar when
+  `solver` is a Sundials DAE algorithm (e.g. `IDA`) — vector `reltol` isn't
+  supported by `IDASVtolerances`.
 - `explicit_jacobian`: Use explicit Jacobian (default: true for performance)
 - `auto_tstops::Bool=true`: Automatically derive solver `tstops` (and, on the
   ODE/DDE path, `d_discontinuities`) from PWL/PULSE/SIN source breakpoints
@@ -571,6 +577,12 @@ end
 # below never pass them to solve() - solve's kwarg splat would clobber
 # prob.kwargs instead of merging.
 
+# Expand a per-class tolerance NamedTuple (e.g. `(vntol=1e-6, iabstol=1e-12,
+# chgtol=1e-14)`) into a full-length abstol vector via `MNA.state_abstol`,
+# using the `MNAData` the problem constructor already attached as `prob.f.sys`.
+# Scalars and pre-built vectors pass through unchanged.
+_resolve_abstol(abstol, prob) = abstol isa NamedTuple ? MNA.state_abstol(prob.f.sys; abstol...) : abstol
+
 # DAE solver dispatch (IDA, DFBDF, etc.)
 # Note: explicit_jacobian defaults to true for Sundials solvers (IDA) for performance.
 # OrdinaryDiffEq DAE solvers (DFBDF, DABDF2, DImplicitEuler) need explicit_jacobian=false
@@ -592,8 +604,15 @@ function _tran_dispatch(circuit::MNA.MNACircuit, tspan::Tuple{<:Real,<:Real},
         explicit_jacobian = solver isa Sundials.SundialsDAEAlgorithm
     end
 
+    # Sundials' IDASVtolerances only support a scalar reltol (vector abstol is fine).
+    if solver isa Sundials.SundialsDAEAlgorithm && !(reltol isa Real)
+        throw(ArgumentError("Sundials IDA only supports a scalar `reltol` (got $(typeof(reltol))); " *
+                             "use a per-class NamedTuple only for `abstol`."))
+    end
+
     prob = SciMLBase.DAEProblem(circuit, tspan; explicit_jacobian=explicit_jacobian,
                                 auto_tstops=auto_tstops, tstops=tstops)
+    abstol = _resolve_abstol(abstol, prob)
     return SciMLBase.solve(prob, solver; abstol=abstol, reltol=reltol, initializealg=initializealg, kwargs...)
 end
 
@@ -607,6 +626,7 @@ function _tran_dispatch(circuit::MNA.MNACircuit, tspan::Tuple{<:Real,<:Real},
                         kwargs...)
     prob = SciMLBase.ODEProblem(circuit, tspan; auto_tstops=auto_tstops,
                                 tstops=tstops, d_discontinuities=d_discontinuities)
+    abstol = _resolve_abstol(abstol, prob)
     return SciMLBase.solve(prob, solver; abstol=abstol, reltol=reltol, initializealg=initializealg, kwargs...)
 end
 
@@ -620,6 +640,7 @@ function _tran_dispatch(circuit::MNA.MNACircuit, tspan::Tuple{<:Real,<:Real},
                         kwargs...)
     prob = SciMLBase.DDEProblem(circuit, tspan; constant_lags=constant_lags, auto_tstops=auto_tstops,
                                 tstops=tstops, d_discontinuities=d_discontinuities)
+    abstol = _resolve_abstol(abstol, prob)
     return SciMLBase.solve(prob, solver; abstol=abstol, reltol=reltol, initializealg=initializealg, kwargs...)
 end
 

--- a/test/mna/oscillator_test.jl
+++ b/test/mna/oscillator_test.jl
@@ -170,4 +170,29 @@ C3 in1 0 10f
         @test normalized_corr < 0.5  # Not in phase
     end
 
+    @testset "3-stage CMOS ring oscillator with per-class vector abstol" begin
+        # Same circuit, but abstol is a per-class NamedTuple (vntol/iabstol/chgtol)
+        # instead of one scalar, exercising MNA.state_abstol via tran!'s expansion.
+        circuit = MNACircuit(ring_oscillator)
+        tspan = (0.0, 200e-9)
+
+        sol = tran!(circuit, tspan;
+                    solver=Rodas5P(linsolve=KLUFactorization()),
+                    initializealg=CedarUICOp(warmup_steps=20, dt=1e-15),
+                    abstol=(vntol=1e-6, iabstol=1e-12, chgtol=1e-14), reltol=1e-6,
+                    dtmax=1e-9)
+
+        @test sol.retcode == SciMLBase.ReturnCode.Success
+
+        t_start = 100e-9
+        t_end = 200e-9
+        times = range(t_start, t_end; length=1000)
+        V_out1 = [nameat(sol, :out1, t) for t in times]
+
+        out1_min, out1_max = extrema(V_out1)
+        @test (out1_max - out1_min) > 2.0
+        @test out1_max > 2.5
+        @test out1_min < 0.8
+    end
+
 end


### PR DESCRIPTION
The ring oscillator's state vector mixes ~1V node voltages, uA branch
currents, and femto-scale charge states under one scalar abstol, so the
tiniest-unit variables dominate the error test. Add MNA.state_abstol to
build a per-class tolerance vector from the index ranges MNAData already
tracks, and let tran!'s abstol accept a (vntol=, iabstol=, chgtol=)
NamedTuple that gets expanded via the problem's attached MNAData (prob.f.sys)
before solve. Sundials IDA only supports vector abstol, not vector reltol,
so reject a non-scalar reltol when the solver is a SundialsDAEAlgorithm.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014nCgA5mxt3drkDHBctaaDw