### PR TITLE
Cleanup: remove dead DAECompiler-era noise-parameter extraction

### DIFF
--- a/doc/noise_analysis_design.md
+++ b/doc/noise_analysis_design.md
@@ -1,0 +1,61 @@
+# Noise analysis design
+
+Noise analysis is a CedarSim feature we still want to port (`doc/scratchpad.md`,
+CedarSim pillar). This note records the intended approach so the design isn't
+lost, and points at the current entry points.
+
+## Status
+
+Not implemented. The scaffolding that exists today:
+
+- `src/ac.jl` — `noise!()` is scoped in the header comment but unimplemented.
+  The AC path already builds a linearized descriptor state-space system
+  (`E·dx = A·x + B·u, y = C·x`) at the DC operating point, which is exactly the
+  linearization a noise analysis consumes.
+- `src/va_env.jl` / `src/vasim.jl` — the Verilog-A `white_noise` /
+  `flicker_noise` builtins are parsed (NyanVerilogAParser keywords) and stubbed
+  to return `0.0`. These are the real per-device noise-source hooks; a noise
+  analysis lights them up instead of zeroing them.
+
+Builtin device noise (thermal `4kT/R`, shot `2qI`, flicker `KF·I^AF/f`) has no
+home yet and would attach to the MNA device stamps.
+
+## Two candidate formulations
+
+### A. Classic adjoint-PSD (the SPICE method)
+
+At each frequency: assemble a per-device noise-current PSD, solve the adjoint
+(transpose) of the AC system for the transfer function from each noise source to
+the output, then sum `|H|²·S` contributions (and cross-terms for correlated
+sources). Well-trodden, matches ngspice/Xyce/vacask, easy to cross-check.
+
+### B. AD-perturbation (the desirable approach)
+
+Represent each noise source as a differentiable **perturbation input** (`ϵ`
+terms) injected at a perturbation frequency (`ϵω`), and obtain the
+source→output transfer functions by differentiating the simulator output with
+respect to those inputs — reusing the same AD that already flows through the MNA
+stamps. Instead of hand-writing an adjoint solve, the transfer functions fall
+out of AD, and correlated / non-white / large-signal (cyclostationary) noise
+compose naturally because the perturbations ride through the real device
+equations rather than a separately-derived small-signal noise model.
+
+**This is the approach we want.** It is the noise-shaped instance of Cadnip's
+core bet — differentiability of the whole simulator (`doc/scratchpad.md`,
+Ecosystem/SciML pillar) — and it distinguishes us from the classic simulators
+rather than re-deriving them. Approach A is worth keeping in mind only as a
+cross-check oracle for a handful of textbook circuits.
+
+### Prior art in git history
+
+CedarSim/DAECompiler already used the `ϵ`-perturbation representation: device
+models carried `ϵ`-prefixed fields (noise-perturbation inputs) and `SimSpec`
+carried an `ϵω` perturbation frequency. A `noiseparams` helper walked the
+circuit builder with a `ParamObserver` mock to harvest the set of `ϵ` knobs
+across the hierarchy. That enumeration code was removed in **b771716** as dead
+(it cataloged knobs but computed no PSDs, matrices, or transfer functions, and
+was welded to the old struct-field representation). Revive it from that commit
+if the `ϵ`-field harvesting pattern is useful — but note that MNAContext's
+structure-discovery pass already flattens the hierarchy during stamping, so the
+natural place to register noise sources is that same pass, not a separate
+`ParamObserver` walk.

--- a/doc/noise_analysis_design.md
+++ b/doc/noise_analysis_design.md
@@ -1,8 +1,8 @@
 # Noise analysis design
 
 Noise analysis is a CedarSim feature we still want to port (`doc/scratchpad.md`,
-CedarSim pillar). This note records the intended approach so the design isn't
-lost, and points at the current entry points.
+CedarSim pillar). This note records the intended approach and the research into
+how it threads through the current MNA system **without slowing DC/transient**.
 
 ## Status
 
@@ -13,49 +13,122 @@ Not implemented. The scaffolding that exists today:
   (`E·dx = A·x + B·u, y = C·x`) at the DC operating point, which is exactly the
   linearization a noise analysis consumes.
 - `src/va_env.jl` / `src/vasim.jl` — the Verilog-A `white_noise` /
-  `flicker_noise` builtins are parsed (NyanVerilogAParser keywords) and stubbed
-  to return `0.0`. These are the real per-device noise-source hooks; a noise
+  `flicker_noise` builtins are parsed (NyanVerilogAParser keywords) and lowered
+  to `0.0` (`vasim.jl:1297`, and named noise branches zeroed at
+  `vasim.jl:3413`). These are the real per-device noise-source hooks; a noise
   analysis lights them up instead of zeroing them.
 
-Builtin device noise (thermal `4kT/R`, shot `2qI`, flicker `KF·I^AF/f`) has no
+Builtin device noise (thermal `4kT·g`, shot `2qI`, flicker `KF·I^AF/f`) has no
 home yet and would attach to the MNA device stamps.
 
-## Two candidate formulations
+## How AC threads through MNA today (the pattern to reuse)
 
-### A. Classic adjoint-PSD (the SPICE method)
+`ac!()` (`src/ac.jl`) does structure discovery once, solves the DC operating
+point, rebuilds at that point, and reads the linearized matrices:
 
-At each frequency: assemble a per-device noise-current PSD, solve the adjoint
-(transpose) of the AC system for the transfer function from each noise source to
-the output, then sum `|H|²·S` contributions (and cross-terms for correlated
-sources). Well-trodden, matches ngspice/Xyce/vacask, easy to cross-check.
+```
+G = assemble_G(ctx; gshunt=gmin)   # resistive Jacobian at the op point
+C = assemble_C(ctx)                # reactive Jacobian
+b_ac = get_rhs_ac(ctx)             # AC excitation column(s)
+dss(-G, C, B=b_ac, C_out=I, D=0)   # H(jω) = (jωC + G)⁻¹ · b_ac
+```
 
-### B. AD-perturbation (the desirable approach)
+The important detail for noise is **how the AC excitation is stored**:
+`MNAContext` carries a *fully deferred* AC channel — `b_ac_I::Vector{MNAIndex}`,
+`b_ac_V::Vector{ComplexF64}` (`context.jl:202`). AC sources append to it during
+stamping; it is only materialized when `ac!` runs. DC and transient never touch
+it.
 
-Represent each noise source as a differentiable **perturbation input** (`ϵ`
-terms) injected at a perturbation frequency (`ϵω`), and obtain the
-source→output transfer functions by differentiating the simulator output with
-respect to those inputs — reusing the same AD that already flows through the MNA
-stamps. Instead of hand-writing an adjoint solve, the transfer functions fall
-out of AD, and correlated / non-white / large-signal (cyclostationary) noise
-compose naturally because the perturbations ride through the real device
-equations rather than a separately-derived small-signal noise model.
+Crucially, the **transient hot path uses a different context**:
+`DirectStampContext` (`value_only.jl`) carries *only* `G_nzval`, `C_nzval`, and
+`b` — there is no `b_ac` channel and no AC machinery in it at all. Restamping
+during a transient solve writes straight to sparse `nzval` arrays via a
+precomputed COO→nzval map, and never allocates. So the AC channel already costs
+transient exactly nothing, because it does not exist in the hot-path context.
 
-**This is the approach we want.** It is the noise-shaped instance of Cadnip's
-core bet — differentiability of the whole simulator (`doc/scratchpad.md`,
-Ecosystem/SciML pillar) — and it distinguishes us from the classic simulators
-rather than re-deriving them. Approach A is worth keeping in mind only as a
-cross-check oracle for a handful of textbook circuits.
+**This is the template for the noise channel.** A noise-source channel added to
+`MNAContext` (structure-discovery only) and deliberately *absent* from
+`DirectStampContext` inherits the same zero-transient-cost property by
+construction.
 
-### Prior art in git history
+## Threading noise sources through stamping
 
-CedarSim/DAECompiler already used the `ϵ`-perturbation representation: device
-models carried `ϵ`-prefixed fields (noise-perturbation inputs) and `SimSpec`
-carried an `ϵω` perturbation frequency. A `noiseparams` helper walked the
-circuit builder with a `ParamObserver` mock to harvest the set of `ϵ` knobs
-across the hierarchy. That enumeration code was removed in **b771716** as dead
-(it cataloged knobs but computed no PSDs, matrices, or transfer functions, and
-was welded to the old struct-field representation). Revive it from that commit
-if the `ϵ`-field harvesting pattern is useful — but note that MNAContext's
-structure-discovery pass already flattens the hierarchy during stamping, so the
-natural place to register noise sources is that same pass, not a separate
-`ParamObserver` walk.
+Add a deferred noise-source list to `MNAContext` alongside `b_ac_*` — enough to
+reconstruct, per source: the branch nodes it injects into, and how to evaluate
+its PSD at the bias point (source kind + params, or a closure).
+
+Make the noise builtins **context-aware** rather than mode-branched:
+
+- On `MNAContext`: `white_noise(ctx, pwr, name)` / `flicker_noise(ctx, pwr,
+  exp, name)` (and builtin thermal/shot on R/diode stamps) append a source
+  descriptor to the noise channel **and return `0.0`**.
+- On `DirectStampContext`: no-op, return `0.0`.
+
+Because the *value* returned is `0.0` in every context, the DC/transient
+contribution (`I(NOII) <+ white_noise(...)`) is byte-identical to today — the
+noise call only has a side effect during the one structure-discovery build on an
+`MNAContext`. No `if mode === :noise` branch is threaded through the generated
+builder, so the hot path has nothing to skip.
+
+## The dual approach, reconciled
+
+The two formulations are **not competitors at the linear-noise level — they are
+the same transfer functions evaluated two ways.**
+
+- **AD-perturbation (the framing we want).** Treat each noise source as a
+  differentiable perturbation input `ϵ_k` injected at the source branch; the
+  source→output transfer function is `∂y/∂ϵ_k`. For the linear AC system this
+  is exactly the `freqresp` of an extra `B` column carrying a unit injection —
+  i.e. reuse the existing DSS machinery, one input column per source.
+- **Adjoint-PSD (the efficient evaluation for one output).** For a chosen
+  output you don't want `∂y/∂ϵ_k` for each `k` via a separate forward solve;
+  you want them all at once. One adjoint solve `(jωC+G)ᵀ x_adj = e_out` per
+  frequency yields `H_k = x_adjᵀ e_k` for *every* source at O(1) each, reusing a
+  single factorization. This is the classic SPICE `.noise` inner loop, and it is
+  simply the cheap way to evaluate the same derivatives.
+
+So the initial port evaluates the AD-perturbation transfer functions **via the
+adjoint** on top of the existing AC linearization. The AD framing is what keeps
+the door open to the parts that classic simulators can't do cheaply:
+
+- differentiating the *output noise* w.r.t. design parameters (the SciML
+  payoff — noise as one more differentiable objective for optimization);
+- large-signal / cyclostationary noise, where the linearization is
+  periodically time-varying (PSS/PAC-style) rather than a single DC-point AC
+  system.
+
+Both are N5 (stretch); N0–N4 deliberately stay on the tractable
+single-operating-point linear `.noise` that the AC path already supports.
+
+## Output quantities (N3)
+
+At each frequency: output PSD `S_out(ω) = Σ_k |H_k(jω)|² S_k(ω)` (add cross
+terms only when correlated sources are introduced). Total noise integrates
+`S_out` over the band; input-referred noise divides by `|H_input(ω)|²` using the
+input source's transfer function. Surface via a `NoiseSol` mirroring `ACSol`,
+with name-based access, and a `.noise` netlist card driven through the
+high-level API.
+
+## Performance guardrails (the "don't blow up transient" contract)
+
+1. The noise channel lives on `MNAContext` only; `DirectStampContext` gets no
+   noise fields and no noise methods. Transient restamping is untouched.
+2. Noise builtins return `0.0` in the value path, so DC/transient numerics are
+   unchanged; registration is a structure-discovery-time side effect.
+3. The adjoint solve reuses the AC factorization across all sources; cost scales
+   with (#frequencies × #outputs), independent of #sources beyond a dot product.
+4. N0 lands with a transient allocation/throughput benchmark asserting no
+   regression before any PSD/solver work builds on top.
+
+## Prior art in git history
+
+CedarSim/DAECompiler used an `ϵ`-perturbation representation: device models
+carried `ϵ`-prefixed fields (noise-perturbation inputs) and `SimSpec` carried an
+`ϵω` perturbation frequency. A `noiseparams` helper walked the builder with a
+`ParamObserver` mock to harvest the set of `ϵ` knobs across the hierarchy. That
+enumeration code was removed in **b771716** as dead — it cataloged knobs but
+computed no PSDs, matrices, or transfer functions, and was welded to the old
+struct-field representation. Revive it from that commit only if the `ϵ`-field
+harvesting pattern proves useful; note that MNAContext's structure-discovery
+pass already flattens the hierarchy during stamping, so the natural place to
+register noise sources is that same pass, not a separate `ParamObserver` walk.

--- a/doc/scratchpad.md
+++ b/doc/scratchpad.md
@@ -19,15 +19,6 @@ The original CedarSim is at 5d5ea8d4e7e17fd06f775eddd11f15a4731a4210 and still h
 Part of that is tests that we didn't port, part is inapplicable, but there are also some big features (noise etc) and extensions (makie etc).
 Its user facing API also feels a bit more thoughtful rather than just grown.
 
-### Noise analysis (todo) — design: `doc/noise_analysis_design.md`
-
-- [ ] N0: deferred noise-source channel on `MNAContext`, no-op on `DirectStampContext` (zero transient cost)
-- [ ] N1: per-source PSD models at the DC bias (thermal/shot/flicker + VA `white_noise`/`flicker_noise`)
-- [ ] N2: noise transfer functions via the AC linearization (adjoint solve per output/frequency)
-- [ ] N3: `noise!()` + `.noise` card — output/total/input-referred, name-based access
-- [ ] N4: validation against ngspice `.noise` through the high-level API
-- [ ] N5 (stretch): differentiable noise objectives + cyclostationary (PSS/PAC) noise
-
 ## Production readiness
 
 Adding more tests and benchmarks to see how we compare to ngspice, vacask, xyce.
@@ -69,3 +60,9 @@ The most nebulous and least important at this stage: copying features from other
 - [x] Cleanup: drop superseded `stamp_reactive_with_detection!` API, its two legacy `detect_or_cached!` overloads, and the always-empty codegen `detection_block`
 - [x] Port the Makie extension (`explore`) to the MNA backend and wire it into `[extensions]` with a headless CairoMakie test
 - [x] Cleanup: drop dead DAECompiler-era `noiseparams`/`modelfields` noise extraction and the unused `SimSpec.ϵω` field
+- [ ] Noise N0: deferred noise-source channel on `MNAContext`, no-op on `DirectStampContext` (zero transient cost) — design: `doc/noise_analysis_design.md`
+- [ ] Noise N1: per-source PSD models at the DC bias (thermal/shot/flicker + VA `white_noise`/`flicker_noise`)
+- [ ] Noise N2: noise transfer functions via the AC linearization (adjoint solve per output/frequency)
+- [ ] Noise N3: `noise!()` + `.noise` card — output/total/input-referred, name-based access
+- [ ] Noise N4: validation against ngspice `.noise` through the high-level API
+- [ ] Noise N5 (stretch): differentiable noise objectives + cyclostationary (PSS/PAC) noise

--- a/doc/scratchpad.md
+++ b/doc/scratchpad.md
@@ -50,13 +50,52 @@ Researching what is out there and trying it out is worthwile.
 
 The most nebulous and least important at this stage: copying features from other simulators
 
-# Progress
+# In flight
 
-- AC source phase (`V1 ... AC mag phase`)
-- Combined AC+transient sources, and Spectre `vsource`/`isource` AC support
-- Cleanup: drop dead backward-compat aliases
-- Cleanup: drop dead `netlist_utils.jl` composition operators
-- Control/analysis dot-cards no longer crash sema
-- Cleanup: drop dead DAECompiler-era `aliasextract.jl` and its `net_alias` stub
-- Cleanup: drop superseded `stamp_reactive_with_detection!` API, its two legacy `detect_or_cached!` overloads, and the always-empty codegen `detection_block`
-- Cleanup: drop dead DAECompiler-era `noiseparams`/`modelfields` noise extraction and the unused `SimSpec.ϵω` field
+## Noise simulation
+
+Bring back noise analysis (CedarSim port). Design + research:
+`doc/noise_analysis_design.md`. Approach: noise sources as differentiable
+perturbation inputs riding the existing AC descriptor-state-space machinery,
+collected through a deferred `MNAContext`-only channel that is a no-op on the
+transient hot path (`DirectStampContext`), so DC/transient cost stays at zero.
+
+- [ ] **N0 — Groundwork: noise-source channel.** Add a deferred noise-source
+  list to `MNAContext` (COO-style, mirroring `b_ac_I`/`b_ac_V`). Do *not* add
+  it to `DirectStampContext`. Make the VA `white_noise`/`flicker_noise`
+  builtins (and builtin thermal/shot) ctx-aware: register a source on
+  `MNAContext`, no-op on `DirectStampContext`, always return `0.0` for the
+  value path so DC/transient numerics are byte-identical. Assert zero extra
+  allocations in a transient benchmark.
+- [ ] **N1 — PSD models at the DC bias.** Evaluate per-source spectral density
+  at the operating point: thermal `4kT·g`, shot `2qI`, flicker `KF·I^AF/f`, VA
+  `white_noise(pwr)` → `pwr`, `flicker_noise(pwr,exp)` → `pwr/f^exp`. Bias comes
+  from the DC solution already computed by the AC path.
+- [ ] **N2 — Transfer functions via the AC system.** Reuse `ac!`'s linearized
+  `(jωC + G)`. Per output+frequency, one adjoint solve
+  `(jωC+G)ᵀ x_adj = e_out` gives the transfer from *every* source at O(1) each
+  (`H_k = x_adjᵀ e_k`); reuse the factorization across sources. (Equivalent to
+  adding each source as a `B` column and reading `freqresp` — the
+  perturbation-input framing — but the adjoint is the efficient evaluation for
+  a single output.)
+- [ ] **N3 — `noise!()` analysis + output.** Output PSD `Σ_k |H_k(jω)|² S_k(ω)`,
+  band integration for total noise, input-referred via the input transfer
+  function. Netlist `.noise` card + name-based access, mirroring `ac!`/`ACSol`.
+- [ ] **N4 — Tests + validation.** Netlist tests (thermal noise of an RC =
+  `4kT·R` shaped by the RC pole; op-amp input-referred noise) cross-checked
+  against ngspice `.noise`, driven through the high-level API.
+- [ ] **N5 (stretch) — differentiable / large-signal.** Differentiate output
+  noise w.r.t. design params (the SciML payoff), and scope cyclostationary
+  (PSS/PAC-style) noise on a periodically-time-varying linearization. Design
+  only for now.
+
+# Done
+
+- [x] AC source phase (`V1 ... AC mag phase`)
+- [x] Combined AC+transient sources, and Spectre `vsource`/`isource` AC support
+- [x] Cleanup: drop dead backward-compat aliases
+- [x] Cleanup: drop dead `netlist_utils.jl` composition operators
+- [x] Control/analysis dot-cards no longer crash sema
+- [x] Cleanup: drop dead DAECompiler-era `aliasextract.jl` and its `net_alias` stub
+- [x] Cleanup: drop superseded `stamp_reactive_with_detection!` API, its two legacy `detect_or_cached!` overloads, and the always-empty codegen `detection_block`
+- [x] Cleanup: drop dead DAECompiler-era `noiseparams`/`modelfields` noise extraction and the unused `SimSpec.ϵω` field

--- a/doc/scratchpad.md
+++ b/doc/scratchpad.md
@@ -17,6 +17,7 @@ At this stage we don't need any "backwards compatibility"
 
 The original CedarSim is at 5d5ea8d4e7e17fd06f775eddd11f15a4731a4210 and still has stuff that we don't.
 Part of that is tests that we didn't port, part is inapplicable, but there are also some big features (noise etc) and extensions (makie etc).
+For noise, the intended AD-perturbation approach is written up in `doc/noise_analysis_design.md`.
 Its user facing API also feels a bit more thoughtful rather than just grown.
 
 ## Production readiness

--- a/doc/scratchpad.md
+++ b/doc/scratchpad.md
@@ -17,8 +17,16 @@ At this stage we don't need any "backwards compatibility"
 
 The original CedarSim is at 5d5ea8d4e7e17fd06f775eddd11f15a4731a4210 and still has stuff that we don't.
 Part of that is tests that we didn't port, part is inapplicable, but there are also some big features (noise etc) and extensions (makie etc).
-For noise, the intended AD-perturbation approach is written up in `doc/noise_analysis_design.md`.
 Its user facing API also feels a bit more thoughtful rather than just grown.
+
+### Noise analysis (todo) — design: `doc/noise_analysis_design.md`
+
+- [ ] N0: deferred noise-source channel on `MNAContext`, no-op on `DirectStampContext` (zero transient cost)
+- [ ] N1: per-source PSD models at the DC bias (thermal/shot/flicker + VA `white_noise`/`flicker_noise`)
+- [ ] N2: noise transfer functions via the AC linearization (adjoint solve per output/frequency)
+- [ ] N3: `noise!()` + `.noise` card — output/total/input-referred, name-based access
+- [ ] N4: validation against ngspice `.noise` through the high-level API
+- [ ] N5 (stretch): differentiable noise objectives + cyclostationary (PSS/PAC) noise
 
 ## Production readiness
 
@@ -52,13 +60,12 @@ The most nebulous and least important at this stage: copying features from other
 
 # Progress
 
-- AC source phase (`V1 ... AC mag phase`)
-- Combined AC+transient sources, and Spectre `vsource`/`isource` AC support
-- Cleanup: drop dead backward-compat aliases
-- Cleanup: drop dead `netlist_utils.jl` composition operators
-- Control/analysis dot-cards no longer crash sema
-- Cleanup: drop dead DAECompiler-era `aliasextract.jl` and its `net_alias` stub
-- Cleanup: drop superseded `stamp_reactive_with_detection!` API, its two legacy `detect_or_cached!` overloads, and the always-empty codegen `detection_block`
-- Cleanup: drop dead DAECompiler-era `noiseparams`/`modelfields` noise extraction and the unused `SimSpec.ϵω` field
-- Port the Makie extension (`explore`) to the MNA backend and wire it into `[extensions]` with a headless CairoMakie test
-- Noise analysis: research + phased port plan (N0–N5) for threading it through MNA without slowing transient (see `doc/noise_analysis_design.md`)
+- [x] AC source phase (`V1 ... AC mag phase`)
+- [x] Combined AC+transient sources, and Spectre `vsource`/`isource` AC support
+- [x] Cleanup: drop dead backward-compat aliases
+- [x] Cleanup: drop dead `netlist_utils.jl` composition operators
+- [x] Control/analysis dot-cards no longer crash sema
+- [x] Cleanup: drop dead DAECompiler-era `aliasextract.jl` and its `net_alias` stub
+- [x] Cleanup: drop superseded `stamp_reactive_with_detection!` API, its two legacy `detect_or_cached!` overloads, and the always-empty codegen `detection_block`
+- [x] Port the Makie extension (`explore`) to the MNA backend and wire it into `[extensions]` with a headless CairoMakie test
+- [x] Cleanup: drop dead DAECompiler-era `noiseparams`/`modelfields` noise extraction and the unused `SimSpec.ϵω` field

--- a/doc/scratchpad.md
+++ b/doc/scratchpad.md
@@ -58,3 +58,4 @@ The most nebulous and least important at this stage: copying features from other
 - Control/analysis dot-cards no longer crash sema
 - Cleanup: drop dead DAECompiler-era `aliasextract.jl` and its `net_alias` stub
 - Cleanup: drop superseded `stamp_reactive_with_detection!` API, its two legacy `detect_or_cached!` overloads, and the always-empty codegen `detection_block`
+- Cleanup: drop dead DAECompiler-era `noiseparams`/`modelfields` noise extraction and the unused `SimSpec.ϵω` field

--- a/src/Cadnip.jl
+++ b/src/Cadnip.jl
@@ -31,7 +31,6 @@ using Base.ScopedValues
 
 Base.@kwdef struct SimSpec
     time::Float64=0.0
-    ϵω::Float64=0.0
     temp::DefaultOr{Float64}=mkdefault(27.0)
     gmin::DefaultOr{Float64}=mkdefault(1e-12)
     scale::DefaultOr{Float64}=mkdefault(1.0)

--- a/src/spectre.jl
+++ b/src/spectre.jl
@@ -259,29 +259,6 @@ function modelparams(m)
     ntfromstruct(i)
 end
 
-noiseparams(circ::AbstractSim) = noiseparams(circ.circuit)
-function noiseparams(circ)
-    observer = ParamObserver()
-    circ(observer)
-    noiseparams(observer)
-end
-function noiseparams(👀::ParamObserver)
-    t = something(getfield(👀, :type), Nothing)
-    noisefields = filter((fn -> startswith(String(fn), "ϵ"), modelfields(typeof(t)))...)
-    args = getfield(👀, :params)
-    childfields = []
-    for (k, v) in args
-        if typeof(v) <: ParamObserver
-            fields = noiseparams(v)
-            if !isempty(fields)
-                push!(childfields, (k => fields))
-            end
-        end
-    end
-    (; (f => 0.0 for f in noisefields)...,
-        childfields...)
-end
-
 function spice_select_device(devkind, level, version, stmt; dialect=:ngspice)
     if devkind == :d
         return :(SpectreEnvironment.diode)
@@ -364,11 +341,6 @@ end
 Base.show(io::IO, m::ParsedModel) = print(io, "ParsedModel($(m.model), ...)")
 Base.nameof(m::ParsedModel{T}) where T = nameof(T)
 Base.nameof(m::BinnedModel) = nameof(first(m.bins))
-
-modelfields(m) = ()
-modelfields(m::DataType) = fieldnames(m)
-modelfields(::Type{ParsedModel{T}}) where T = modelfields(T)
-modelfields(::Type{BinnedModel{T}}) where T = modelfields(eltype(T))
 
 Base.@assume_effects :foldable function case_adjust_kwargs_fallback(model::Type{T}, kwargs::NamedTuple{Names}) where {Names, T}
     case_insensitive = Dict(Symbol(lowercase(String(kw))) => kw for kw in fieldnames(T))


### PR DESCRIPTION
## What

Removes DAECompiler-era noise-parameter infrastructure that the MNA backend never wired up:

- **`noiseparams` (three methods, `src/spectre.jl`)** — walked a `ParamObserver` tree to build a nested `NamedTuple` of `"ϵ"`-prefixed noise fields. Nothing calls it anywhere in `src/`, `test/`, or `ext/`.
- **`modelfields` (four methods, `src/spectre.jl`)** — the only consumer of `modelfields` was `noiseparams`, so it's now orphaned and removed too.
- **`SimSpec.ϵω` (`src/Cadnip.jl`)** — a small-signal noise perturbation frequency field that was only ever declared, never read. `SimSpec` is only ever constructed as `SimSpec()` (all defaults), so dropping the field is safe.

`modelparams`/`ntfromstruct` are **retained** — they're still used by the sky130 parse tests.

## Why

Matches the ongoing cleanup pillar in `doc/scratchpad.md`: at this early stage we carry no backward-compat, and this is dead code left over from the DAECompiler backend. Net −28 lines of source.

## Verification

Ran a focused load + solve against the package (`--project=.`):

- Cadnip loads cleanly with the removals.
- `SimSpec()` constructs without `ϵω` (`time=0.0 temp=27.0`).
- `noiseparams` / `modelfields` are undefined; `modelparams` / `ntfromstruct` remain defined.
- A resistor-divider netlist still solves end-to-end (parser → codegen → `dc!`), giving `out = 2.5 V` as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiHjQ3TLNUXtsMARLvcXk9)_