### PR TITLE
Ignore control/analysis dot-cards in sema instead of crashing

### DIFF
--- a/doc/scratchpad.md
+++ b/doc/scratchpad.md
@@ -60,3 +60,7 @@ Fixed SPICE sources with both an AC and transient spec silently dropping the AC 
 ## Cleanup: drop dead backward-compat aliases
 
 Removed unused deprecated aliases (`MNACircuitProblem`, the legacy 4-arg `MNACircuit(builder, params, spec, tspan)` constructor, `AnyStampContext`, `branches_have_same_alloc_count`) and a stale self-contradictory `MNAData` docstring note; none were referenced anywhere in the tree.
+
+## Control/analysis dot-cards no longer crash sema
+
+`.ac`/`.dc`/`.print`/`.width`/`.ic`/`.meas`/`.data`/`.csparam` (and `.temp`) previously hit the `@show stmt; error()` fallthrough in `sema!` — only `.tran` was ignored; now these builder-irrelevant control cards are ignored, and `.temp <value>` is funneled through the same option channel as `.option temp=<value>`.

--- a/src/spc/codegen.jl
+++ b/src/spc/codegen.jl
@@ -188,6 +188,13 @@ function cg_expr!(state::CodegenState, cs::Union{SNode{SC.UnaryOp}, SNode{SP.Una
     return Expr(:call, op, cg_expr!(state, cs.operand))
 end
 
+# Options can be set either via `.option name=value` (a `Parameter` node with a
+# `.val` field) or, for temperature, via the standalone `.temp value` directive
+# (a `TempStatement` node whose value lives in `.temp`). Normalize both to the
+# underlying value expression node.
+_option_value_node(p::SNode{SP.Parameter}) = p.val
+_option_value_node(p::SNode{SP.TempStatement}) = p.temp
+
 function cg_expr!(state::CodegenState, id::Symbol)
     if id == Symbol("true")
         true
@@ -520,7 +527,7 @@ function codegen!(state::CodegenState)
         end
         temp_expr  = :(old_options.temp)
         if haskey(state.sema.options, :temp)
-            temp_expr = :($(Cadnip.isdefault)(old_options.temp) ? $(cg_expr!(state, state.sema.options[:temp][end][2].val)) : $temp_expr)
+            temp_expr = :($(Cadnip.isdefault)(old_options.temp) ? $(cg_expr!(state, _option_value_node(state.sema.options[:temp][end][2]))) : $temp_expr)
         end
         push!(ret.args, quote
             old_options = $(Cadnip.options)[]
@@ -2790,7 +2797,7 @@ function codegen_mna!(state::CodegenState; skip_nets::Vector{Symbol}=Symbol[], i
 
     # Handle temperature option - update spec if temp is set
     if haskey(state.sema.options, :temp)
-        temp_expr = cg_expr!(state, state.sema.options[:temp][end][2].val)
+        temp_expr = cg_expr!(state, _option_value_node(state.sema.options[:temp][end][2]))
         push!(block.args, :(spec = $(MNASpec)(temp=$temp_expr, mode=spec.mode)))
     end
 

--- a/src/spc/sema.jl
+++ b/src/spc/sema.jl
@@ -453,6 +453,11 @@ function sema!(scope::SemaResult, n::Union{SNode{SPICENetlistSource}, SNode{SP.S
                 name = LSymbol(param.name)
                 push!(get!(()->[], scope.options, name), scope.global_position=>param)
             end
+        elseif isa(stmt, SNode{SP.TempStatement})
+            # `.temp <value>` is equivalent to `.option temp=<value>`; funnel it
+            # through the same option channel so codegen threads it into MNASpec.
+            # Later definitions win via the `[end]` lookup in codegen.
+            push!(get!(()->[], scope.options, :temp), scope.global_position=>stmt)
         elseif isa(stmt, SNode{SP.ParamStatement})
             for param in stmt.params
                 name = LSymbol(param.name)
@@ -528,8 +533,16 @@ function sema!(scope::SemaResult, n::Union{SNode{SPICENetlistSource}, SNode{SP.S
                     sema_include!(scope, includee)
                 end
             end
-        elseif isa(stmt, SNode{SP.Tran}) || isa(stmt, SNode{SP.EndStatement})
-            # Ignore for Sema purposes
+        elseif isa(stmt, SNode{SP.Tran}) || isa(stmt, SNode{SP.EndStatement}) ||
+               isa(stmt, SNode{SP.ACStatement}) || isa(stmt, SNode{SP.DCStatement}) ||
+               isa(stmt, SNode{SP.PrintStatement}) || isa(stmt, SNode{SP.WidthStatement}) ||
+               isa(stmt, SNode{SP.ICStatement}) || isa(stmt, SNode{SP.MeasurePointStatement}) ||
+               isa(stmt, SNode{SP.MeasureRangeStatement}) ||
+               isa(stmt, SNode{SP.DataStatement}) || isa(stmt, SNode{SP.CSParamStatement})
+            # Analysis (.ac/.dc/.tran), output (.print/.width/.meas), and
+            # initial-condition/data (.ic/.data/.csparam) control cards carry no
+            # information the MNA netlist builder consumes. Ignore them rather
+            # than crashing; the frequency/time sweep is driven by ac!/tran!.
         elseif isa(stmt, SNode{SP.IfBlock})
             depth = length(scope.condition_stack)
             for case in stmt.cases

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -589,8 +589,10 @@ end
     @test_broken isapprox_deftol(sol[:vcc], -10.0)
 end
 
-# Currently errors at sema stage - .temp directive handling calls error()
-#=
+# `.temp <value>` is funneled through the same option channel as `.option
+# temp=<value>` (see sema.jl), so it shares the same (currently broken)
+# temper-in-.param propagation. What it no longer does is crash at the sema
+# stage.
 @testset "SPICE parameter scope (.temp)" begin
     # Test .temp directive
     spice_code = """
@@ -602,9 +604,8 @@ end
     """
     ctx, sol = solve_mna_spice_code(spice_code)
     # foo = temper = 10 (from .temp)
-    @test isapprox_deftol(sol[:vcc], -10.0)
+    @test_broken isapprox_deftol(sol[:vcc], -10.0)
 end
-=#
 
 @testset "SPICE parameter scope (default temper)" begin
     # Test that the default temper is 27
@@ -617,6 +618,32 @@ end
     ctx, sol = solve_mna_spice_code(spice_code)
     # Default temper = 27
     @test isapprox_deftol(sol[:vcc], -27.0)
+end
+
+# Analysis (.ac/.dc/.tran), output (.print/.width), and initial-condition
+# (.ic) control cards used to crash the semantic analysis stage with
+# `@show stmt; error()`. They carry no information the MNA netlist builder
+# consumes, so they must be ignored, not fatal.
+@testset "Control/analysis dot-cards are ignored, not fatal" begin
+    # A trivial resistive divider (out = 5 * 1k/(1k+1k) = 2.5V) sprinkled with
+    # control cards the builder does not consume.
+    base = """
+    * control cards
+    V1 vcc 0 DC 5
+    R1 vcc out 1k
+    R2 out 0 1k
+    """
+    for card in (
+        ".ac dec 10 1 1e6",
+        ".dc V1 0 5 0.1",
+        ".print dc v(out)",
+        ".width out=80",
+        ".ic v(out)=1",
+    )
+        spice_code = base * card * "\n"
+        ctx, sol = solve_mna_spice_code(spice_code)
+        @test isapprox_deftol(sol[:out], 2.5)
+    end
 end
 
 # Currently errors at runtime - instance param referencing other params not scoped correctly


### PR DESCRIPTION
## Problem

A SPICE netlist carrying a routine control card such as `.ac dec 20 1 1e6`, `.dc V1 0 5 0.1`, `.print`, `.width`, `.ic`, `.meas`, `.data`, `.csparam`, or `.temp` **crashed at the semantic-analysis stage**. In `sema!`, only `.tran` (and `.end`) were explicitly ignored; every other control card fell through to the `@show stmt; error()` catch-all. `basic.jl` even carried a commented-out `.temp` test noting it "errors at sema stage."

## Change

- **`src/spc/sema.jl`** — ignore `.ac`/`.dc`/`.print`/`.width`/`.ic`/`.meas`/`.data`/`.csparam` the same way `.tran` already is. These carry no information the MNA netlist builder consumes; the frequency/time sweep is driven by `ac!`/`tran!`.
- **`.temp <value>`** is now funneled through the same `options[:temp]` channel as `.option temp=<value>`, so codegen threads it into `MNASpec` uniformly. A small `_option_value_node` helper (`src/spc/codegen.jl`) reads the value expression from either a `Parameter` (`.option`) or `TempStatement` (`.temp`) node.

## Tests

- Enabled the previously-commented `.temp` test. It is `@test_broken`, sharing the same pre-existing `temper`-in-`.param` propagation limitation that `.option temp` already has (that deeper `Cadnip.spec`/`MNASpec` disconnect is intentionally out of scope here) — the point is it no longer crashes.
- Added **"Control/analysis dot-cards are ignored, not fatal"**: a resistive divider that must still solve to 2.5 V with each of `.ac`/`.dc`/`.print`/`.width`/`.ic` attached (5/5 pass).

`test/basic.jl` runs clean locally on Julia 1.12 (exit 0, no failures/errors), exercising both codegen temp-threading paths with the new helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxqPS8rcuv8kpoSX3BCbPh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxqPS8rcuv8kpoSX3BCbPh)_