### PR TITLE
Port the Makie extension (explore) to the MNA backend

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -68,6 +68,7 @@ path = "NyanSpectreNetlistParser.jl"
 path = "NyanVerilogAParser.jl"
 
 [extensions]
+CadnipMakieExt = "Makie"
 CadnipModelingToolkitExt = "ModelingToolkit"
 CadnipReviseExt = "Revise"
 

--- a/doc/scratchpad.md
+++ b/doc/scratchpad.md
@@ -58,3 +58,4 @@ The most nebulous and least important at this stage: copying features from other
 - Control/analysis dot-cards no longer crash sema
 - Cleanup: drop dead DAECompiler-era `aliasextract.jl` and its `net_alias` stub
 - Cleanup: drop superseded `stamp_reactive_with_detection!` API, its two legacy `detect_or_cached!` overloads, and the always-empty codegen `detection_block`
+- Port the Makie extension (`explore`) to the MNA backend and wire it into `[extensions]` with a headless CairoMakie test

--- a/ext/CadnipMakieExt.jl
+++ b/ext/CadnipMakieExt.jl
@@ -1,48 +1,84 @@
 module CadnipMakieExt
 
 using Makie
-using DAECompiler: get_sys
 using Cadnip
-using OrdinaryDiffEq
+using Cadnip: tran!
+using Cadnip.MNA: MNACircuit, alter, assemble!
 using StructArrays
 
-function Cadnip.explore(sol)
+# Collect the numeric leaf parameters of a (possibly nested) params NamedTuple as
+# `dotted.path => value` pairs. The dotted paths are exactly the selectors that
+# `alter(circuit; var"a.b.c" = ...)` understands, so a slider can drive any
+# scalar parameter, however deeply nested.
+function _numeric_params(nt::NamedTuple, prefix::String="")
+    out = Pair{Symbol,Float64}[]
+    for (k, v) in pairs(nt)
+        path = isempty(prefix) ? string(k) : string(prefix, ".", k)
+        if v isa NamedTuple
+            append!(out, _numeric_params(v, path))
+        elseif v isa Real
+            push!(out, Symbol(path) => Float64(v))
+        end
+    end
+    return out
+end
+
+"""
+    explore(circuit::MNACircuit, tspan; solver=nothing, kwargs...) -> Figure
+
+Interactively explore a transient simulation of `circuit`. Opens a Makie figure
+with one logarithmic slider per scalar circuit parameter; moving a slider
+re-runs `tran!(circuit, tspan)` with the altered parameter and updates every
+node-voltage trace live.
+
+Requires a Makie backend to be loaded (e.g. `using GLMakie` for an interactive
+window, or `using CairoMakie` to render/save a static frame). `solver` and any
+extra `kwargs` are forwarded to `tran!`.
+
+```julia
+using GLMakie
+circuit = MNACircuit(build_rc; R=1e3, C=1e-6)
+explore(circuit, (0.0, 5e-3))
+```
+"""
+function Cadnip.explore(circuit::MNACircuit, tspan::Tuple{<:Real,<:Real};
+                        solver=nothing, kwargs...)
+    params = _numeric_params(circuit.params)
+    isempty(params) &&
+        error("explore: circuit has no scalar parameters to sweep")
+
     fig = Figure()
+    ax = Axis(fig[1, 1]; xlabel="t (s)", ylabel="V (V)")
 
-    prob = sol.prob
-    # TODO this should really use some *Sim abstraction to enumerate/alter parameters
-    # see https://github.com/JuliaComputing/Cadnip.jl/issues/352
-    ps = sol.prob.p::ParamSim
-    sys = get_sys(prob)
-
-    ax = Axis(fig[1, 1])
-
-    sg = SliderGrid(
-        fig[1, 2],
-        ((label = String(k), range = (10 .^ (-3:0.1:3)).*v, format = "{:.1e}", startvalue = v)
-            for (k, v) in pairs(ps.params.params))...,
+    sg = SliderGrid(fig[1, 2],
+        ((label = string(name),
+          range = (10 .^ (-3:0.05:3)) .* value,
+          format = "{:.2e}",
+          startvalue = value) for (name, value) in params)...,
         width = 350,
         tellheight = false)
 
-    sliderobservables = [s.value for s in sg.sliders]
-    traces = lift(sliderobservables...) do slvalues...
-        params = Cadnip.VectorPrism((;params=slvalues))
-        # TODO this ignores spec params and breaks on nested params
-        prob = remake(prob, p=ParamSim(ps.circuit, ps.mode, ps.spec, params))
-        sol = solve(prob, sol.alg; initializealg=CedarDCOp())
-        return sol
+    # Circuit structure (and therefore the node set) is constant across parameter
+    # changes, so the names only need to be resolved once.
+    node_names = assemble!(circuit).node_names
+    names = Tuple(first(p) for p in params)
+
+    slider_values = [s.value for s in sg.sliders]
+    solution = lift(slider_values...) do values...
+        altered = alter(circuit; NamedTuple{names}(values)...)
+        return tran!(altered, tspan; solver, kwargs...)
     end
 
-    for (vec, name) in Cadnip.default_name_map(sys)
-        trace = lift(traces) do sol
-            scope = getproperty(sys, vec)
-            StructArray{Point2{Float64}}((sol.t, sol[scope]))
+    for name in node_names
+        (name === :gnd || name === Symbol("0")) && continue
+        trace = lift(solution) do sol
+            StructArray{Point2f}((Float64.(sol.t), Float64.(sol[name])))
         end
-        lines!(ax, trace, label=name)
+        lines!(ax, trace; label = string(name))
     end
 
-    axislegend()
-    fig
+    axislegend(ax)
+    return fig
 end
 
 end # module

--- a/scratch/makie.jl
+++ b/scratch/makie.jl
@@ -1,33 +1,31 @@
+# Interactive exploration of a transient simulation.
+#
+# `Cadnip.explore(circuit, tspan)` opens a Makie window with one log slider per
+# scalar parameter; dragging a slider re-runs the transient and updates every
+# node-voltage trace live. Loading GLMakie activates the CadnipMakieExt.
 using GLMakie
 using Cadnip
-using Cadnip.SpectreEnvironment
-using OrdinaryDiffEq
-using StructArrays
 
-spice_code = """
-*Third order low pass filter, butterworth, with ω_c = 1
+# Third-order Butterworth low-pass (ω_c = 1), driven by a sine source. The
+# builder reads its element values from `params`, so every one of them becomes a
+# slider in the explorer.
+function butterworth(params, spec, t::Real=0.0; x=Float64[], ctx=nothing)
+    p = merge((L1=3/2, C2=4/3, L3=1/2, R4=1.0, freq=1.0, amp=1.0), params)
 
-.param L1_val=3/2
-+ C2_val=4/3
-+ L3_val=1/2
-+ R4_val=1
-+ f_val=1
+    ctx === nothing ? (ctx = Cadnip.MNA.MNAContext()) : Cadnip.MNA.reset_for_restamping!(ctx)
+    get = n -> Cadnip.MNA.get_node!(ctx, n)
+    vin, n1, vout = get(:vin), get(:n1), get(:vout)
 
-V1 vin 0 SIN (0, 1, 'f_val')
-L1 vin n1 'L1_val'
-C2 n1 0 'C2_val'
-L3 n1 vout 'L3_val'
-R4 vout 0 'R4_val'
-"""
+    ω = 2π * p.freq
+    Cadnip.MNA.stamp!(Cadnip.MNA.VoltageSource(p.amp * sin(ω * t); name=:V1), ctx, vin, 0)
+    Cadnip.MNA.stamp!(Cadnip.MNA.Inductor(p.L1), ctx, vin, n1)
+    Cadnip.MNA.stamp!(Cadnip.MNA.Capacitor(p.C2), ctx, n1, 0)
+    Cadnip.MNA.stamp!(Cadnip.MNA.Inductor(p.L3), ctx, n1, vout)
+    Cadnip.MNA.stamp!(Cadnip.MNA.Resistor(p.R4), ctx, vout, 0)
+    return ctx
+end
 
-circuit_code = Cadnip.make_spectre_circuit(
-    Cadnip.NyanSpectreNetlistParser.SPICENetlistParser.SPICENetlistCSTParser.parse(spice_code);
-);
-circuit = eval(circuit_code)
+circuit = MNACircuit(butterworth; L1=3/2, C2=4/3, L3=1/2, R4=1.0, freq=1.0, amp=1.0)
 
-sim = ParamSim(circuit; l1_val=3/2, c2_val=4/3, l3_val=1/2, r4_val=1.0, f_val=1.0)
-sys = CircuitIRODESystem(sim)
-prob = ODEProblem(sys, nothing, (0.0, 100.0), sim)
-sol = solve(prob, FBDF(autodiff=false); initializealg=CedarDCOp())
-
-Cadnip.explore(sol)
+fig = Cadnip.explore(circuit, (0.0, 100.0))
+display(fig)

--- a/src/util.jl
+++ b/src/util.jl
@@ -236,27 +236,8 @@ function tlshow(expr)
     end
 end
 
-function default_name_map(sys)
-    # Collect all top-level nodes that are terminal:
-    top_level_nodes = Set(filter(n -> isempty(propertynames(getproperty(sys, n))), propertynames(sys)))
-    # Strip `node_` from the front if there's no conflicting other node:
-    name_map = Dict{Symbol,String}()
-    for name in top_level_nodes
-        # Only allow variables and observed
-        level = getfield(sys, :result).names[name]
-        (level.var !== nothing || level.obs !== nothing) || continue
-
-        str_name = string(name)
-        if startswith(str_name, "node_") && str_name[6:end] ∉ top_level_nodes
-            str_name = string(str_name[6:end])
-        end
-        # Filter out anything named `gnd` or `0`
-        if str_name ∈ ("0", "gnd", "GND", "node_0", "node_gnd", "node_GND")
-            continue
-        end
-        name_map[name] = str_name
-    end
-    return name_map
-end
-
+# Interactive circuit exploration. The method lives in the Makie package
+# extension (`ext/CadnipMakieExt.jl`); this declares the generic function so the
+# extension can add to it and it is reachable as `Cadnip.explore` once a Makie
+# backend is loaded.
 function explore end

--- a/test/params.jl
+++ b/test/params.jl
@@ -4,11 +4,14 @@ include("common.jl")
 
 # MNA imports for parameter tests
 using Cadnip.MNA: MNAContext, MNACircuit, MNASpec, get_node!, stamp!, assemble!, solve_dc
-using Cadnip.MNA: Resistor, VoltageSource
+using Cadnip.MNA: Resistor, Capacitor, VoltageSource
 
 using Cadnip.MNA: alter, reset_for_restamping!  # MNA-specific alter for MNACircuit
 using Cadnip: ParamLens, IdentityLens
 using Cadnip: dc!
+
+# Loading a Makie backend activates CadnipMakieExt, which defines Cadnip.explore.
+import CairoMakie
 
 #==============================================================================#
 # Test 1: Simple parameterized circuit (replaces ParCir struct)
@@ -116,19 +119,44 @@ sol = dc!(circuit)
 @test sol[:I_V] == -5.0
 
 #==============================================================================#
-# Test 4: CairoMakie exploration (skip for MNA - requires different API)
+# Test 4: Makie exploration (CadnipMakieExt)
 #
-# The original test used Cadnip.explore(sol) which expects DAECompiler solution.
-# MNA solutions use a different format. Skip or adapt as needed.
+# `Cadnip.explore(circuit, tspan)` builds an interactive figure with one slider
+# per scalar parameter and a live node-voltage trace per node. Loading a Makie
+# backend (CairoMakie here) activates the extension. We render to a PNG to
+# force the observable/solve/plot pipeline to run end-to-end headlessly.
 #==============================================================================#
 
-# Note: MNA solution exploration would use different API
-# Keeping as placeholder for future MNA visualization support
-# import CairoMakie
-# fig = Cadnip.explore(sol)
-# plots_dir = joinpath(Base.pkgdir(Cadnip), "test", "plots")
-# mkpath(plots_dir)
-# CairoMakie.save(joinpath(plots_dir, "explore.png"), fig)
+# RC low-pass with sweepable Vcc/R/C, driven to a step response over the tspan.
+function build_rc_explore(params, spec, t::Real=0.0; x=Float64[], ctx=nothing)
+    p = merge((Vcc=5.0, R=1e3, C=1e-6), params)
+    if ctx === nothing
+        ctx = MNAContext()
+    else
+        reset_for_restamping!(ctx)
+    end
+    vcc = get_node!(ctx, :vcc)
+    out = get_node!(ctx, :out)
+    stamp!(VoltageSource(p.Vcc; name=:V), ctx, vcc, 0)
+    stamp!(Resistor(p.R), ctx, vcc, out)
+    stamp!(Capacitor(p.C), ctx, out, 0)
+    return ctx
+end
+
+@testset "CadnipMakieExt explore()" begin
+    circuit = MNACircuit(build_rc_explore; Vcc=5.0, R=1e3, C=1e-6)
+    fig = Cadnip.explore(circuit, (0.0, 5e-3))
+    @test fig isa CairoMakie.Makie.Figure
+
+    # Rendering exercises the full lift → alter → tran! → plot pipeline.
+    plot_path = joinpath(mktempdir(), "explore.png")
+    CairoMakie.save(plot_path, fig)
+    @test isfile(plot_path) && filesize(plot_path) > 0
+
+    # No numeric parameters → nothing to sweep → informative error.
+    empty_circuit = MNACircuit(build_rc_explore)
+    @test_throws ErrorException Cadnip.explore(empty_circuit, (0.0, 5e-3))
+end
 
 #==============================================================================#
 # Test 5: SPICE netlist with parameters - using MNA codegen


### PR DESCRIPTION
## What

Revives the interactive `Cadnip.explore` figure on the MNA backend instead of deleting it.

## Why

`ext/CadnipMakieExt.jl` was left over from the DAECompiler era. It read `sol.prob.p::ParamSim`, called `DAECompiler.get_sys`, `Cadnip.VectorPrism`, and `default_name_map` — all removed during the MNA migration — and was **never registered in `[extensions]`**, so Julia never loaded it. There's no reason interactive exploration can't work on the new backend, so this ports it rather than dropping it.

## Changes

- **`ext/CadnipMakieExt.jl`** — rewrite `Cadnip.explore` to take an `MNACircuit` + `tspan`. It builds one logarithmic slider per scalar parameter (recursing into nested params as dotted `a.b.c` selectors that `alter` already understands), and on any slider change re-runs `tran!` on the altered circuit and updates every node-voltage trace live. Node names come from `assemble!(circuit).node_names`; traces read back via the SII `sol[:name]` accessor. `solver`/extra kwargs are forwarded to `tran!`.
- **`Project.toml`** — register `CadnipMakieExt = "Makie"` under `[extensions]` so the extension actually loads when a Makie backend is present (`Makie` was already a weakdep).
- **`src/util.jl`** — drop the now-unused DAECompiler-era `default_name_map`; keep (and document) the `explore` generic-function stub that the extension adds a method to.
- **`scratch/makie.jl`** — rewrite the broken driver (it used the removed `CircuitIRODESystem`/`CedarDCOp` entry points) into a working demo: a third-order Butterworth low-pass driven through `explore`.
- **`test/params.jl`** — replace the old DAECompiler exploration placeholder with a real headless test: load `CairoMakie`, build an RC circuit, render `explore(...)` to a PNG (exercising the full lift → `alter` → `tran!` → plot path), and assert the no-parameter case errors informatively.

## Usage

```julia
using GLMakie
circuit = MNACircuit(build_rc; R=1e3, C=1e-6)
explore(circuit, (0.0, 5e-3))   # sliders for R and C; live node-voltage traces
```

## Testing

`test/params.jl` passes on Julia 1.12, including the new `CadnipMakieExt explore()` testset (3/3) which renders through CairoMakie headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)