### PR TITLE
Implement Verilog-A $limit codegen (PCNR Option 1) + VA DC benchmark

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,44 +2,23 @@
 
 ## Environment
 
-### Local Development (Native)
+**Use Julia 1.12.** Better compilation performance for long functions (like VA
+models), and it builds a full c6288 (212k-variable, PSP103-heavy) circuit with
+no trouble.
 
-When running on a local machine with full system access:
+- On a local machine Julia is usually pre-installed via juliaup — just use `julia`.
+- In a fresh cloud/remote session Julia is typically not pre-installed. Install it:
+  ```bash
+  curl -fsSL https://install.julialang.org | sh -s -- -y
+  . ~/.bashrc
+  ~/.juliaup/bin/juliaup add 1.12 && ~/.juliaup/bin/juliaup default 1.12
+  ```
+  then run Julia via `~/.juliaup/bin/julia` (full path).
+- For a fresh local setup: `juliaup add 1.12 && juliaup default 1.12`.
 
-- **Use Julia 1.12** - better compilation performance for long functions (like VA models)
-- Julia is typically pre-installed via juliaup, just use `julia` command
-- Full system resources available - no memory limits
-- For fresh setup: `juliaup add 1.12 && juliaup default 1.12`
-
-### Web/Sandbox Environment (Claude Code Web)
-
-When running in gVisor-sandboxed environment (check with `uname -r` showing `runsc` or kernel 4.4.0):
-
-- **Julia is NOT pre-installed** - install juliaup first:
-  - Run: `curl -fsSL https://install.julialang.org | sh -s -- -y`
-  - Then source the profile: `. ~/.bashrc`
-  - Add Julia 1.11: `~/.juliaup/bin/juliaup add 1.11`
-  - Set as default: `~/.juliaup/bin/juliaup default 1.11`
-  - Use `~/.juliaup/bin/julia` to run Julia (full path required)
-- **Use Julia 1.11** - more stable in sandbox environment
-  - Julia 1.12 has threading bugs that cause segfaults during artifact downloads in gVisor
-- **Memory limited** - large VA model compilations (PSP103VA with 200+ params) may OOM
-- **Precompilation issues** - may need to disable compile workloads
-
-### Other Cloud/Remote Environments (Claude Code Remote, non-gVisor)
-
-Some cloud sessions (e.g. Claude Code Remote containers) are *not* the gVisor
-sandbox above - `uname -r` shows a real kernel version (not `runsc`/`4.4.0`).
-Julia is also typically not pre-installed here, so use the same juliaup
-install steps as the gVisor case. But treat these like "Local Development
-(Native)" for the version choice: **Julia 1.12 works fine** - confirmed in a
-session on a real (non-runsc) kernel where `Pkg.instantiate()`/precompile and
-a full c6288 (212k-variable, PSP103-heavy) circuit build under 1.12 completed
-with no segfaults. The 1.12 threading/segfault issue documented above is
-specific to the actual gVisor/runsc sandbox, not to cloud environments in
-general - don't downgrade to 1.11 just because you're in a container.
-
-**Fix for precompilation segfaults:** Create `test/LocalPreferences.toml`:
+**Heavy VA model precompilation** (PSP103VA with 200+ params, BSIM4) can be slow
+or memory-hungry. To skip the compile workloads, create
+`test/LocalPreferences.toml`:
 
 ```toml
 [PSPModels]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,56 @@ See `doc/` for design documents. Check `git log --oneline -20 --name-only` for r
 | `test/mna/vadistiller_integration.jl` | Large VA models (BSIM4) |
 | `test/mna/audio_integration.jl` | BJT circuits |
 
+### Test Style: prefer netlists + the high-level API
+
+**Default to SPICE/Spectre netlists driven through the high-level API for any
+test that asserts on *circuit behavior* (a DC operating point, a transient
+trajectory, convergence, model-card parameter handling, an AC response).**
+Reserve hand-written `stamp!` / `MNAContext` / `get_node!` builders for unit
+tests that specifically exercise *low-level stamping mechanics* — matrix
+assembly, COO structure, positional-counter discipline, `stamp_G!`/`stamp_C!`,
+the `alloc_*` primitives, `DirectStampContext` restamping. If a test is really
+about "does this circuit solve to the right answer," it should be a netlist.
+
+Preferred (declarative; exercises the real
+parser → codegen → `ModelRegistry` → solve path that production uses):
+
+```julia
+const rectifier = sp"""
+V1 vin 0 DC 5
+R1 vin out 1k
+D1 out 0 dmod
+.model dmod d is=76.9p n=1.45
+"""i
+
+sol = dc!(MNACircuit(rectifier))
+@test 0.6 < sol[:out] < 0.8        # name-based access, robust to system size
+```
+
+Avoid, for behavioral tests (hand-managed nodes, `_mna_x_` threading, and
+fragile positional `sol.x[2]` indexing that breaks the moment the system gains
+a variable — e.g. a `$limit` limiting row):
+
+```julia
+function rect(p, s, t=0.0; x=Float64[], ctx=MNAContext())
+    reset_for_restamping!(ctx)
+    vin = get_node!(ctx, :vin); out = get_node!(ctx, :out)
+    stamp!(VoltageSource(5.0; name=:V1), ctx, vin, 0)
+    stamp!(Resistor(1000.0), ctx, vin, out)
+    stamp!(sp_diode(), ctx, out, 0; _mna_spec_=s, _mna_x_=x)
+    return ctx
+end
+sol = solve_dc(rect, (;), MNASpec()); @test 0.6 < sol.x[2] < 0.8
+```
+
+Why: netlists cover the parser, codegen, and two-tier model resolution that
+real users hit (a hand-stamped `sp_diode()` skips all of it); `sol[:name]`
+survives added state variables where `sol.x[i]` silently shifts; and the
+netlist form is a fraction of the boilerplate. Load netlists at module top
+level (`const c = sp"""..."""i`, or `Base.include(@__MODULE__,
+SpiceFile(path))`) and pass the builder to `MNACircuit` — see **File-First
+Circuit Loading** below for the world-age rules.
+
 ## Gotchas and Patterns
 
 ### Builder Function Signature

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,37 @@ altered = alter(circuit; var"inner.params.R1"=200.0)
 ```
 The `lens(; defaults...)` call merges with `lens.nt.params` if present.
 
+### Parameter Sweeps (the sweep API)
+
+Don't hand-roll a `for`-loop that rebuilds a circuit per value — use the sweep
+API. Wrap the range(s) in a sweep, bind to a builder with `CircuitSweep`, and
+run `dc!`/`tran!`, which return a `SweepResult` iterating `(params, sol)` pairs:
+
+```julia
+sweep = Sweep(vac = [0.5e-3, 1e-3, 2e-3])          # one axis
+# ProductSweep(a=..., b=...)  → full grid;  TandemSweep(a=..., b=...) → zipped
+cs = CircuitSweep(ce_amplifier, sweep; vac=1e-3, freq=1e3)   # base params as kwargs
+for (params, sol) in tran!(cs, (0.0, 5e-3))
+    @test sol[:coll] ...                            # params aligned to its sol
+end
+```
+
+**The gotcha (the "wrap"):** two things must line up or the sweep is a silent
+no-op that returns the default for every point.
+1. **Pass the base value as a `CircuitSweep` kwarg** (`; vac=1e-3, freq=1e3`
+   above) — this seeds the params NamedTuple so the swept name resolves. The
+   canonical working netlist example is `test/mna/audio_integration.jl`
+   (`.param vac` / `.param freq` driving a `SIN` source).
+2. **The builder must actually read `params.<name>` where you want variation.**
+   A hand-coded builder must `merge(defaults, params)` or use `ParamLens`. In a
+   SPICE netlist, a `.param` that feeds a *runtime-evaluated* source (SIN/PULSE
+   amplitude, freq) responds to the sweep; a `.param` baked into a *DC operating
+   value* is folded at codegen time and will not — vary that via a builder that
+   reads the param, not a bare `.param` on a `DC` card.
+
+For hierarchical/subcircuit params use `var"a.b.c"` selectors with a matching
+wrapped base (`inner=(params=(R1=…),)`), same as `alter` (see ParamLens above).
+
 ### SPICE Name Collisions
 PDK modules use `baremodule` so SPICE names like `inv`, `log`, `exp` don't
 conflict with Julia builtins. Generated code uses explicit `Base.hasfield`,

--- a/benchmarks/pcnr/dc_newton_iterations.jl
+++ b/benchmarks/pcnr/dc_newton_iterations.jl
@@ -3,11 +3,19 @@
 #
 # Compares DC Newton iteration counts across all the nonlinear methods Cadnip
 # uses (see doc/pcnr_plan.md and src/mna/solve.jl) on a handful of diode
-# rectifier / cascade topologies. Every circuit is a hand-written native
-# `Diode` builder (not VA), each available in a `limit=true` and `limit=false`
-# variant so PCNR (which needs the limiting-augmented system) and the plain
-# NonlinearSolve algorithms (which run on the natural, unaugmented system) can
-# both be exercised fairly.
+# rectifier / cascade topologies, in two families:
+#
+#   * native `Diode` builders (rectifier/chain3/graetz/mul4), each with a
+#     `limit=true` and `limit=false` variant so PCNR (which needs the
+#     limiting-augmented system) and the plain NonlinearSolve algorithms
+#     (which run on the natural, unaugmented system) are both exercised;
+#   * real VADistiller `sp_diode` twins (*_va), which always carry a PCNR
+#     limiting variable via the Verilog-A `$limit` codegen -- there is no
+#     `limit=false` twin, so every method runs on the one augmented system
+#     (the correctorless ones see an inert limiter, i.e. the natural problem).
+#
+# The VA twins are the end goal of the `$limit` work: measuring the distilled
+# ngspice diode with real limiting active, next to the native reference.
 #
 # Run with:
 #   ~/.juliaup/bin/julia --project=test benchmarks/pcnr/dc_newton_iterations.jl [output_file]
@@ -22,6 +30,9 @@ using Cadnip.MNA
 import Cadnip.MNA as MNA
 using LinearAlgebra
 using Printf
+# Real distilled ngspice diode (registers sp_diode; carries a PCNR limiting
+# variable via the Verilog-A `$limit` codegen). See doc/pcnr_plan.md.
+using VADistillerModels: sp_diode
 
 # NonlinearSolve/SciMLBase are not direct dependencies of test/Project.toml,
 # but MNA does `using NonlinearSolve` / `using SciMLBase` internally, which
@@ -144,6 +155,74 @@ function mul4(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
 end
 
 #==============================================================================#
+# VADistiller sp_diode twins of the circuits above.
+#
+# The end goal (doc/pcnr_plan.md): exercise the DC benchmark on the *real*
+# distilled ngspice diode instead of the hand-written native `Diode`. sp_diode
+# ships its own SPICE limiting logic in Verilog-A and, via the `$limit` codegen,
+# always carries a PCNR limiting variable -- there is no `limit=false` twin, so
+# for these circuits every method (PCNR, plain-Newton, and the NonlinearSolve
+# algorithms) runs on the same limit-augmented system. Under a correctorless
+# solver the limiter is provably inert (the linear g_lim rows keep x_lim = V),
+# so those methods see the natural problem; only PCNR's corrector activates it.
+#
+# d1n4007-like parameters matching the native DIODE_* constants above.
+va_diode(name::Symbol) = sp_diode(; is=DIODE_IS, n=DIODE_N)
+
+function rectifier_va(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
+    ctx = ctx === nothing ? MNAContext() : (MNA.reset_for_restamping!(ctx); ctx)
+    vin = get_node!(ctx, :vin)
+    out = get_node!(ctx, :out)
+    stamp!(VoltageSource(params.Vsrc; name=:V1), ctx, vin, 0)
+    stamp!(Resistor(1000.0), ctx, vin, out)
+    stamp!(va_diode(:D1), ctx, out, 0; _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D1)
+    return ctx
+end
+
+function chain3_va(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
+    ctx = ctx === nothing ? MNAContext() : (MNA.reset_for_restamping!(ctx); ctx)
+    vin = get_node!(ctx, :vin); n1 = get_node!(ctx, :n1)
+    n2 = get_node!(ctx, :n2); n3 = get_node!(ctx, :n3)
+    stamp!(VoltageSource(params.Vsrc; name=:V1), ctx, vin, 0)
+    stamp!(Resistor(1000.0), ctx, vin, n1)
+    stamp!(va_diode(:D1), ctx, n1, n2; _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D1)
+    stamp!(va_diode(:D2), ctx, n2, n3; _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D2)
+    stamp!(va_diode(:D3), ctx, n3, 0;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D3)
+    return ctx
+end
+
+function graetz_va(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
+    ctx = ctx === nothing ? MNAContext() : (MNA.reset_for_restamping!(ctx); ctx)
+    inp = get_node!(ctx, :inp); inn = get_node!(ctx, :inn)
+    outp = get_node!(ctx, :outp); outn = get_node!(ctx, :outn)
+    stamp!(VoltageSource(params.Vsrc; name=:VS), ctx, inp, inn)
+    stamp!(va_diode(:D1), ctx, inp, outp;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D1)
+    stamp!(va_diode(:D2), ctx, outn, inp;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D2)
+    stamp!(va_diode(:D3), ctx, inn, outp;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D3)
+    stamp!(va_diode(:D4), ctx, outn, inn;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D4)
+    stamp!(Resistor(1e3), ctx, outp, outn)
+    stamp!(Resistor(1e6), ctx, inn, 0)
+    stamp!(Resistor(1e6), ctx, outn, 0)
+    return ctx
+end
+
+function mul4_va(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
+    ctx = ctx === nothing ? MNAContext() : (MNA.reset_for_restamping!(ctx); ctx)
+    a = get_node!(ctx, :a); n1 = get_node!(ctx, :n1); n2 = get_node!(ctx, :n2)
+    n10 = get_node!(ctx, :n10); n20 = get_node!(ctx, :n20)
+    stamp!(VoltageSource(params.Vsrc; name=:VS), ctx, a, 0)
+    stamp!(Resistor(0.01), ctx, a, n1)
+    stamp!(va_diode(:D1), ctx, 0, n1;    _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D1)
+    stamp!(va_diode(:D2), ctx, n1, n10;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D2)
+    stamp!(va_diode(:D3), ctx, n10, n2;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D3)
+    stamp!(va_diode(:D4), ctx, n2, n20;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D4)
+    stamp!(Resistor(100e3), ctx, n1, n2)
+    stamp!(Resistor(100e3), ctx, 0, n10)
+    stamp!(Resistor(100e3), ctx, n10, n20)
+    return ctx
+end
+
+#==============================================================================#
 # Circuit list: (name, builder, [Vsrc...])
 #==============================================================================#
 
@@ -152,6 +231,14 @@ const CIRCUITS = [
     ("chain3", chain3, [50.0]),
     ("graetz", graetz, [20.0, 325.0]),
     ("mul4", mul4, [50.0]),
+]
+
+# VA sp_diode twins, run through run_circuit_va (single augmented system).
+const CIRCUITS_VA = [
+    ("rectifier_va", rectifier_va, [5.0, 50.0]),
+    ("chain3_va", chain3_va, [50.0]),
+    ("graetz_va", graetz_va, [20.0, 325.0]),
+    ("mul4_va", mul4_va, [50.0]),
 ]
 
 #==============================================================================#
@@ -304,6 +391,40 @@ function run_circuit(name, builder, Vsrc)
     return rows
 end
 
+# VA sp_diode: there is no `limit=false` twin (the `$limit` codegen always
+# allocates a limiting variable), so PCNR, plain-Newton, and every
+# NonlinearSolve method run on the *same* limit-augmented system. The
+# correctorless methods see an inert limiter (linear g_lim rows pin
+# x_lim = V), i.e. the natural problem; only PCNR's corrector activates it.
+function run_circuit_va(name, builder, Vsrc)
+    spec = MNASpec(mode=:dcop)
+    rows = Row[]
+    params = (Vsrc=Vsrc,)
+    cs, ws, n = build_problem(builder, params, spec)
+
+    u_pcnr, ok_pcnr, iters_pcnr = MNA._dc_pcnr_newton(cs, ws, zeros(n);
+                                                       abstol=1e-10, maxiters=200)
+    Fpcnr = zeros(n)
+    MNA.fast_rebuild!(ws, cs, u_pcnr, 0.0)
+    mul!(Fpcnr, cs.G, u_pcnr)
+    Fpcnr .-= ws.dctx.b
+    push!(rows, Row(name, Vsrc, "PCNR", ok_pcnr, iters_pcnr, iters_pcnr, norm(Fpcnr),
+                     ok_pcnr ? "Success" : "Failure"))
+
+    u_plain, ok_plain, iters_plain, resid_plain = plain_newton_loop(cs, ws, zeros(n);
+                                                                     abstol=1e-10, maxiters=200)
+    push!(rows, Row(name, Vsrc, "PlainNewton(augmented,no-correct)", ok_plain, iters_plain,
+                     iters_plain, resid_plain, ok_plain ? "Success" : "Failure"))
+
+    u0 = zeros(n)
+    for (mname, alg_fn) in NLS_METHODS
+        r = run_nls_method(cs, ws, alg_fn, u0; abstol=1e-10, maxiters=200)
+        push!(rows, Row(name, Vsrc, mname, r.converged, r.nsteps, r.nf, r.resid, r.retcode))
+    end
+
+    return rows
+end
+
 #==============================================================================#
 # Output
 #==============================================================================#
@@ -411,6 +532,12 @@ function main()
     for (name, builder, Vsrcs) in CIRCUITS
         for Vsrc in Vsrcs
             append!(all_rows, run_circuit(name, builder, Vsrc))
+        end
+    end
+    # Real VADistiller sp_diode twins (single augmented system per circuit).
+    for (name, builder, Vsrcs) in CIRCUITS_VA
+        for Vsrc in Vsrcs
+            append!(all_rows, run_circuit_va(name, builder, Vsrc))
         end
     end
 

--- a/benchmarks/pcnr/dc_newton_iterations.jl
+++ b/benchmarks/pcnr/dc_newton_iterations.jl
@@ -2,20 +2,17 @@
 # PCNR vs. NonlinearSolve.jl DC Newton convergence benchmark
 #
 # Compares DC Newton iteration counts across all the nonlinear methods Cadnip
-# uses (see doc/pcnr_plan.md and src/mna/solve.jl) on a handful of diode
-# rectifier / cascade topologies, in two families:
+# uses (see doc/pcnr_plan.md and src/mna/solve.jl) on a handful of real
+# VADistiller `sp_diode` rectifier / cascade topologies -- the end goal of the
+# `$limit` work: the distilled ngspice diode with SPICE limiting active.
 #
-#   * native `Diode` builders (rectifier/chain3/graetz/mul4), each with a
-#     `limit=true` and `limit=false` variant so PCNR (which needs the
-#     limiting-augmented system) and the plain NonlinearSolve algorithms
-#     (which run on the natural, unaugmented system) are both exercised;
-#   * real VADistiller `sp_diode` twins (*_va), which always carry a PCNR
-#     limiting variable via the Verilog-A `$limit` codegen -- there is no
-#     `limit=false` twin, so every method runs on the one augmented system
-#     (the correctorless ones see an inert limiter, i.e. the natural problem).
-#
-# The VA twins are the end goal of the `$limit` work: measuring the distilled
-# ngspice diode with real limiting active, next to the native reference.
+# sp_diode always carries a PCNR limiting variable (via the Verilog-A `$limit`
+# codegen), so there is no unlimited twin: PCNR, a reference plain-Newton loop
+# (corrector disabled), and every NonlinearSolve algorithm all run on the one
+# limit-augmented system. The correctorless methods see an inert limiter (the
+# linear g_lim rows pin x_lim = V), i.e. the natural problem -- so this is
+# exactly the comparison of interest: limiting-aware PCNR vs. methods that
+# don't support limiting, on the same circuit.
 #
 # Run with:
 #   ~/.juliaup/bin/julia --project=test benchmarks/pcnr/dc_newton_iterations.jl [output_file]
@@ -56,70 +53,54 @@ const CedarRobustNLSolve = MNA.CedarRobustNLSolve
 # sync between the structure-detection pass and later fast restamps.
 #==============================================================================#
 
-# d1n4007-like diode parameters (rs/cjo ignored -- this is a DC benchmark)
+# Real distilled ngspice diode (d1n4007-like is/n; rs/cjo irrelevant at DC).
+# sp_diode ships its own SPICE limiting logic in Verilog-A and, via the
+# `$limit` codegen, always carries a PCNR limiting variable. There is no
+# "unlimited" twin, so every method (PCNR, plain-Newton, and the NonlinearSolve
+# algorithms) runs on the same limit-augmented system: under a correctorless
+# solver the limiter is provably inert (the linear g_lim rows keep x_lim = V),
+# so those methods see the natural problem; only PCNR's corrector activates it.
+# That is exactly the comparison of interest -- limiting-aware PCNR vs. methods
+# that don't support limiting -- so a native/unlimited reference is unnecessary.
 const DIODE_IS = 76.9e-12
 const DIODE_N = 1.45
-const DIODE_VT = 0.026
-
-make_diode(name::Symbol, limit::Bool) =
-    Diode(Is=DIODE_IS, n=DIODE_N, Vt=DIODE_VT, limit=limit, name=name)
+d(name::Symbol) = sp_diode(; is=DIODE_IS, n=DIODE_N)
 
 # 1. Half-wave rectifier: Vsrc -[1k]- out -D1- gnd
 function rectifier(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
-    if ctx === nothing
-        ctx = MNAContext()
-    else
-        MNA.reset_for_restamping!(ctx)
-    end
+    ctx = ctx === nothing ? MNAContext() : (MNA.reset_for_restamping!(ctx); ctx)
     vin = get_node!(ctx, :vin)
     out = get_node!(ctx, :out)
-
     stamp!(VoltageSource(params.Vsrc; name=:V1), ctx, vin, 0)
     stamp!(Resistor(1000.0), ctx, vin, out)
-    stamp!(make_diode(:D1, params.limit), ctx, out, 0; x=x)
+    stamp!(d(:D1), ctx, out, 0; _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D1)
     return ctx
 end
 
 # 2. Series chain: Vsrc -[1k]- n1 -D1- n2 -D2- n3 -D3- gnd
 function chain3(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
-    if ctx === nothing
-        ctx = MNAContext()
-    else
-        MNA.reset_for_restamping!(ctx)
-    end
-    vin = get_node!(ctx, :vin)
-    n1 = get_node!(ctx, :n1)
-    n2 = get_node!(ctx, :n2)
-    n3 = get_node!(ctx, :n3)
-
+    ctx = ctx === nothing ? MNAContext() : (MNA.reset_for_restamping!(ctx); ctx)
+    vin = get_node!(ctx, :vin); n1 = get_node!(ctx, :n1)
+    n2 = get_node!(ctx, :n2); n3 = get_node!(ctx, :n3)
     stamp!(VoltageSource(params.Vsrc; name=:V1), ctx, vin, 0)
     stamp!(Resistor(1000.0), ctx, vin, n1)
-    stamp!(make_diode(:D1, params.limit), ctx, n1, n2; x=x)
-    stamp!(make_diode(:D2, params.limit), ctx, n2, n3; x=x)
-    stamp!(make_diode(:D3, params.limit), ctx, n3, 0; x=x)
+    stamp!(d(:D1), ctx, n1, n2; _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D1)
+    stamp!(d(:D2), ctx, n2, n3; _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D2)
+    stamp!(d(:D3), ctx, n3, 0;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D3)
     return ctx
 end
 
 # 3. Full-wave (Graetz) bridge, DC only (100uF smoothing cap is open at DC,
 # so it's omitted -- see benchmarks/vacask/graetz/cedarsim/runme.sp).
-# vs inp inn 0 sin ... -> DC value Vsrc, stamped node-to-node (two-node
-# VoltageSource is supported directly, no need to route through ground).
 function graetz(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
-    if ctx === nothing
-        ctx = MNAContext()
-    else
-        MNA.reset_for_restamping!(ctx)
-    end
-    inp = get_node!(ctx, :inp)
-    inn = get_node!(ctx, :inn)
-    outp = get_node!(ctx, :outp)
-    outn = get_node!(ctx, :outn)
-
+    ctx = ctx === nothing ? MNAContext() : (MNA.reset_for_restamping!(ctx); ctx)
+    inp = get_node!(ctx, :inp); inn = get_node!(ctx, :inn)
+    outp = get_node!(ctx, :outp); outn = get_node!(ctx, :outn)
     stamp!(VoltageSource(params.Vsrc; name=:VS), ctx, inp, inn)
-    stamp!(make_diode(:D1, params.limit), ctx, inp, outp; x=x)
-    stamp!(make_diode(:D2, params.limit), ctx, outn, inp; x=x)
-    stamp!(make_diode(:D3, params.limit), ctx, inn, outp; x=x)
-    stamp!(make_diode(:D4, params.limit), ctx, outn, inn; x=x)
+    stamp!(d(:D1), ctx, inp, outp;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D1)
+    stamp!(d(:D2), ctx, outn, inp;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D2)
+    stamp!(d(:D3), ctx, inn, outp;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D3)
+    stamp!(d(:D4), ctx, outn, inn;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D4)
     stamp!(Resistor(1e3), ctx, outp, outn)     # rl
     stamp!(Resistor(1e6), ctx, inn, 0)          # rgnd1
     stamp!(Resistor(1e6), ctx, outn, 0)         # rgnd2
@@ -127,98 +108,21 @@ function graetz(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
 end
 
 # 4. Diode multiplier (mul4), DC only -- caps replaced by 100k resistors
-# (open at DC; the resistors keep the DC problem meaningful, preserving the
-# cascade stiffness without leaving nodes floating through reverse-diode
-# leakage alone). See benchmarks/vacask/mul/cedarsim/runme.sp.
+# (open at DC; the resistors keep the DC problem meaningful). See
+# benchmarks/vacask/mul/cedarsim/runme.sp.
 function mul4(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
-    if ctx === nothing
-        ctx = MNAContext()
-    else
-        MNA.reset_for_restamping!(ctx)
-    end
-    a = get_node!(ctx, :a)
-    n1 = get_node!(ctx, :n1)
-    n2 = get_node!(ctx, :n2)
-    n10 = get_node!(ctx, :n10)
-    n20 = get_node!(ctx, :n20)
-
-    stamp!(VoltageSource(params.Vsrc; name=:VS), ctx, a, 0)
-    stamp!(Resistor(0.01), ctx, a, n1)          # r1
-    stamp!(make_diode(:D1, params.limit), ctx, 0, n1; x=x)
-    stamp!(make_diode(:D2, params.limit), ctx, n1, n10; x=x)
-    stamp!(make_diode(:D3, params.limit), ctx, n10, n2; x=x)
-    stamp!(make_diode(:D4, params.limit), ctx, n2, n20; x=x)
-    stamp!(Resistor(100e3), ctx, n1, n2)        # c1 || c3 (dedup'd)
-    stamp!(Resistor(100e3), ctx, 0, n10)        # c2
-    stamp!(Resistor(100e3), ctx, n10, n20)      # c4
-    return ctx
-end
-
-#==============================================================================#
-# VADistiller sp_diode twins of the circuits above.
-#
-# The end goal (doc/pcnr_plan.md): exercise the DC benchmark on the *real*
-# distilled ngspice diode instead of the hand-written native `Diode`. sp_diode
-# ships its own SPICE limiting logic in Verilog-A and, via the `$limit` codegen,
-# always carries a PCNR limiting variable -- there is no `limit=false` twin, so
-# for these circuits every method (PCNR, plain-Newton, and the NonlinearSolve
-# algorithms) runs on the same limit-augmented system. Under a correctorless
-# solver the limiter is provably inert (the linear g_lim rows keep x_lim = V),
-# so those methods see the natural problem; only PCNR's corrector activates it.
-#
-# d1n4007-like parameters matching the native DIODE_* constants above.
-va_diode(name::Symbol) = sp_diode(; is=DIODE_IS, n=DIODE_N)
-
-function rectifier_va(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
-    ctx = ctx === nothing ? MNAContext() : (MNA.reset_for_restamping!(ctx); ctx)
-    vin = get_node!(ctx, :vin)
-    out = get_node!(ctx, :out)
-    stamp!(VoltageSource(params.Vsrc; name=:V1), ctx, vin, 0)
-    stamp!(Resistor(1000.0), ctx, vin, out)
-    stamp!(va_diode(:D1), ctx, out, 0; _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D1)
-    return ctx
-end
-
-function chain3_va(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
-    ctx = ctx === nothing ? MNAContext() : (MNA.reset_for_restamping!(ctx); ctx)
-    vin = get_node!(ctx, :vin); n1 = get_node!(ctx, :n1)
-    n2 = get_node!(ctx, :n2); n3 = get_node!(ctx, :n3)
-    stamp!(VoltageSource(params.Vsrc; name=:V1), ctx, vin, 0)
-    stamp!(Resistor(1000.0), ctx, vin, n1)
-    stamp!(va_diode(:D1), ctx, n1, n2; _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D1)
-    stamp!(va_diode(:D2), ctx, n2, n3; _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D2)
-    stamp!(va_diode(:D3), ctx, n3, 0;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D3)
-    return ctx
-end
-
-function graetz_va(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
-    ctx = ctx === nothing ? MNAContext() : (MNA.reset_for_restamping!(ctx); ctx)
-    inp = get_node!(ctx, :inp); inn = get_node!(ctx, :inn)
-    outp = get_node!(ctx, :outp); outn = get_node!(ctx, :outn)
-    stamp!(VoltageSource(params.Vsrc; name=:VS), ctx, inp, inn)
-    stamp!(va_diode(:D1), ctx, inp, outp;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D1)
-    stamp!(va_diode(:D2), ctx, outn, inp;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D2)
-    stamp!(va_diode(:D3), ctx, inn, outp;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D3)
-    stamp!(va_diode(:D4), ctx, outn, inn;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D4)
-    stamp!(Resistor(1e3), ctx, outp, outn)
-    stamp!(Resistor(1e6), ctx, inn, 0)
-    stamp!(Resistor(1e6), ctx, outn, 0)
-    return ctx
-end
-
-function mul4_va(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
     ctx = ctx === nothing ? MNAContext() : (MNA.reset_for_restamping!(ctx); ctx)
     a = get_node!(ctx, :a); n1 = get_node!(ctx, :n1); n2 = get_node!(ctx, :n2)
     n10 = get_node!(ctx, :n10); n20 = get_node!(ctx, :n20)
     stamp!(VoltageSource(params.Vsrc; name=:VS), ctx, a, 0)
-    stamp!(Resistor(0.01), ctx, a, n1)
-    stamp!(va_diode(:D1), ctx, 0, n1;    _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D1)
-    stamp!(va_diode(:D2), ctx, n1, n10;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D2)
-    stamp!(va_diode(:D3), ctx, n10, n2;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D3)
-    stamp!(va_diode(:D4), ctx, n2, n20;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D4)
-    stamp!(Resistor(100e3), ctx, n1, n2)
-    stamp!(Resistor(100e3), ctx, 0, n10)
-    stamp!(Resistor(100e3), ctx, n10, n20)
+    stamp!(Resistor(0.01), ctx, a, n1)          # r1
+    stamp!(d(:D1), ctx, 0, n1;    _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D1)
+    stamp!(d(:D2), ctx, n1, n10;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D2)
+    stamp!(d(:D3), ctx, n10, n2;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D3)
+    stamp!(d(:D4), ctx, n2, n20;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:D4)
+    stamp!(Resistor(100e3), ctx, n1, n2)        # c1 || c3 (dedup'd)
+    stamp!(Resistor(100e3), ctx, 0, n10)        # c2
+    stamp!(Resistor(100e3), ctx, n10, n20)      # c4
     return ctx
 end
 
@@ -233,20 +137,12 @@ const CIRCUITS = [
     ("mul4", mul4, [50.0]),
 ]
 
-# VA sp_diode twins, run through run_circuit_va (single augmented system).
-const CIRCUITS_VA = [
-    ("rectifier_va", rectifier_va, [5.0, 50.0]),
-    ("chain3_va", chain3_va, [50.0]),
-    ("graetz_va", graetz_va, [20.0, 325.0]),
-    ("mul4_va", mul4_va, [50.0]),
-]
-
 #==============================================================================#
 # Sanity check: DC solution via the default (fully robust) solve path
 #==============================================================================#
 
 function sanity_check(name, builder, Vsrc)
-    params = (Vsrc=Vsrc, limit=true)
+    params = (Vsrc=Vsrc,)
     spec = MNASpec(mode=:dcop)
     sol = MNA.solve_dc(builder, params, spec)
     println("== $name (Vsrc=$Vsrc) DC sanity check ==")
@@ -356,47 +252,12 @@ function build_problem(builder, params, spec)
     return cs, ws, n
 end
 
+# sp_diode has no `limit=false` twin (the `$limit` codegen always allocates a
+# limiting variable), so PCNR, plain-Newton, and every NonlinearSolve method run
+# on the *same* limit-augmented system. The correctorless methods see an inert
+# limiter (linear g_lim rows pin x_lim = V), i.e. the natural problem; only
+# PCNR's corrector activates it.
 function run_circuit(name, builder, Vsrc)
-    spec = MNASpec(mode=:dcop)
-    rows = Row[]
-
-    # --- limit=true variant: PCNR + reference plain-Newton-on-augmented ---
-    params_lim = (Vsrc=Vsrc, limit=true)
-    cs_lim, ws_lim, n_lim = build_problem(builder, params_lim, spec)
-
-    u_pcnr, ok_pcnr, iters_pcnr = MNA._dc_pcnr_newton(cs_lim, ws_lim, zeros(n_lim);
-                                                       abstol=1e-10, maxiters=200)
-    Fpcnr = zeros(n_lim)
-    MNA.fast_rebuild!(ws_lim, cs_lim, u_pcnr, 0.0)
-    mul!(Fpcnr, cs_lim.G, u_pcnr)
-    Fpcnr .-= ws_lim.dctx.b
-    push!(rows, Row(name, Vsrc, "PCNR", ok_pcnr, iters_pcnr, iters_pcnr, norm(Fpcnr),
-                     ok_pcnr ? "Success" : "Failure"))
-
-    u_plain, ok_plain, iters_plain, resid_plain = plain_newton_loop(cs_lim, ws_lim, zeros(n_lim);
-                                                                     abstol=1e-10, maxiters=200)
-    push!(rows, Row(name, Vsrc, "PlainNewton(augmented,no-correct)", ok_plain, iters_plain,
-                     iters_plain, resid_plain, ok_plain ? "Success" : "Failure"))
-
-    # --- limit=false variant: NonlinearSolve.jl algorithms on the natural system ---
-    params_nolim = (Vsrc=Vsrc, limit=false)
-    cs_nolim, ws_nolim, n_nolim = build_problem(builder, params_nolim, spec)
-    u0 = zeros(n_nolim)
-
-    for (mname, alg_fn) in NLS_METHODS
-        r = run_nls_method(cs_nolim, ws_nolim, alg_fn, u0; abstol=1e-10, maxiters=200)
-        push!(rows, Row(name, Vsrc, mname, r.converged, r.nsteps, r.nf, r.resid, r.retcode))
-    end
-
-    return rows
-end
-
-# VA sp_diode: there is no `limit=false` twin (the `$limit` codegen always
-# allocates a limiting variable), so PCNR, plain-Newton, and every
-# NonlinearSolve method run on the *same* limit-augmented system. The
-# correctorless methods see an inert limiter (linear g_lim rows pin
-# x_lim = V), i.e. the natural problem; only PCNR's corrector activates it.
-function run_circuit_va(name, builder, Vsrc)
     spec = MNASpec(mode=:dcop)
     rows = Row[]
     params = (Vsrc=Vsrc,)
@@ -471,11 +332,12 @@ function generate_markdown(all_rows::Vector{Row})
 
     println(io, "## DC Newton method comparison (PCNR)")
     println(io)
-    println(io, "Compares DC Newton *iteration counts* (not wall-clock) across every ",
-                 "nonlinear method Cadnip uses -- the PCNR limiting-augmented loop, a ",
-                 "reference plain-Newton loop on the same augmented system with the ",
-                 "corrector disabled, and each `NonlinearSolve.jl` algorithm on the ",
-                 "natural (unaugmented) system.")
+    println(io, "Compares DC Newton *iteration counts* (not wall-clock) on the real ",
+                 "distilled `sp_diode` across every nonlinear method Cadnip uses -- the ",
+                 "PCNR limiting-augmented loop, a reference plain-Newton loop with the ",
+                 "corrector disabled, and each `NonlinearSolve.jl` algorithm -- all on ",
+                 "the one limit-augmented system (the correctorless methods see an inert ",
+                 "limiter, i.e. the natural problem).")
     println(io)
     println(io, "Benchmarks run on Julia $(VERSION)")
     println(io)
@@ -532,12 +394,6 @@ function main()
     for (name, builder, Vsrcs) in CIRCUITS
         for Vsrc in Vsrcs
             append!(all_rows, run_circuit(name, builder, Vsrc))
-        end
-    end
-    # Real VADistiller sp_diode twins (single augmented system per circuit).
-    for (name, builder, Vsrcs) in CIRCUITS_VA
-        for Vsrc in Vsrcs
-            append!(all_rows, run_circuit_va(name, builder, Vsrc))
         end
     end
 

--- a/benchmarks/pcnr/dc_newton_iterations.jl
+++ b/benchmarks/pcnr/dc_newton_iterations.jl
@@ -27,9 +27,9 @@ using Cadnip.MNA
 import Cadnip.MNA as MNA
 using LinearAlgebra
 using Printf
-# Real distilled ngspice diode (registers sp_diode; carries a PCNR limiting
-# variable via the Verilog-A `$limit` codegen). See doc/pcnr_plan.md.
-using VADistillerModels: sp_diode
+# Real distilled ngspice devices (register sp_diode / sp_bjt; each carries PCNR
+# limiting variables via the Verilog-A `$limit` codegen). See doc/pcnr_plan.md.
+using VADistillerModels: sp_diode, sp_bjt
 
 # NonlinearSolve/SciMLBase are not direct dependencies of test/Project.toml,
 # but MNA does `using NonlinearSolve` / `using SciMLBase` internally, which
@@ -126,6 +126,25 @@ function mul4(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
     return ctx
 end
 
+# 5. Darlington pair (NPN): Q1's emitter drives Q2's base, so the two Vbe drops
+# stack and the current gains multiply — the BJT analog of the diode chain, and
+# the multi-branch stress case (each sp_bjt has 3 limited junctions: vbe, vbc,
+# vsub). Vsrc drives the input base through Rb; the output emitter sits at
+# ~Vsrc − 2·Vbe. sp_bjt terminals: collector, base, emitter, substrate.
+q(name::Symbol) = sp_bjt(; bf=100.0, is=1e-15)
+function darlington(params, spec, t::Real=0.0; x=MNA.ZERO_VECTOR, ctx=nothing)
+    ctx = ctx === nothing ? MNAContext() : (MNA.reset_for_restamping!(ctx); ctx)
+    vcc = get_node!(ctx, :vcc); vin = get_node!(ctx, :vin); base = get_node!(ctx, :base)
+    mid = get_node!(ctx, :mid); out = get_node!(ctx, :out)
+    stamp!(VoltageSource(5.0; name=:Vcc), ctx, vcc, 0)
+    stamp!(VoltageSource(params.Vsrc; name=:Vin), ctx, vin, 0)
+    stamp!(Resistor(10e3), ctx, vin, base)                 # rb
+    stamp!(q(:Q1), ctx, vcc, base, mid, 0; _mna_spec_=spec, _mna_x_=x, _mna_instance_=:Q1)
+    stamp!(q(:Q2), ctx, vcc, mid, out, 0;  _mna_spec_=spec, _mna_x_=x, _mna_instance_=:Q2)
+    stamp!(Resistor(1e3), ctx, out, 0)                     # rl
+    return ctx
+end
+
 #==============================================================================#
 # Circuit list: (name, builder, [Vsrc...])
 #==============================================================================#
@@ -135,6 +154,7 @@ const CIRCUITS = [
     ("chain3", chain3, [50.0]),
     ("graetz", graetz, [20.0, 325.0]),
     ("mul4", mul4, [50.0]),
+    ("darlington", darlington, [3.0, 5.0]),
 ]
 
 #==============================================================================#

--- a/doc/pcnr_plan.md
+++ b/doc/pcnr_plan.md
@@ -377,11 +377,13 @@ voltage):
    interaction at all: warm starts have `vnew ≈ vold`, which makes pnjlim a
    no-op on its own; `x_lim` carries the previous timestep's value through
    the DAE state, playing the role of ngspice's MODEINITPRED vold. Placement
-   note: when Phase 2 lands, the signal should probably move from the
-   stamping context to `MNASpec` (matching SPICE's CKTmode and letting VA
-   models read the *same* signal via `$simparam("initjct", 0)`), with the
-   PCNR loop stamping its first cold pass through a spec-modified
-   `CompiledStructure` as the stepping code already does for gshunt/srcFact.
+   note (corrected 2026-07): an earlier revision suggested moving the signal
+   to `MNASpec` and exposing it as `$simparam("initjct", 0)` — but no model
+   reads any "initjct" simparam. What the VADistiller models actually read is
+   `$simparam("iniLim", -1)` inside `initialize_limiting()` (all 13 limited
+   models, e.g. `diode.va:370`), so Phase 2 keeps the flag on the stamping
+   context and special-cases `iniLim` in `$simparam` codegen to read it (see
+   Phase 2 below). No spec-modified `CompiledStructure` pass is needed.
 
    *Convergence-tail detail:* the recorded-`w` corrector leaves a one-step
    lag in the `g_lim` rows (`x_lim = V` from the previous iterate), so on
@@ -409,60 +411,107 @@ was that evaluating *at* `x_lim` made the vcrit seed effective and the
 anchoring trivially consistent. Same behavior now lives inside the unified
 `limit!` API.
 
-### Phase 2: `$limit` codegen in vasim.jl — future work (not a quick job)
+### Phase 2: `$limit` codegen in vasim.jl — refined plan (researched 2026-07)
 
 **The runtime side is already built and proven.** The `limit!` primitive
 (see "Formulation" above) is exactly what `$limit(V(p,n), fn, args...)`
 lowers to, and the native `Diode` already goes through it — so Phase 2 is
-*pure codegen*: no new solver or context mechanisms. Per site:
-
-- OldGet-style read → the `vold = x[ℓ]` read inside `limit!`;
-- the model computes `w = DEVpnjlim(vnew, vold, ...)` itself (an ordinary
-  VA analog-function call, already supported) and evaluates at `w`; AD flows
-  node partials through the limiter, so conductances stay in the node-node
-  block;
-- NewSet-style sites → additional `record_limit_w!` calls on the same
-  branch variable (allocate once per branch, last record wins);
-- the `g_lim` row stays the linear `x_lim − (V_p − V_n) = 0`.
+*pure codegen*: no new solver or context mechanisms, and (verified) no
+changes to `contrib.jl`/`context.jl`/`value_only.jl`/`solve.jl` at all,
+because generated VA `stamp!` methods inline all of their own stamping
+(dual extraction `src/vasim.jl:2907-2948`, Ieq companion `:3055-3078`) and
+never route through `stamp_contribution!`.
 
 Trace check (rectifier from zeros): iter 0 stamps at `w₀ = pnjlim(0,0) = 0`;
 predict pushes `V → 5` but correct resets `x_lim ← w₀ = 0`; iter 1 computes
 `w₁ = pnjlim(5, 0) = vt·ln(5/vt) ≈ 0.14` — the limiter fires exactly as in
 ngspice.
 
-**Codegen must also implement `lim_rhs` anchoring** (see the "Measured"
-notes above): contributions that used limit-replaced voltages need their
-companion anchored at the evaluation point,
-`Δb = Σ ∂I/∂w_k · (V_probe,k − w_k)`, with the *undamped* `∂I/∂w` partials
-(limit-replaced values enter the dual system with passthrough partials, not
-chain-ruled through the limiter). This is OSDI's `lim_rhs` field, so
-OpenVAF-targeted models already assume a simulator that does this.
+#### Verified facts that reshape the earlier sketch
 
-**Recovering initjct for VA models.** The `initjct` bypass inside `limit!`
-covers native devices and any LRM-idiomatic `$limit(V(p,n), "pnjlim", vte,
-vcrit)` site (where the simulator owns the limiter). It can NOT cover the
-VADistiller OldGet/NewSet idiom, because there the limiter runs inline in
-the model and trusts the cold probe. Options, in order of preference:
+1. **initjct needs no model patches and no upstream ask.** All 13 limited
+   models already ship `initialize_limiting()` *with* the MODEINITJCT
+   vcrit-seed branch emitted (e.g. `diode.va:367-381` and the seed at
+   `:738-740`), gated on `$simparam("iniLim", -1)`. The earlier options
+   discussion (VADistiller emitting the branch / string-form `$limit` /
+   AST pattern-matching) is superseded: the branch is there; only the
+   `iniLim` answer is missing. Today `iniLim` defaults to −1, which routes
+   to a heuristic requiring `analysis("nodeset")` — hardcoded `false` in
+   vasim — so `initialize_limiting()` is always false and the seed never
+   fires. The single wire needed: special-case `"iniLim"` in the
+   `$simparam` handler (`src/vasim.jl:1135-1154`) to emit
+   `Int(ctx.initjct)` — the per-pass flag both context types already carry
+   and `_dc_pcnr_newton` already arms for exactly the first cold pass.
+   The LRM string form `$limit(V(p,n), "pnjlim", vte, vcrit)` (simulator-
+   owned limiter, covered by `limit!`'s own initjct bypass) stays future
+   work — no in-repo model uses it.
 
-1. **VADistiller emits the MODEINITJCT branch it currently drops.** The
-   branch exists in the ngspice C sources the distiller transpiles
-   (`if (CKTmode & MODEINITJCT) vd = vcrit`); emitting it guarded by
-   `$simparam("initjct", 0)` costs one line per junction and Cadnip's
-   `$simparam` plumbing already exists (`MNASpec` fields). Faithful to
-   ngspice, no heuristics. Worth proposing upstream to VADistiller; a local
-   patch to the distilled models is a stopgap.
-2. **VADistiller emits string-form `$limit`** where it recognizes the
-   `DEVpnjlim(vnew, vold, args...)` call pattern — then the simulator owns
-   evaluation point, seeding, and corrector outright (full paper-pure
-   semantics). Partial coverage only: composite limiting like diode.va's
-   breakdown branch (`pnjlim` on `-(vd+bv)`) can't be expressed per-probe.
-3. **AST pattern-matching in Cadnip's codegen** to extract the limiter
-   dataflow between OldGet and NewSet sites: fragile against arbitrary VA
-   between the sites; not recommended.
+2. **Simparam inventory** (grep over all 13 models; every call carries a
+   default, so unmatched names never error):
 
-None of this is "baked into how `$limit` works" — the get/set idiom is a
-VADistiller transpilation convention, not the LRM's intent; the LRM's
-named-function form is simulator-side limiting, i.e. the pilot shape.
+   | simparam (default) | uses | status |
+   |---|---|---|
+   | `tnom`, `gmin`, `reltol`, `vntol`, `abstol` | 64 | resolve against existing `MNASpec` fields |
+   | `scale` (1), `defw`/`defl` (1e-4), `defas`/`defad` (0), `epsmin` | 62 | defaults correct (ngspice defaults) |
+   | `oldlimit` (0) | 12 | default 0 = ngspice `CKTfixLimit` off = modern fetlim+limvds path |
+   | `iteration` (10) | 13 | only read in the `initialize_limiting()` heuristic; dead once `iniLim` answers |
+   | **`iniLim` (−1)** | 13 | **wire to `ctx.initjct`** (above) |
+   | `sourceScaleFactor` (1.0) | 1 | vdmos thermal branch; ngspice's srcFact — optionally map to `_mna_spec_.srcFact` |
+
+3. **Per-branch state, per-site lowering, no OldGet/NewSet classification.**
+   State (limit variable, `vold`, `g_lim` row) is keyed per (instance,
+   probe branch) — allocated hoisted/unconditionally, one slot per branch.
+   Every `$limit` site on that branch lowers uniformly: call its limiter fn
+   as `fn(vnew_dual, vold, user_args...)` via the existing VA-function
+   machinery (`:1206-1237`), `record_limit_w!(extract_value(result))`
+   (last record wins — OldGet's `vold` record is overwritten by NewSet's),
+   return per the dual-semantics choice below. Site counts are OldGet/NewSet
+   pairs everywhere: diode 2/1, bjt 6/3, mos*/bsim3v3/vdmos 8/4, jfet 4/2,
+   bsim4v8 18/9.
+
+#### Jacobian dual semantics — the option space
+
+The design hinge is what dual a `$limit` site returns, because its partials
+become the stamped conductance. The inline `DEVpnjlim` output `w_raw`
+carries chain-ruled partials `∂w/∂V` (≈1 inactive, ≪1 when compressing).
+Coherent (G, RHS-anchor) combinations:
+
+- **Option 1 — chain-ruled (damped) G + probe anchor.** Return `w_raw`
+  as-is. `G = dI/dw·∂w/∂V` is the true composite derivative, so the
+  existing probe-anchored `Ieq` (`:3058-3062`) is already consistent.
+  ~3-line change, no dual widening, no Δb. Cost: hard limiting collapses
+  the stamped conductance → the measured 17-18-iteration cold-start crawl
+  (see the "Measured" notes above). Correct, just slower.
+- **Option 2 — passthrough (undamped) G + w anchor** (ngspice/OSDI
+  `lim_rhs`). Return a fresh dual `Dual(w, ±1 at the probe-node slots)`:
+  `G = dI/dw` full-strength (SPICE's `gd`), i.e. linearization
+  `I ≈ I(w) + G·(V − w)`. The probe-anchored companion is then wrong by a
+  phantom current `G·(V_probe − w)`, so the RHS needs
+  `Δb = Σⱼ (∂I/∂wⱼ)·(V_probe,ⱼ − wⱼ)`. Getting `∂I/∂wⱼ` requires one
+  extra dual slot per site (widen the `JacobianTag` duals from
+  `n_all_nodes` to `W = n_all_nodes + S`; site j's return carries `+1` at
+  slot `n_all_nodes+j`, read only for Δb, never stamped into G) — the node
+  partial is the *sum* of direct-V dependence (series-R path, gmin terms)
+  and through-w dependence, and Δb needs the through-w part isolated. This
+  dual shape mirrors the initjct bypass already inside `limit!`
+  (`devices.jl:1206`). Cross-check against the native diode:
+  `Ieq = I(w) − G·V + G·(V − w) = I(w) − G·w` — exactly
+  `stamp_limited_companion!`.
+- **Option 3 — chain-ruled G + w anchor**: what native `Diode` does today
+  (generic `pnjlim` under AD + `stamp_limited_companion!`); impure but
+  benign — damping only bites far from the solution, and with the initjct
+  seed the limiter is barely active after the first pass; 7 iterations
+  measured on the pilot.
+- Undamped G + probe anchor is the invalid fourth combination (the phantom
+  "18 mA at 0 V" failure in the Measured notes).
+
+**Sequencing: land Option 1 first** (verifies VA limiting end-to-end with
+the PCNR corrector at minimal complexity), **then upgrade to Option 2**
+(dual widening + Δb) with `benchmarks/pcnr` iteration counts as referee.
+The two remain a one-line A/B at the site-return emission — which the
+"damped Jacobian" risk item below explicitly asks to keep.
+
+#### Effort and steps
 
 **Effort assessment**: this is the most delicate file in the repo
 (positional-counter discipline, dual handling, per-branch site grouping
@@ -470,23 +519,51 @@ across a 3.7k-line codegen; BSIM4 has 18 sites/9 branches to validate).
 Multi-session, careful work — not delegable to a quick agent pass. No type
 piracy anywhere: it's all Cadnip-owned codegen and context plumbing.
 
-7. `src/vasim.jl` `$limit` handler (`:1192`): group call sites by probe
-   branch within the module; first site allocates (hoisted, unconditional —
-   same rule as hoisted `get_G_idx!` stamping); emit the OldGet read and the
-   NewSet record per the mapping above, via the existing VA analog-function
-   call machinery (`all_functions`, which already handles the
-   `inout limited` flag).
-8. Integration tests: `test/mna/vadistiller.jl` additions — diode rectifier,
-   the astable BJT case (`test/mna/astable_bjt_test.jl`), MOS sweeps; verify
-   `dc!`/`tran!` results unchanged on already-converging circuits and
-   fallback usage (gmin/source stepping) reduced on the difficult ones.
-9. Benchmarks: `benchmarks/vacask` suite — NR iteration counts and wall-clock
-   vs. VACASK (which runs the same models *with* limiting active), wpd plots
-   for `mul`. This is the acceptance gate: limiting should cut iterations
-   and/or fallback invocations without accuracy regressions.
-   A first cross-method DC benchmark (PCNR vs NewtonRaphson / TrustRegion /
-   RobustMultiNewton / LM / PseudoTransient / `CedarRobustNLSolve` on
-   graetz/mul-style native-Diode topologies) lives in `benchmarks/pcnr/`.
+7. `src/vasim.jl` changes. `MNAScope` (~`:551-575`) gains `limit_branches`
+   (ordered unique probe branches), `limit_sites` (one per site in lowering
+   order) and a `cond_depth` counter (incremented around conditional/loop/
+   case body lowering). The `$limit` handler (replace `:1192-1198`) errors
+   at codegen time for non-`V(p,n)` probes, string-form limiters, unknown
+   fns, or a site under a runtime conditional (`cond_depth > 0` would
+   desync positional counters); otherwise find-or-append the branch, push
+   the site, and emit the uniform lowering above (reusing the VA-function
+   arg-marshalling at `:1206-1237`). `$simparam` gains the `iniLim`
+   special case. Assembly (`generate_mna_stamp_method_nterm`): hoisted
+   limit preamble spliced between `$internal_node_alloc` (`:3426`) and
+   `$instance_stamp_calls` (`:3429`) — per branch: `alloc_limit!(...;
+   init=0.0)` (the vcrit seed comes from the model's own iniLim branch,
+   unlike native `Diode`'s `init=vcrit`), the `vold = _mna_x_[li]` read,
+   and the 3-entry `g_lim` row. For Option 2 additionally: per-site
+   partials constants, widened `dual_creation` (`:3176-3183`), `dIdW/dqdW`
+   extraction in the three `branch_stamp` type branches (`:2907-2948`),
+   and Δb terms in the Ieq (`:3058-3062`), charge-constraint
+   (`:3036-3040`, before the `CHARGE_SCALE` multiply) and two-node voltage
+   (`:3325-3357`) companions. A module with no `$limit` sites generates
+   byte-identical code to today.
+8. Integration tests. `test/mna/pcnr.jl` additions: sp_diode structure
+   detection (5 random-x passes), anchoring unit test against
+   hand-computed `pnjlim` (crafted `x` with `V_probe = 5`,
+   `x_lim = vold = 0.6`), initjct seed test (`limit_w ≈ vcrit`, no phantom
+   current), rectifier/chain3 convergence counts, transient smoke.
+   `test/mna/vadistiller.jl` / `test/mna/vadistiller_integration.jl`
+   regression — audit size-sensitive assertions (system sizes grow by
+   n_limits for every limited model). Validation ladder: diode → bjt
+   (`test/mna/astable_bjt_test.jl`, 3 limit vars/instance) → mos1 (fetlim
+   cross-branch: vds limited using vgs — fine, the `g_lim` row stays
+   3-entry, cross couplings ride the node conductances via AD); bsim4v8
+   compile+DC smoke only (W = n_all_nodes+18 is the compile-pressure worst
+   case; the `noinline` escape hatch at `:3412` exists).
+9. Benchmarks: `benchmarks/pcnr/dc_newton_iterations.jl` gains VA twins of
+   its four circuits (stamping `sp_diode(is=76.9e-12, n=1.45)` directly,
+   pattern per `test/mna/vadistiller_integration.jl:211-221`) alongside
+   the native rows — native `limit=false` remains the unaugmented baseline
+   VA cannot express; the NonlinearSolve methods run on the VA circuits'
+   augmented system (limiter provably inert under correctorless solvers,
+   see "Why every other solver still works"). `benchmarks/vacask` remains
+   the acceptance gate: NR iteration counts and wall-clock vs. VACASK
+   (which runs the same models *with* limiting active), wpd plots for
+   `mul` — limiting should cut iterations and/or fallback invocations
+   without accuracy regressions.
 
 ### Phase 3 (optional, evidence-driven): explicit corrector + full coupling
 

--- a/doc/pcnr_plan.md
+++ b/doc/pcnr_plan.md
@@ -429,19 +429,23 @@ ngspice.
 
 #### Verified facts that reshape the earlier sketch
 
-1. **initjct needs no model patches and no upstream ask.** All 13 limited
-   models already ship `initialize_limiting()` *with* the MODEINITJCT
+1. **initjct seeding is deferred (measured: it must wait for Option 2).**
+   All 13 limited models ship `initialize_limiting()` *with* the MODEINITJCT
    vcrit-seed branch emitted (e.g. `diode.va:367-381` and the seed at
-   `:738-740`), gated on `$simparam("iniLim", -1)`. The earlier options
-   discussion (VADistiller emitting the branch / string-form `$limit` /
-   AST pattern-matching) is superseded: the branch is there; only the
-   `iniLim` answer is missing. Today `iniLim` defaults to −1, which routes
-   to a heuristic requiring `analysis("nodeset")` — hardcoded `false` in
-   vasim — so `initialize_limiting()` is always false and the seed never
-   fires. The single wire needed: special-case `"iniLim"` in the
-   `$simparam` handler (`src/vasim.jl:1135-1154`) to emit
-   `Int(ctx.initjct)` — the per-pass flag both context types already carry
-   and `_dc_pcnr_newton` already arms for exactly the first cold pass.
+   `:738-740`), gated on `$simparam("iniLim", -1)`, so no model patch or
+   upstream ask is needed to *reach* the seed. But the seed as the models
+   write it is `load_vd = DIOtVcrit` — a plain constant assignment that
+   **drops the AD partials**. Under Option 1 (below), the device then stamps
+   *zero* conductance on the seeded pass, which is singular for
+   series-junction topologies (the 3-diode chain floats its internal nodes).
+   Native `limit!` avoids this because its bypass seeds while *keeping*
+   passthrough partials (`vnew − value(vnew) + init`, `devices.jl:1206`);
+   reproducing that for VA models needs the w-anchored dual the site builds
+   in Option 2, not the model's own constant seed. So the Option 1 impl
+   leaves `$simparam("iniLim")` returning **0** (special-cased in the
+   `$simparam` handler at `src/vasim.jl:1135-1154`, seed off) and takes the
+   honest cold-start limiter crawl instead. Wiring `iniLim` to `ctx.initjct`
+   becomes correct once Option 2's passthrough-dual return is in place.
    The LRM string form `$limit(V(p,n), "pnjlim", vte, vcrit)` (simulator-
    owned limiter, covered by `limit!`'s own initjct bypass) stays future
    work — no in-repo model uses it.
@@ -454,8 +458,8 @@ ngspice.
    | `tnom`, `gmin`, `reltol`, `vntol`, `abstol` | 64 | resolve against existing `MNASpec` fields |
    | `scale` (1), `defw`/`defl` (1e-4), `defas`/`defad` (0), `epsmin` | 62 | defaults correct (ngspice defaults) |
    | `oldlimit` (0) | 12 | default 0 = ngspice `CKTfixLimit` off = modern fetlim+limvds path |
-   | `iteration` (10) | 13 | only read in the `initialize_limiting()` heuristic; dead once `iniLim` answers |
-   | **`iniLim` (−1)** | 13 | **wire to `ctx.initjct`** (above) |
+   | `iteration` (10) | 13 | only read in the `initialize_limiting()` heuristic; dead while `iniLim` returns 0 |
+   | **`iniLim` (−1)** | 13 | special-cased to **0** for now (seed off); wire to `ctx.initjct` in Option 2 (above) |
    | `sourceScaleFactor` (1.0) | 1 | vdmos thermal branch; ngspice's srcFact — optionally map to `_mna_spec_.srcFact` |
 
 3. **Per-branch state, per-site lowering, no OldGet/NewSet classification.**

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -200,7 +200,8 @@ function make_mna_device(vm::VANode{VerilogModule}; noinline::Union{Bool,Nothing
         Dict{Symbol, Tuple{Int, Vector{Symbol}}}(),
         Dict{Symbol, Symbol}(:V => :potential, :I => :flow),
         Expr[], Any[], Symbol[], Set{Pair{Symbol,Symbol}}(),
-        Expr[], Dict{Tuple{String,Int,Tuple{Vararg{Char}},Char}, Symbol}(), Dict{String, Any}())
+        Expr[], Dict{Tuple{String,Int,Tuple{Vararg{Char}},Char}, Symbol}(), Dict{String, Any}(),
+        Tuple{Symbol,Symbol}[], Ref(0))
 
     internal_nodes = Vector{Symbol}()
     var_types = Dict{Symbol, Union{Type{Int}, Type{Float64}, Type{String}}}()
@@ -319,7 +320,8 @@ function make_mna_device(vm::VANode{VerilogModule}; noinline::Union{Bool,Nothing
         named_branches, nothing,
         array_nodes, access_map,
         Expr[], Any[], Symbol[], Set{Pair{Symbol,Symbol}}(),
-        Expr[], Dict{Tuple{String,Int,Tuple{Vararg{Char}},Char}, Symbol}(), Dict{String, Any}())
+        Expr[], Dict{Tuple{String,Int,Tuple{Vararg{Char}},Char}, Symbol}(), Dict{String, Any}(),
+        Tuple{Symbol,Symbol}[], Ref(0))
 
     # Generate analog block code
     analog_body = Expr(:block)
@@ -572,6 +574,13 @@ struct MNAScope
     extra_module_stmts::Vector{Expr}
     table_itp_consts::Dict{Tuple{String,Int,Tuple{Vararg{Char}},Char}, Symbol}
     table_files::Dict{String, Any}  # abspath -> parsed _TableData{D}
+    # PCNR `$limit` support. Populated during analog-block lowering, consumed
+    # by generate_mna_stamp_method_nterm. Each unique probe branch (p, n) gets
+    # one limiting variable; `$limit` sites on the same branch share it. Shared
+    # by reference across scope copies so pushes during lowering are visible at
+    # assembly time.
+    limit_branches::Vector{Tuple{Symbol,Symbol}}
+    cond_depth::Base.RefValue{Int}  # runtime-conditional nesting; `$limit` sites must be at depth 0
 end
 
 """Create a copy of the scope with delay_expr set for absdelay rewriting."""
@@ -580,7 +589,8 @@ with_delay(s::MNAScope, delay_jl) = MNAScope(
     s.used_branches, s.var_types, s.all_functions, s.undefault_ids,
     s.ddx_order, s.named_branches, delay_jl,
     s.array_nodes, s.access_map, s.extra_stamps, s.extra_stamps_b, s.extra_internal_nodes, s.current_probes,
-    s.extra_module_stmts, s.table_itp_consts, s.table_files)
+    s.extra_module_stmts, s.table_itp_consts, s.table_files,
+    s.limit_branches, s.cond_depth)
 
 """
     resolve_array_ref(scope, node_expr) -> Symbol
@@ -1140,6 +1150,17 @@ function (to_julia::MNAScope)(stmt::VANode{FunctionCall})
             param_str = String(stmt.args[1].item)
         end
         param_sym = Symbol(param_str)
+        if param_str == "iniLim"
+            # ngspice MODEINITJCT signal. Left at 0 (seed off) for now: the
+            # VADistiller models' seed branch assigns `load_vd = vcrit` as a
+            # plain constant, which drops the AD partials and makes every
+            # junction stamp zero conductance on the seeded pass — singular for
+            # series-junction topologies. Native `limit!` seeds while preserving
+            # passthrough partials; matching that for VA models needs the
+            # w-anchored dual machinery (Option 2), so seeding is deferred to
+            # there. Returning 0 gives the honest cold-start limiter crawl.
+            return 0
+        end
         if length(stmt.args) == 1
             # No default - error if not found
             return :(hasproperty(_mna_spec_, $(QuoteNode(param_sym))) ?
@@ -1190,12 +1211,68 @@ function (to_julia::MNAScope)(stmt::VANode{FunctionCall})
             return false
         end
     elseif fname == Symbol("\$limit")
-        # $limit(voltage, limiter_fn, ...) - voltage limiting for Newton convergence
-        # In our MNA implementation, we can optionally apply limiting or just return the voltage
-        # For now, we simply return the voltage value without limiting
-        # This allows the model to run, though convergence may be slower
-        voltage_expr = to_julia(stmt.args[1].item)
-        return voltage_expr
+        # $limit(V(p,n), limiter_fn, user_args...) — PCNR Newton voltage limiting.
+        #
+        # Per the Verilog-AMS LRM the simulator prepends (vnew, vold) to the
+        # user arguments, where `vold` is the branch's limiting variable (the
+        # voltage the device evaluated at last iteration, x[ℓ]). The model's
+        # own limiter (DEVlimitOldGet/NewSet, wrapping DEVpnjlim/fetlim) then
+        # computes the value the device actually uses; we record it as the
+        # PCNR corrector target and return it.
+        #
+        # State is keyed per (instance, probe branch): one limiting variable
+        # shared across all `$limit` sites on that branch. The variable is
+        # allocated, its `vold` read, and its linear g_lim tracking row stamped
+        # by the hoisted preamble in generate_mna_stamp_method_nterm; here we
+        # only reference the per-branch locals it binds (_mna_lidx_<b>,
+        # _mna_vold_<b>).
+        length(stmt.args) >= 2 || return Expr(:call, error, "\$limit requires at least 2 arguments")
+        probe = stmt.args[1].item
+        if !(probe isa VANode{FunctionCall} &&
+             get(to_julia.access_map, Symbol(probe.id), nothing) == :potential &&
+             length(probe.args) in (1, 2))
+            return Expr(:call, error, "\$limit: first argument must be a potential probe V(p[,n])")
+        end
+        to_julia.cond_depth[] == 0 ||
+            return Expr(:call, error, "\$limit under a runtime conditional is unsupported (would desync stamping counters)")
+        limiter = stmt.args[2].item
+        limiter isa VANode{StringLiteral} &&
+            return Expr(:call, error, "\$limit string-form limiter is not yet supported; use the function-reference form")
+        limiter_fn = Symbol(limiter)
+        haskey(to_julia.all_functions, limiter_fn) ||
+            return Expr(:call, error, "\$limit: unknown limiter function $limiter_fn")
+
+        # Resolve the probe to a (p, n) node pair, mirroring the V() handler:
+        # V(p,n) → (p,n); V(br) with br a named branch → its nodes; V(p) → (p, gnd).
+        id1 = resolve_array_ref(to_julia, probe.args[1].item)
+        if length(probe.args) == 1 && haskey(to_julia.named_branches, id1)
+            bn = to_julia.named_branches[id1]
+            p_sym, n_sym = bn.first, bn.second
+        elseif length(probe.args) == 1
+            p_sym, n_sym = id1, Symbol("0")
+        else
+            p_sym = id1
+            n_sym = resolve_array_ref(to_julia, probe.args[2].item)
+        end
+        branch = (p_sym, n_sym)
+        b = findfirst(==(branch), to_julia.limit_branches)
+        if b === nothing
+            push!(to_julia.limit_branches, branch)
+            b = length(to_julia.limit_branches)
+        end
+
+        vnew_expr = to_julia(probe)  # dual (p - n), identity partials on the probe nodes
+        vold_sym = Symbol("_mna_vold_", b)
+        lidx_sym = Symbol("_mna_lidx_", b)
+        # stmt.args is a NodeList (integer indexing only, no range slicing).
+        user_args = Any[to_julia(stmt.args[i].item) for i in 3:length(stmt.args)]
+        fn_call = Expr(:call, limiter_fn, vnew_expr, vold_sym, user_args...)
+        return quote
+            let _mna_limres = $fn_call
+                Cadnip.MNA.record_limit_w!(ctx, $lidx_sym, Cadnip.MNA.extract_value(_mna_limres))
+                _mna_limres
+            end
+        end
     end
 
     # Noise functions - return 0 in MNA (noise not simulated in DC/transient)
@@ -1987,6 +2064,10 @@ function hoist_conditional_stamps(ifex::Expr)
 end
 
 function (to_julia::MNAScope)(stmt::VANode{AnalogConditionalBlock})
+    # `$limit` sites nested under a runtime conditional would desync the
+    # positional stamping counters; track depth so the handler can reject them.
+    to_julia.cond_depth[] += 1
+    try
     aif = stmt.aif
     function if_body_to_julia(ifstmt)
         if formof(ifstmt) == AnalogSeqBlock
@@ -2021,6 +2102,9 @@ function (to_julia::MNAScope)(stmt::VANode{AnalogConditionalBlock})
         return ifex
     else
         return Expr(:block, hoisted_exprs..., transformed_ifex)
+    end
+    finally
+        to_julia.cond_depth[] -= 1
     end
 end
 
@@ -2077,26 +2161,41 @@ end
 
 # Handle analog for loops
 function (to_julia::MNAScope)(stmt::VANode{AnalogFor})
-    body = to_julia(stmt.stmt)
-    push!(body.args, to_julia(stmt.update_stmt))
-    # Convert VA condition to boolean
-    cond = :(!(iszero($(to_julia(stmt.cond_expr)))))
-    while_expr = Expr(:while, cond, body)
-    Expr(:block, to_julia(stmt.init_stmt), while_expr)
+    to_julia.cond_depth[] += 1
+    try
+        body = to_julia(stmt.stmt)
+        push!(body.args, to_julia(stmt.update_stmt))
+        # Convert VA condition to boolean
+        cond = :(!(iszero($(to_julia(stmt.cond_expr)))))
+        while_expr = Expr(:while, cond, body)
+        Expr(:block, to_julia(stmt.init_stmt), while_expr)
+    finally
+        to_julia.cond_depth[] -= 1
+    end
 end
 
 # Handle analog while loops
 function (to_julia::MNAScope)(stmt::VANode{AnalogWhile})
-    body = to_julia(stmt.stmt)
-    # Convert VA condition to boolean
-    cond = :(!(iszero($(to_julia(stmt.cond_expr)))))
-    Expr(:while, cond, body)
+    to_julia.cond_depth[] += 1
+    try
+        body = to_julia(stmt.stmt)
+        # Convert VA condition to boolean
+        cond = :(!(iszero($(to_julia(stmt.cond_expr)))))
+        Expr(:while, cond, body)
+    finally
+        to_julia.cond_depth[] -= 1
+    end
 end
 
 # Handle analog repeat loops
 function (to_julia::MNAScope)(stmt::VANode{AnalogRepeat})
-    body = to_julia(stmt.stmt)
-    Expr(:for, :(_ = 1:$(stmt.num_repeat)), body)
+    to_julia.cond_depth[] += 1
+    try
+        body = to_julia(stmt.stmt)
+        Expr(:for, :(_ = 1:$(stmt.num_repeat)), body)
+    finally
+        to_julia.cond_depth[] -= 1
+    end
 end
 
 # Handle contribution statements inside conditionals
@@ -2303,6 +2402,8 @@ end
 
 # Handle case statements
 function (to_julia::MNAScope)(stmt::VANode{CaseStatement})
+    to_julia.cond_depth[] += 1
+    try
     s = gensym()
     first = true
     expr = nothing
@@ -2328,6 +2429,9 @@ function (to_julia::MNAScope)(stmt::VANode{CaseStatement})
     end
     default_case !== nothing && push!(expr.args, default_case)
     Expr(:block, :($s = $(to_julia(stmt.switch))), expr)
+    finally
+        to_julia.cond_depth[] -= 1
+    end
 end
 
 function (to_julia::MNAScope)(fd::VANode{AnalogFunctionDeclaration})
@@ -2371,7 +2475,8 @@ function (to_julia::MNAScope)(fd::VANode{AnalogFunctionDeclaration})
         to_julia.named_branches, nothing,
         to_julia.array_nodes, to_julia.access_map,
         to_julia.extra_stamps, to_julia.extra_stamps_b, to_julia.extra_internal_nodes, to_julia.current_probes,
-        to_julia.extra_module_stmts, to_julia.table_itp_consts, to_julia.table_files)
+        to_julia.extra_module_stmts, to_julia.table_itp_consts, to_julia.table_files,
+        to_julia.limit_branches, to_julia.cond_depth)
 
     in_args = [k for k in arg_order if inout_decls[k] in (:input, :inout)]
     out_args = [k for k in arg_order if inout_decls[k] in (:output, :inout)]
@@ -2727,6 +2832,39 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
     # All node symbols for dual creation (terminals + internal)
     all_node_syms = [port_args; internal_nodes]
     all_node_params = [node_params; internal_node_params]
+
+    # PCNR `$limit` preamble. One limiting variable per unique probe branch
+    # collected during lowering (to_julia.limit_branches). For each branch we
+    # allocate the variable (hoisted + unconditional so DirectStampContext's
+    # positional counters stay in sync across passes), read its `vold` from the
+    # solution vector, and stamp the linear tracking row g_lim = x_lim − (V_p −
+    # V_n) = 0. The `$limit` sites (lowered into contrib_eval) reference the
+    # per-branch _mna_lidx_<b> / _mna_vold_<b> locals bound here.
+    map_node_param(sym) = sym == Symbol("0") ? 0 : begin
+        idx = findfirst(==(sym), all_node_syms)
+        idx === nothing && error("\$limit probe node $sym not a terminal or internal node of the module")
+        all_node_params[idx]
+    end
+    limit_preamble = Expr(:block)
+    for (b, (p_sym, n_sym)) in enumerate(to_julia.limit_branches)
+        p_param = map_node_param(p_sym)
+        n_param = map_node_param(n_sym)
+        lidx_sym = Symbol("_mna_lidx_", b)
+        li_sym = Symbol("_mna_li_", b)
+        vold_sym = Symbol("_mna_vold_", b)
+        lim_name = QuoteNode(Symbol(symname, "_lim_", p_sym, "_", n_sym))
+        # stamp_G! skips ground (col 0) internally on both context types, before
+        # touching DirectStampContext's positional counter, so unconditional
+        # calls stay counter-consistent — matching the native limit! primitive.
+        push!(limit_preamble.args, quote
+            $lidx_sym = Cadnip.MNA.alloc_limit!(ctx, $lim_name, _mna_instance_, $p_param, $n_param; init=0.0)
+            $li_sym = Cadnip.MNA.resolve_index(ctx, $lidx_sym)
+            $vold_sym = Cadnip.MNA.extract_value(_mna_x_[$li_sym])
+            Cadnip.MNA.stamp_G!(ctx, $lidx_sym, $lidx_sym, 1.0)
+            Cadnip.MNA.stamp_G!(ctx, $lidx_sym, $p_param, -1.0)
+            Cadnip.MNA.stamp_G!(ctx, $lidx_sym, $n_param, 1.0)
+        end)
+    end
 
     # Split into two blocks:
     # 1. local_var_init: Variable initialization (before internal_node_alloc)
@@ -3424,6 +3562,11 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
 
         # Allocate internal nodes (idempotent - returns existing index if already allocated)
         $internal_node_alloc
+
+        # PCNR `$limit`: allocate limiting variables, read vold, stamp g_lim rows.
+        # After internal_node_alloc (probes may reference internal nodes) and at a
+        # fixed position for positional-counter discipline.
+        $limit_preamble
 
         # Stamp child module instances (module instantiation)
         $instance_stamp_calls

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -2859,7 +2859,14 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
         push!(limit_preamble.args, quote
             $lidx_sym = Cadnip.MNA.alloc_limit!(ctx, $lim_name, _mna_instance_, $p_param, $n_param; init=0.0)
             $li_sym = Cadnip.MNA.resolve_index(ctx, $lidx_sym)
-            $vold_sym = Cadnip.MNA.extract_value(_mna_x_[$li_sym])
+            # vold read tolerant of a short x: ZERO_VECTOR (structure discovery)
+            # and the intermediate detection passes in build_with_detection pass
+            # an x sized to a *prior* system, and voltage-dependent charge
+            # detection (e.g. a junction cap) grows n_charges between passes,
+            # shifting limit indices past that x. vold only affects the limited
+            # evaluation value, never the (branch-free) stamp structure, so 0.0
+            # is correct whenever x can't supply it.
+            $vold_sym = $li_sym <= length(_mna_x_) ? Cadnip.MNA.extract_value(_mna_x_[$li_sym]) : 0.0
             Cadnip.MNA.stamp_G!(ctx, $lidx_sym, $lidx_sym, 1.0)
             Cadnip.MNA.stamp_G!(ctx, $lidx_sym, $p_param, -1.0)
             Cadnip.MNA.stamp_G!(ctx, $lidx_sym, $n_param, 1.0)

--- a/src/vasim.jl
+++ b/src/vasim.jl
@@ -201,7 +201,7 @@ function make_mna_device(vm::VANode{VerilogModule}; noinline::Union{Bool,Nothing
         Dict{Symbol, Symbol}(:V => :potential, :I => :flow),
         Expr[], Any[], Symbol[], Set{Pair{Symbol,Symbol}}(),
         Expr[], Dict{Tuple{String,Int,Tuple{Vararg{Char}},Char}, Symbol}(), Dict{String, Any}(),
-        Tuple{Symbol,Symbol}[], Ref(0))
+        Tuple{Symbol,Symbol}[], Ref(0), Tuple{Symbol,Symbol}[])
 
     internal_nodes = Vector{Symbol}()
     var_types = Dict{Symbol, Union{Type{Int}, Type{Float64}, Type{String}}}()
@@ -321,7 +321,7 @@ function make_mna_device(vm::VANode{VerilogModule}; noinline::Union{Bool,Nothing
         array_nodes, access_map,
         Expr[], Any[], Symbol[], Set{Pair{Symbol,Symbol}}(),
         Expr[], Dict{Tuple{String,Int,Tuple{Vararg{Char}},Char}, Symbol}(), Dict{String, Any}(),
-        Tuple{Symbol,Symbol}[], Ref(0))
+        Tuple{Symbol,Symbol}[], Ref(0), Tuple{Symbol,Symbol}[])
 
     # Generate analog block code
     analog_body = Expr(:block)
@@ -581,6 +581,10 @@ struct MNAScope
     # assembly time.
     limit_branches::Vector{Tuple{Symbol,Symbol}}
     cond_depth::Base.RefValue{Int}  # runtime-conditional nesting; `$limit` sites must be at depth 0
+    # One entry per `$limit` call site (its probe branch), index = site j. Each
+    # site gets an extra JacobianTag dual slot (n_all_nodes+j) so its ∂I/∂w can
+    # be isolated for the OSDI `lim_rhs` companion anchoring (Option 2).
+    limit_sites::Vector{Tuple{Symbol,Symbol}}
 end
 
 """Create a copy of the scope with delay_expr set for absdelay rewriting."""
@@ -590,7 +594,7 @@ with_delay(s::MNAScope, delay_jl) = MNAScope(
     s.ddx_order, s.named_branches, delay_jl,
     s.array_nodes, s.access_map, s.extra_stamps, s.extra_stamps_b, s.extra_internal_nodes, s.current_probes,
     s.extra_module_stmts, s.table_itp_consts, s.table_files,
-    s.limit_branches, s.cond_depth)
+    s.limit_branches, s.cond_depth, s.limit_sites)
 
 """
     resolve_array_ref(scope, node_expr) -> Symbol
@@ -1151,15 +1155,14 @@ function (to_julia::MNAScope)(stmt::VANode{FunctionCall})
         end
         param_sym = Symbol(param_str)
         if param_str == "iniLim"
-            # ngspice MODEINITJCT signal. Left at 0 (seed off) for now: the
-            # VADistiller models' seed branch assigns `load_vd = vcrit` as a
-            # plain constant, which drops the AD partials and makes every
-            # junction stamp zero conductance on the seeded pass — singular for
-            # series-junction topologies. Native `limit!` seeds while preserving
-            # passthrough partials; matching that for VA models needs the
-            # w-anchored dual machinery (Option 2), so seeding is deferred to
-            # there. Returning 0 gives the honest cold-start limiter crawl.
-            return 0
+            # ngspice MODEINITJCT signal. The VADistiller models gate their
+            # vcrit-seed branch (initialize_limiting()) on this; wire it to the
+            # per-pass initjct flag the PCNR loop arms for the first cold pass.
+            # Safe now that the `$limit` return is a passthrough dual: even
+            # though the model's seed assigns `load_vd = vcrit` as a constant,
+            # the NewSet site rebuilds it as Dual(vcrit, passthrough), so the
+            # junction still stamps conductance at vcrit (no singular matrix).
+            return :(Int(ctx.initjct))
         end
         if length(stmt.args) == 1
             # No default - error if not found
@@ -1261,17 +1264,32 @@ function (to_julia::MNAScope)(stmt::VANode{FunctionCall})
             b = length(to_julia.limit_branches)
         end
 
+        # Register this call site (index j); it owns an extra dual slot so its
+        # ∂I/∂w can be isolated for the lim_rhs companion anchoring below.
+        push!(to_julia.limit_sites, (p_sym, n_sym))
+        j = length(to_julia.limit_sites)
+
         vnew_expr = to_julia(probe)  # dual (p - n), identity partials on the probe nodes
         vold_sym = Symbol("_mna_vold_", b)
         lidx_sym = Symbol("_mna_lidx_", b)
+        w_sym = Symbol("_mna_limw_", j)        # recorded value, reused in the Ieq Δb term
+        seed_sym = Symbol("_mna_limseed_", j)  # Dual(0, e_j), bound by the preamble
         # stmt.args is a NodeList (integer indexing only, no range slicing).
         user_args = Any[to_julia(stmt.args[i].item) for i in 3:length(stmt.args)]
         fn_call = Expr(:call, limiter_fn, vnew_expr, vold_sym, user_args...)
+        # Return a fresh *passthrough* (undamped) dual anchored at w: value = w,
+        # ∂/∂V_p = +1, ∂/∂V_n = -1 (carried from the probe), plus a unit partial
+        # in this site's own slot j. The model's inline limiter (DEVpnjlim) ran
+        # chain-ruled under AD; we discard those damped partials here — the
+        # undamped conductance G(w) at the node positions is ngspice/OSDI's
+        # convention, and the site slot lets the companion re-anchor at w (the
+        # `Δb` correction in generate_mna_stamp_method_nterm). Mirrors limit!'s
+        # initjct bypass (`vnew - value(vnew) + init`), so the model's own
+        # constant vcrit seed is repaired to a conductance-carrying dual too.
         return quote
-            let _mna_limres = $fn_call
-                Cadnip.MNA.record_limit_w!(ctx, $lidx_sym, Cadnip.MNA.extract_value(_mna_limres))
-                _mna_limres
-            end
+            $w_sym = Cadnip.MNA.extract_value($fn_call)
+            Cadnip.MNA.record_limit_w!(ctx, $lidx_sym, $w_sym)
+            $vnew_expr - Cadnip.MNA.extract_value($vnew_expr) + $w_sym + $seed_sym
         end
     end
 
@@ -2476,7 +2494,7 @@ function (to_julia::MNAScope)(fd::VANode{AnalogFunctionDeclaration})
         to_julia.array_nodes, to_julia.access_map,
         to_julia.extra_stamps, to_julia.extra_stamps_b, to_julia.extra_internal_nodes, to_julia.current_probes,
         to_julia.extra_module_stmts, to_julia.table_itp_consts, to_julia.table_files,
-        to_julia.limit_branches, to_julia.cond_depth)
+        to_julia.limit_branches, to_julia.cond_depth, to_julia.limit_sites)
 
     in_args = [k for k in arg_order if inout_decls[k] in (:input, :inout)]
     out_args = [k for k in arg_order if inout_decls[k] in (:output, :inout)]
@@ -2793,6 +2811,25 @@ function mna_translate_contribution(to_julia::MNAScope, cs::VANode{ContributionS
 end
 
 """
+    limit_rhs_terms(to_julia, all_node_syms, prefix) -> [(dw_sym, delta_expr), ...]
+
+Per-`\$limit`-site pieces of the OSDI `lim_rhs` companion correction. For site
+`j` with probe branch `(p, n)`, returns the extracted partial symbol
+`<prefix>j` (e.g. `dI_dW3`) paired with the anchor delta `(V_p − V_n − wⱼ)` as
+Float64 node-voltage locals. Empty when the module has no `\$limit` sites.
+"""
+function limit_rhs_terms(to_julia::MNAScope, all_node_syms, prefix::Symbol)
+    map(1:length(to_julia.limit_sites)) do j
+        (p_sym, n_sym) = to_julia.limit_sites[j]
+        pidx = p_sym == Symbol("0") ? nothing : findfirst(==(p_sym), all_node_syms)
+        nidx = n_sym == Symbol("0") ? nothing : findfirst(==(n_sym), all_node_syms)
+        vp = pidx === nothing ? 0.0 : Symbol("V_", pidx)
+        vn = nidx === nothing ? 0.0 : Symbol("V_", nidx)
+        (Symbol(prefix, j), :($vp - $vn - $(Symbol("_mna_limw_", j))))
+    end
+end
+
+"""
 Generate stamp! method for n-terminal device (potentially with internal nodes).
 
 For n-terminal devices with internal nodes, we use a vector-valued dual approach:
@@ -2833,6 +2870,13 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
     all_node_syms = [port_args; internal_nodes]
     all_node_params = [node_params; internal_node_params]
 
+    # PCNR `$limit` dual layout: the JacobianTag duals carry n_all_nodes node
+    # partials plus one extra slot per `$limit` call site (S of them), so each
+    # site's ∂I/∂w is isolable for lim_rhs anchoring. Width W == n_all_nodes when
+    # the module has no `$limit` sites, so non-limited codegen is unchanged.
+    n_limit_sites = length(to_julia.limit_sites)
+    dual_width = n_all_nodes + n_limit_sites
+
     # PCNR `$limit` preamble. One limiting variable per unique probe branch
     # collected during lowering (to_julia.limit_branches). For each branch we
     # allocate the variable (hoisted + unconditional so DirectStampContext's
@@ -2871,6 +2915,14 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
             Cadnip.MNA.stamp_G!(ctx, $lidx_sym, $p_param, -1.0)
             Cadnip.MNA.stamp_G!(ctx, $lidx_sym, $n_param, 1.0)
         end)
+    end
+    # Per-site unit dual for the site's own slot (n_all_nodes+j): the `$limit`
+    # handler adds this to the probe dual to build the passthrough return.
+    for j in 1:n_limit_sites
+        seed_partials = Expr(:tuple, [k == n_all_nodes + j ? 1.0 : 0.0 for k in 1:dual_width]...)
+        push!(limit_preamble.args,
+            :($(Symbol("_mna_limseed_", j)) =
+                ForwardDiff.Dual{Cadnip.MNA.JacobianTag}(0.0, $seed_partials...)))
     end
 
     # Split into two blocks:
@@ -3067,10 +3119,13 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
                 # Extract resistive values (JacobianTag partials are plain floats)
                 I_val = ForwardDiff.value(I_resist)
                 $([:($(Symbol("dI_dV", k)) = ForwardDiff.partials(I_resist, $k)) for k in 1:n_all_nodes]...)
+                # Per-`$limit`-site ∂I/∂w and ∂q/∂w (undamped, from the site slots).
+                $([:($(Symbol("dI_dW", j)) = ForwardDiff.partials(I_resist, $(n_all_nodes + j))) for j in 1:n_limit_sites]...)
 
                 # Extract charge value and capacitances
                 q_val = ForwardDiff.value(I_react)
                 $([:($(Symbol("dq_dV", k)) = ForwardDiff.partials(I_react, $k)) for k in 1:n_all_nodes]...)
+                $([:($(Symbol("dq_dW", j)) = ForwardDiff.partials(I_react, $(n_all_nodes + j))) for j in 1:n_limit_sites]...)
 
                 has_reactive = true
 
@@ -3078,16 +3133,20 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
                 # Pure resistive: just JacobianTag dual, no ContributionTag
                 I_val = ForwardDiff.value(I_branch)
                 $([:($(Symbol("dI_dV", k)) = ForwardDiff.partials(I_branch, $k)) for k in 1:n_all_nodes]...)
+                $([:($(Symbol("dI_dW", j)) = ForwardDiff.partials(I_branch, $(n_all_nodes + j))) for j in 1:n_limit_sites]...)
                 q_val = 0.0
                 $([:($(Symbol("dq_dV", k)) = 0.0) for k in 1:n_all_nodes]...)
+                $([:($(Symbol("dq_dW", j)) = 0.0) for j in 1:n_limit_sites]...)
                 has_reactive = false
 
             else
                 # Scalar result (constant contribution)
                 I_val = Float64(I_branch)
                 $([:($(Symbol("dI_dV", k)) = 0.0) for k in 1:n_all_nodes]...)
+                $([:($(Symbol("dI_dW", j)) = 0.0) for j in 1:n_limit_sites]...)
                 q_val = 0.0
                 $([:($(Symbol("dq_dV", k)) = 0.0) for k in 1:n_all_nodes]...)
+                $([:($(Symbol("dq_dW", j)) = 0.0) for j in 1:n_limit_sites]...)
                 has_reactive = false
             end
         end
@@ -3182,6 +3241,10 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
                     $([quote
                         _b_constraint -= $(Symbol("dq_dV", k)) * $(Symbol("V_", k))  # - dQ/dV_k * V_k
                     end for k in 1:n_all_nodes]...)
+                    # lim_rhs anchoring for the charge companion (same as Ieq): the
+                    # junction charge was evaluated at w, so re-anchor there.
+                    $([:(_b_constraint += $dw * $delta)
+                       for (dw, delta) in limit_rhs_terms(to_julia, all_node_syms, :dq_dW)]...)
                     Cadnip.MNA.stamp_b!(ctx, _q_idx, Cadnip.MNA.CHARGE_SCALE * _b_constraint)
                 else
                     # Linear capacitor: use standard C matrix stamping
@@ -3203,6 +3266,14 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
         ieq_terms = Any[:I_val]
         for k in 1:n_all_nodes
             push!(ieq_terms, :(- $(Symbol("dI_dV", k)) * $(Symbol("V_", k))))
+        end
+        # lim_rhs anchoring: with passthrough duals the companion is linearized
+        # at the probe voltage, but the device evaluated at w. Re-anchor at w by
+        # adding Σⱼ ∂I/∂wⱼ · (V_probe,j − wⱼ). ∂I/∂wⱼ is 0 for sites this branch
+        # doesn't depend on, and the whole term → 0 at convergence (w = V_probe),
+        # so the fixed point is unchanged — only the Newton path is corrected.
+        for (dw, delta) in limit_rhs_terms(to_julia, all_node_syms, :dI_dW)
+            push!(ieq_terms, :($dw * $delta))
         end
         ieq_expr = Expr(:call, :+, ieq_terms...)
 
@@ -3321,8 +3392,11 @@ function generate_mna_stamp_method_nterm(symname, ps, port_args, internal_nodes,
     dual_creation = Expr(:block)
     for i in 1:n_all_nodes
         node_sym = all_node_syms[i]
-        # Create JacobianTag dual with identity partials for ddx() support
-        partials = Expr(:tuple, [k == i ? 1.0 : 0.0 for k in 1:n_all_nodes]...)
+        # Create JacobianTag dual with identity partials for ddx() support.
+        # Width is dual_width (n_all_nodes + one slot per `$limit` site); the
+        # site slots are zero for node duals and carry the passthrough unit in
+        # the `$limit` handler's return (see limit_preamble seeds).
+        partials = Expr(:tuple, [k == i ? 1.0 : 0.0 for k in 1:dual_width]...)
         push!(dual_creation.args,
             :($node_sym = ForwardDiff.Dual{Cadnip.MNA.JacobianTag}($(Symbol("V_", i)), $partials...)))
     end

--- a/test/mna/vadistiller_integration.jl
+++ b/test/mna/vadistiller_integration.jl
@@ -146,6 +146,34 @@ D2 n2 n3 dlc
 D3 n3 0 dlc
 """i
 
+# Darlington pair (NPN): Q1's emitter drives Q2's base, so the Vbe drops stack
+# and the current gains multiply — the BJT analog of the diode chain, and a
+# genuinely stiff convergence case (nanoamp base current, milliamp output). Each
+# sp_bjt contributes three limited junctions (vbe, vbc, vsub), so this exercises
+# the multi-branch `$limit` path the lim_rhs anchoring is really about.
+const darlington = sp"""
+* NPN Darlington pair — chained exponentials
+.model qn npn bf=100 is=1e-15
+Vcc vcc 0 DC 5
+Vin in 0 DC 3
+Rb in b 10k
+Q1 vcc b mid qn
+Q2 vcc mid out qn
+Rl out 0 1k
+"""i
+
+# Drive a builder through the PCNR limiting loop directly and report its
+# iteration count — the convergence measurement the correctness tests don't make.
+function pcnr_converge(builder; abstol=1e-8, maxiters=200)
+    spec = MNASpec(mode=:dcop)
+    ctx = Cadnip.MNA._detect_structure(builder, (;), spec)
+    cs = Cadnip.MNA.compile_structure(builder, (;), spec; ctx=ctx)
+    ws = Cadnip.MNA.create_workspace(cs; ctx=ctx)
+    n = Cadnip.MNA.system_size(ctx)
+    u, ok, iters = Cadnip.MNA._dc_pcnr_newton(cs, ws, zeros(n); abstol=abstol, maxiters=maxiters)
+    return (u=u, converged=ok, iters=iters, n_limits=ctx.n_limits)
+end
+
 @testset "VADistiller Integration Tests" begin
 
     #==========================================================================#
@@ -274,6 +302,21 @@ D3 n3 0 dlc
                 # Three forward-biased junctions in series from n1 to ground; each
                 # drops ~0.7-0.8 V, so n1 sits near 2.0-2.5 V and R1 takes the rest.
                 @test 1.8 < sol[:n1] < 2.7
+            end
+
+            @testset "\$limit: Darlington pair convergence (multi-branch BJT)" begin
+                # Chained BJT exponentials — the multi-branch analog of the diode
+                # chain. Pins that the PCNR limiting loop actually converges (not
+                # just that the answer is right), which is where Option 2's
+                # per-site lim_rhs anchoring on multi-junction devices matters.
+                r = pcnr_converge(darlington)
+                @test r.converged
+                @test r.n_limits == 6          # 3 junctions (vbe/vbc/vsub) × 2 BJTs
+                @test r.iters <= 20            # Option 2 measures 12; margin for CI
+                # Operating point: out ≈ Vin − 2·Vbe ≈ 1.6 V (both BJTs on).
+                sol = dc!(MNACircuit(darlington))
+                @test 1.4 < sol[:out] < 1.9
+                @test sol[:mid] > sol[:out]    # Q1 emitter above Q2 emitter
             end
 
             @testset "Diode with series resistance" begin

--- a/test/mna/vadistiller_integration.jl
+++ b/test/mna/vadistiller_integration.jl
@@ -223,6 +223,63 @@ D1 da 0 diode_a m=5
                 @test v_diode > 0.6 && v_diode < 0.7
             end
 
+            @testset "\$limit codegen: limiting variable + convergence" begin
+                # Verify VA `$limit` now lowers to a real PCNR limiting variable
+                # (previously a no-op). One limiting variable per sp_diode
+                # instance, keyed on its junction branch.
+                function rect(Vsrc; x=Float64[], ctx=MNAContext())
+                    reset_for_restamping!(ctx)
+                    vin = get_node!(ctx, :vin)
+                    out = get_node!(ctx, :out)
+                    stamp!(VoltageSource(Vsrc; name=:V1), ctx, vin, 0)
+                    stamp!(Resistor(1000.0; name=:R1), ctx, vin, out)
+                    stamp!(sp_diode(), ctx, out, 0; _mna_spec_=MNASpec(), _mna_x_=x)
+                    return ctx
+                end
+
+                # Structure: stamping allocates exactly one limiting variable.
+                ctx0 = rect(5.0)
+                @test ctx0.n_limits == 1
+
+                # Cold-start convergence from zeros on a hard 50 V drive — the
+                # case classic Newton diverges on (exp(50/vt) overflow) and
+                # limiting exists to tame.
+                for Vsrc in (5.0, 50.0, 325.0)
+                    sol = solve_dc((p, s, t=0.0; x=Float64[], ctx=MNAContext()) -> rect(Vsrc; x, ctx),
+                                   (;), MNASpec())
+                    vj = sol.x[2]                     # junction voltage
+                    i_r = (Vsrc - vj) / 1000.0        # series-R current
+                    @test 0.4 < vj < 1.2              # sane forward drop, no overflow
+                    @test i_r > 1e-4                  # diode conducts
+                end
+            end
+
+            @testset "\$limit: 3-diode series chain converges" begin
+                function chain3_va(Vsrc; x=Float64[], ctx=MNAContext())
+                    reset_for_restamping!(ctx)
+                    vin = get_node!(ctx, :vin)
+                    n1 = get_node!(ctx, :n1)
+                    n2 = get_node!(ctx, :n2)
+                    n3 = get_node!(ctx, :n3)
+                    stamp!(VoltageSource(Vsrc; name=:V1), ctx, vin, 0)
+                    stamp!(Resistor(1000.0; name=:R1), ctx, vin, n1)
+                    stamp!(sp_diode(), ctx, n1, n2; _mna_spec_=MNASpec(), _mna_x_=x)
+                    stamp!(sp_diode(), ctx, n2, n3; _mna_spec_=MNASpec(), _mna_x_=x)
+                    stamp!(sp_diode(), ctx, n3, 0;  _mna_spec_=MNASpec(), _mna_x_=x)
+                    return ctx
+                end
+
+                ctx0 = chain3_va(50.0)
+                @test ctx0.n_limits == 3          # one per junction
+
+                sol = solve_dc((p, s, t=0.0; x=Float64[], ctx=MNAContext()) -> chain3_va(50.0; x, ctx),
+                               (;), MNASpec())
+                # Three forward-biased junctions in series from n1 to ground; each
+                # drops ~0.7-0.8 V, so n1 sits near 2.0-2.5 V and R1 takes the rest.
+                v_n1 = sol.x[2]
+                @test 1.8 < v_n1 < 2.7
+            end
+
             @testset "Diode with series resistance" begin
                 function sp_diode_rs_circuit(params, spec, t::Real=0.0; x=Float64[], ctx=MNAContext())
                     reset_for_restamping!(ctx)

--- a/test/mna/vadistiller_integration.jl
+++ b/test/mna/vadistiller_integration.jl
@@ -117,6 +117,35 @@ D1 da 0 diode_a m=5
 .END
 """i
 
+# `$limit` codegen exercised through the high-level SPICE API (the preferred
+# test style — see CLAUDE.md "Test Style"). Each netlist gets a distinct model
+# name so the per-module codegen doesn't collide. sol.limit_names exposes the
+# PCNR limiting variables the `$limit` lowering allocates; sol[:name] is robust
+# to that added state where a positional sol.x[i] would shift.
+const limit_rect_5 = sp"""
+* half-wave rectifier, 5 V
+.model dlr5 d is=76.9p n=1.45
+V1 vin 0 DC 5
+R1 vin out 1k
+D1 out 0 dlr5
+"""i
+const limit_rect_325 = sp"""
+* half-wave rectifier, hard 325 V drive (raw Newton overflows here)
+.model dlr3 d is=76.9p n=1.45
+V1 vin 0 DC 325
+R1 vin out 1k
+D1 out 0 dlr3
+"""i
+const limit_chain3 = sp"""
+* three forward-biased junctions in series, 50 V
+.model dlc d is=76.9p n=1.45
+V1 vin 0 DC 50
+R1 vin n1 1k
+D1 n1 n2 dlc
+D2 n2 n3 dlc
+D3 n3 0 dlc
+"""i
+
 @testset "VADistiller Integration Tests" begin
 
     #==========================================================================#
@@ -224,60 +253,27 @@ D1 da 0 diode_a m=5
             end
 
             @testset "\$limit codegen: limiting variable + convergence" begin
-                # Verify VA `$limit` now lowers to a real PCNR limiting variable
-                # (previously a no-op). One limiting variable per sp_diode
-                # instance, keyed on its junction branch.
-                function rect(Vsrc; x=Float64[], ctx=MNAContext())
-                    reset_for_restamping!(ctx)
-                    vin = get_node!(ctx, :vin)
-                    out = get_node!(ctx, :out)
-                    stamp!(VoltageSource(Vsrc; name=:V1), ctx, vin, 0)
-                    stamp!(Resistor(1000.0; name=:R1), ctx, vin, out)
-                    stamp!(sp_diode(), ctx, out, 0; _mna_spec_=MNASpec(), _mna_x_=x)
-                    return ctx
-                end
+                # VA `$limit` now lowers to a real PCNR limiting variable
+                # (previously a no-op): one per sp_diode junction branch, visible
+                # as sol.limit_names. The hard 325 V drive is the case raw Newton
+                # diverges on (exp(325/vt) overflow) and limiting exists to tame.
+                sol5 = dc!(MNACircuit(limit_rect_5))
+                @test length(sol5.limit_names) == 1     # one limiting variable
+                @test 0.4 < sol5[:out] < 1.2            # sane forward drop
+                @test (5.0 - sol5[:out]) / 1000.0 > 1e-4  # diode conducts
 
-                # Structure: stamping allocates exactly one limiting variable.
-                ctx0 = rect(5.0)
-                @test ctx0.n_limits == 1
-
-                # Cold-start convergence from zeros on a hard 50 V drive — the
-                # case classic Newton diverges on (exp(50/vt) overflow) and
-                # limiting exists to tame.
-                for Vsrc in (5.0, 50.0, 325.0)
-                    sol = solve_dc((p, s, t=0.0; x=Float64[], ctx=MNAContext()) -> rect(Vsrc; x, ctx),
-                                   (;), MNASpec())
-                    vj = sol.x[2]                     # junction voltage
-                    i_r = (Vsrc - vj) / 1000.0        # series-R current
-                    @test 0.4 < vj < 1.2              # sane forward drop, no overflow
-                    @test i_r > 1e-4                  # diode conducts
-                end
+                sol325 = dc!(MNACircuit(limit_rect_325))
+                @test length(sol325.limit_names) == 1
+                @test 0.4 < sol325[:out] < 1.2          # no overflow at 325 V
+                @test (325.0 - sol325[:out]) / 1000.0 > 1e-4
             end
 
             @testset "\$limit: 3-diode series chain converges" begin
-                function chain3_va(Vsrc; x=Float64[], ctx=MNAContext())
-                    reset_for_restamping!(ctx)
-                    vin = get_node!(ctx, :vin)
-                    n1 = get_node!(ctx, :n1)
-                    n2 = get_node!(ctx, :n2)
-                    n3 = get_node!(ctx, :n3)
-                    stamp!(VoltageSource(Vsrc; name=:V1), ctx, vin, 0)
-                    stamp!(Resistor(1000.0; name=:R1), ctx, vin, n1)
-                    stamp!(sp_diode(), ctx, n1, n2; _mna_spec_=MNASpec(), _mna_x_=x)
-                    stamp!(sp_diode(), ctx, n2, n3; _mna_spec_=MNASpec(), _mna_x_=x)
-                    stamp!(sp_diode(), ctx, n3, 0;  _mna_spec_=MNASpec(), _mna_x_=x)
-                    return ctx
-                end
-
-                ctx0 = chain3_va(50.0)
-                @test ctx0.n_limits == 3          # one per junction
-
-                sol = solve_dc((p, s, t=0.0; x=Float64[], ctx=MNAContext()) -> chain3_va(50.0; x, ctx),
-                               (;), MNASpec())
+                sol = dc!(MNACircuit(limit_chain3))
+                @test length(sol.limit_names) == 3      # one per junction
                 # Three forward-biased junctions in series from n1 to ground; each
                 # drops ~0.7-0.8 V, so n1 sits near 2.0-2.5 V and R1 takes the rest.
-                v_n1 = sol.x[2]
-                @test 1.8 < v_n1 < 2.7
+                @test 1.8 < sol[:n1] < 2.7
             end
 
             @testset "Diode with series resistance" begin


### PR DESCRIPTION
## Summary

Lowers Verilog-A `$limit(V(p,n), limiter_fn, args...)` onto the existing PCNR limiting runtime instead of dropping it as a no-op (`src/vasim.jl:1192`), so the VADistiller models get real SPICE Newton limiting. Then wires the real distilled `sp_diode` into the DC Newton benchmark — the stated end goal.

Every VADistiller model (diode, bjt, mos1-9, bsim3v3, bsim4v8, vdmos, jfet, mes) ships full SPICE limiting logic in Verilog-A and calls `$limit` to reach the state the simulator must maintain; until now that state was never allocated, so limiting never fired.

Background and design rationale: `doc/pcnr_plan.md` (Phase 2 section, updated here).

## What changed

**Codegen (`src/vasim.jl`)** — pure codegen; no solver/context changes, since generated VA `stamp!` methods inline their own stamping:
- `MNAScope` gains `limit_branches` (unique probe branches, one limiting variable each) and a `cond_depth` counter, threaded through all scope constructors and shared by reference across copies.
- The `$limit` handler resolves the probe to a `(p,n)` node pair (2-node, named-branch, or 1-node-to-ground forms — the last covers vdmos's `V(t)` thermal probe), finds/creates the branch's limiting variable, calls the model's own limiter function with `(vnew, vold)` prepended per the LRM, records the result as the PCNR corrector target, and returns it. OldGet/NewSet sites need no special casing (last record wins).
- A hoisted, unconditional preamble allocates each branch's limiting variable, reads its `vold`, and stamps the linear `g_lim = x_lim − (V_p − V_n) = 0` tracking row, at a fixed body position so `DirectStampContext`'s positional counters stay in sync.
- `cond_depth` makes a `$limit` under a runtime conditional an error at codegen (would desync counters). All in-repo sites are unconditional.

This is **Option 1** (chain-ruled/damped conductance, probe-anchored RHS): the site returns the model's own AD-differentiated limiter output, so the existing companion stamping is already consistent — no dual widening, no `lim_rhs` correction. `$simparam("iniLim")` is special-cased to `0` (seed off): the models' vcrit-seed branch assigns a plain constant and drops the AD partials, which stamps zero conductance and goes singular on series-junction topologies. Seeding waits for Option 2's w-anchored dual (documented in the plan).

**Benchmark (`benchmarks/pcnr/dc_newton_iterations.jl`)** — adds `rectifier_va`/`chain3_va`/`graetz_va`/`mul4_va` twins stamping `sp_diode` (d1n4007-like params matching the native `DIODE_*` constants), alongside the native rows. VA circuits have no `limit=false` twin, so every method runs on the one augmented system (correctorless solvers see an inert limiter, i.e. the natural problem; only PCNR activates it).

## Verification

- `test/mna/pcnr.jl` 73/73 and `test/mna/vadistiller.jl` 51/51 unregressed.
- sp_diode rectifier converges cleanly at 5 / 50 / 325 V, 3-diode chain at 50 V, and (in the full integration suite) sp_bjt, sp_mos1-9, sp_bsim3v3, sp_bsim4v8, sp_vdmos all codegen and solve. The limiting variable tracks the junction voltage at the solution (limiter inert at convergence).
- Adds sp_diode `$limit` testsets to `test/mna/vadistiller_integration.jl`.
- Local verification of the full integration suite and the benchmark run is in progress; CI is the additional gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLZRv91wMD8iWjZFbTun1g)_