### PR TITLE
AC: unify onto one result type (ACSol), retire ACSolution/solve_ac

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,15 +105,33 @@ result = dc!(CircuitSweep(circuit, sweep))     # Parameter sweep
 `dc!(cs::CircuitSweep)` returns a `SweepResult` that iterates `(params, sol)`
 pairs. Solutions support name-based access via `sol[:node]` / `sol[:I_vsrc]`.
 
-`ac!(circuit)` returns an `ACSol` — a linearized descriptor state-space system
-about the DC operating point — that you evaluate at chosen frequencies:
+`ac!(circuit, freqs)` returns an `ACSol` — a linearized descriptor state-space
+system about the DC operating point, carrying the Hz frequency grid you asked
+for. Name-based access is the SPICE-native readout (same `sol[:name]` meaning as
+DC/transient), and Hz helpers need no manual 2π conversion:
+
+```julia
+f   = acdec(20, 1, 1e6)                         # 1 Hz … 1 MHz, in Hz (SPICE .ac dec)
+ac  = ac!(circuit, f)
+resp = ac[:vout]                                # complex response over the grid
+mag  = magnitude_db(ac, :vout)                  # magnitude in dB
+phs  = phase_deg(ac, :vout)                     # phase in degrees
+```
+
+`freqresp` evaluates at arbitrary angular frequencies (ω in rad/s — the
+ControlSystems convention), and needs no stored grid:
 
 ```julia
 ac = ac!(circuit)
-f  = acdec(20, 1, 1e6)                          # 1 Hz … 1 MHz, in Hz (SPICE .ac dec)
-mag = magnitude_db(ac, :vout, f)                # magnitude in dB
-phs = phase_deg(ac, :vout, f)                   # phase in degrees
-H   = freqresp(ac, :vout, 2π .* f)              # raw complex response (ω in rad/s)
+H  = freqresp(ac, :vout, 2π .* f)               # raw complex response
+```
+
+For the ControlSystems / DescriptorSystems interop, `subsystem(ac, :name)`
+returns the SISO descriptor system for `ss`, `bode`, poles/zeros:
+
+```julia
+using RobustAndOptimalControl                   # ss(::DescriptorStateSpace)
+mag, phase, w = bode(ss(subsystem(ac, :vout)), 2π .* f)
 ```
 
 ### Two-tier model resolution

--- a/doc/ac_result_unification.md
+++ b/doc/ac_result_unification.md
@@ -41,13 +41,25 @@ views from it, then retiring `solve_ac`/`ACSolution`. Concretely:
 - Port `test/mna/core.jl`'s `solve_ac` call sites to the unified type.
 - Delete `ACSolution`, `solve_ac`, and the now-duplicated accessors.
 
-### 2. Make `sol[:name]` return-type consistent
+### 2. Make `sol[:name]` return-type consistent — **done**
 
-`ACSolution[:name]` returns a response vector; `ACSol[:name]` returns a SISO
-subsystem. Same indexing syntax, different return type is a footgun. Pick one
-meaning (a response vector reads as the natural SPICE answer; expose the
-subsystem via an explicit accessor such as `subsystem(ac, :name)` or the
-existing `ac[:name]` kept only if it clearly means "control-systems object").
+`ACSolution[:name]` returned a response vector; `ACSol[:name]` returned a SISO
+subsystem. Same indexing syntax, different return type was a footgun. Resolved:
+
+- `ACSol[:name]` now returns a complex **response vector** over the analysis's
+  Hz grid — the natural SPICE answer, matching `ACSolution[:name]`. To carry the
+  grid, `ac!` gained an optional `freqs` argument: `ac!(circuit, acdec(...))`.
+  Without a grid, `ac[:name]` errors and points at `freqresp`.
+- The SISO descriptor subsystem moved to the explicit accessor
+  `subsystem(ac, :name)` (control-systems object → `ss`/`bode`/poles/zeros).
+- `magnitude_db(ac, :name)` / `phase_deg(ac, :name)` two-arg forms read the
+  stored grid; the three-arg Hz forms remain.
+- `ACSolution[:name]` also now resolves branch currents, not just node voltages,
+  so both types index alike.
+
+Still open for the full unification (sub-task 1): retiring `ACSolution`/`solve_ac`
+onto a single type. The two `[:name]` surfaces now agree, so that retirement is a
+mechanical follow-up rather than a behavior change.
 
 ### 3. Hz-first helpers, rad/s only where the contract demands it
 

--- a/doc/ac_result_unification.md
+++ b/doc/ac_result_unification.md
@@ -1,9 +1,9 @@
 # AC result-type unification — design plan
 
-Status: **not started.** This records the design for cleaning up the AC-analysis
-UX gaps discovered while adding the Hz-based `magnitude_db`/`phase_deg` helpers
-(`src/ac.jl`). Small, self-contained follow-ups; the tracking checkboxes live in
-`doc/scratchpad.md`.
+Status: **done.** Sub-tasks 1–4 landed: `ACSol` is the single AC result type,
+its `sol[:name]` is a Hz response vector, the DSS interop moved to
+`subsystem`/`freqresp`, and hierarchical node access works. This records the
+design; the tracking checkboxes live in `doc/scratchpad.md`.
 
 ## The problem: two parallel AC result types
 
@@ -29,17 +29,25 @@ implementations, so the end state is one type, not two.
 
 ## Sub-tasks
 
-### 1. Unify on a single AC result type
+### 1. Unify on a single AC result type — **done**
 
-Leaning toward keeping `ACSol` (DSS-backed, strictly more capable — you can get
-`ss`/`bode`/poles/zeros/`freqresp` out of it) and deriving the SPICE-native
-views from it, then retiring `solve_ac`/`ACSolution`. Concretely:
+Kept `ACSol` (DSS-backed, strictly more capable — `ss`/`bode`/poles/zeros/
+`freqresp`) and derived the SPICE-native views from it, then retired
+`solve_ac`/`ACSolution`. Concretely, as landed:
 
-- Give `ACSol` the SPICE-native surface `ACSolution` has today: an Hz-based
-  `sol[:name]` response trajectory and the `magnitude_db`/`phase_deg` Bode
-  readout (the Hz methods added on top of `freqresp` are the first step).
-- Port `test/mna/core.jl`'s `solve_ac` call sites to the unified type.
-- Delete `ACSolution`, `solve_ac`, and the now-duplicated accessors.
+- `ACSol` carries the SPICE-native surface: an Hz `sol[:name]` response vector
+  (over the grid passed to `ac!(circuit, freqs)`) and the two-argument
+  `magnitude_db`/`phase_deg` Bode readout, all on top of `freqresp`.
+- `test/mna/core.jl`'s `solve_ac` call sites moved to `ac!` (netlist-driven
+  behavioral tests, per CLAUDE.md), and `test/common.jl` dropped the import.
+- Deleted `ACSolution`, all `solve_ac` methods, and the duplicated accessors;
+  `magnitude_db`/`phase_deg` are now bare generics in `solve.jl` whose only
+  methods live on `ACSol`.
+
+One correctness note surfaced during the port: the old low-level
+`solve_ac(sys, freqs)` excited with the DC rhs `b`, so it treated a plain DC
+source as an AC stimulus. `ac!` uses `b_ac` (explicit `AC` magnitudes) — the
+correct SPICE semantics — so ported tests give their sources an `AC`/`ac=` spec.
 
 ### 2. Make `sol[:name]` return-type consistent — **done**
 
@@ -54,26 +62,26 @@ subsystem. Same indexing syntax, different return type was a footgun. Resolved:
   `subsystem(ac, :name)` (control-systems object → `ss`/`bode`/poles/zeros).
 - `magnitude_db(ac, :name)` / `phase_deg(ac, :name)` two-arg forms read the
   stored grid; the three-arg Hz forms remain.
-- `ACSolution[:name]` also now resolves branch currents, not just node voltages,
-  so both types index alike.
+Landed together with sub-task 1: with `ACSolution` retired there is only one
+`[:name]` surface, and it is the response vector.
 
-Still open for the full unification (sub-task 1): retiring `ACSolution`/`solve_ac`
-onto a single type. The two `[:name]` surfaces now agree, so that retirement is a
-mechanical follow-up rather than a behavior change.
+### 3. Hz-first helpers, rad/s only where the contract demands it — **done**
 
-### 3. Hz-first helpers, rad/s only where the contract demands it
-
-Keep `freqresp` in rad/s (it *is* the ControlSystems contract) but route every
+`freqresp` stays in rad/s (it *is* the ControlSystems contract) while every
 SPICE-facing helper — `magnitude_db`, `phase_deg`, `sol[:name]` trajectory
-access, and a future `.ac` netlist card — through Hz so users never
-hand-convert. Document the one rad/s boundary (`freqresp`) prominently.
+access — routes through Hz so users never hand-convert. The one rad/s boundary
+(`freqresp`) is documented in the README AC section and the `ac.jl` header.
 
-### 4. Hierarchical device-observable access (`src/ac.jl` LIMITATION 1)
+### 4. Hierarchical device-observable access — **done (for what MNA models)**
 
-Only flat top-level node/current names are observable today; device-internal
-variables via a hierarchical path (`sys.l3.V`) are not. Voltages across devices
-wired between top-level nodes can already be had as node differences; the gap is
-genuinely-internal nodes. Scope this against whatever the unified type exposes.
+Subcircuit-internal nodes flatten into the flat name table (`:x1_out`), so they
+are observable by name on an `ACSol` exactly like top-level nodes, and a
+`NodeRef` from `scope(...)` now indexes an `ACSol` too (parity with
+`DCSolution`/transient). The only thing that is *not* a system variable is a
+voltage across a device wired between two named nodes (an inductor's `V(l3)`) —
+that is a derived quantity, taken as a node difference. So there is no remaining
+hierarchical-access gap for anything MNA represents as a state; genuine
+device-internal observables would need the device to expose them as nodes.
 
 ## Notes
 

--- a/doc/scratchpad.md
+++ b/doc/scratchpad.md
@@ -61,9 +61,9 @@ The most nebulous and least important at this stage: copying features from other
 - [x] Port the Makie extension (`explore`) to the MNA backend and wire it into `[extensions]` with a headless CairoMakie test
 - [x] Cleanup: drop dead DAECompiler-era `noiseparams`/`modelfields` noise extraction and the unused `SimSpec.ϵω` field
 - [x] UX: Hz-based `magnitude_db`/`phase_deg` for the high-level `ac!` (`ACSol`) result, fixed AC docs/README
-- [ ] AC UX: unify the two AC result types (`ACSolution` Hz vs `ACSol` rad/s) onto one Hz-first surface that keeps the ControlSystems interop — see `doc/ac_result_unification.md`
-- [x] AC UX: make `sol[:name]` return-type consistent across AC types — both `ACSolution` and `ACSol` now index to a complex response vector; the DSS subsystem moved to `subsystem(ac, :name)`; `ac!(circuit, freqs)` carries a Hz grid and 2-arg `magnitude_db`/`phase_deg`
-- [ ] AC UX: hierarchical device-observable access in AC (`src/ac.jl` LIMITATION 1) — see `doc/ac_result_unification.md`
+- [x] AC UX: unify the two AC result types onto one Hz-first surface that keeps the ControlSystems interop — retired `ACSolution`/`solve_ac`; `ac!`/`ACSol` is the single AC path (DSS-backed `freqresp`/`ss`/`bode` + SPICE-native `sol[:name]`)
+- [x] AC UX: make `sol[:name]` return-type consistent across AC types — `ACSol` now indexes to a complex response vector (matching DC/tran); the DSS subsystem moved to `subsystem(ac, :name)`; `ac!(circuit, freqs)` carries a Hz grid and 2-arg `magnitude_db`/`phase_deg`
+- [x] AC UX: hierarchical device-observable access in AC — subcircuit nodes flatten into the name table so `ac[:x1_out]` resolves, and a `NodeRef` from `scope(...)` indexes an `ACSol` (parity with DC/tran); genuine device-across voltages remain node differences
 - [ ] Noise N0: deferred noise-source channel on `MNAContext`, no-op on `DirectStampContext` (zero transient cost) — design: `doc/noise_analysis_design.md`
 - [ ] Noise N1: per-source PSD models at the DC bias (thermal/shot/flicker + VA `white_noise`/`flicker_noise`)
 - [ ] Noise N2: noise transfer functions via the AC linearization (adjoint solve per output/frequency)

--- a/doc/scratchpad.md
+++ b/doc/scratchpad.md
@@ -62,7 +62,7 @@ The most nebulous and least important at this stage: copying features from other
 - [x] Cleanup: drop dead DAECompiler-era `noiseparams`/`modelfields` noise extraction and the unused `SimSpec.ϵω` field
 - [x] UX: Hz-based `magnitude_db`/`phase_deg` for the high-level `ac!` (`ACSol`) result, fixed AC docs/README
 - [ ] AC UX: unify the two AC result types (`ACSolution` Hz vs `ACSol` rad/s) onto one Hz-first surface that keeps the ControlSystems interop — see `doc/ac_result_unification.md`
-- [ ] AC UX: make `sol[:name]` return-type consistent across AC types — see `doc/ac_result_unification.md`
+- [x] AC UX: make `sol[:name]` return-type consistent across AC types — both `ACSolution` and `ACSol` now index to a complex response vector; the DSS subsystem moved to `subsystem(ac, :name)`; `ac!(circuit, freqs)` carries a Hz grid and 2-arg `magnitude_db`/`phase_deg`
 - [ ] AC UX: hierarchical device-observable access in AC (`src/ac.jl` LIMITATION 1) — see `doc/ac_result_unification.md`
 - [ ] Noise N0: deferred noise-source channel on `MNAContext`, no-op on `DirectStampContext` (zero transient cost) — design: `doc/noise_analysis_design.md`
 - [ ] Noise N1: per-source PSD models at the DC bias (thermal/shot/flicker + VA `white_noise`/`flicker_noise`)

--- a/src/ac.jl
+++ b/src/ac.jl
@@ -13,20 +13,24 @@
 # For MNA: C·dx/dt + G·x = b
 # DSS form: E·dx = A·x + B·u  where E=C, A=-G, B=b_ac
 #
-# Current Limitations:
-# --------------------
-# 1. Hierarchical device observables: Cannot observe internal device variables via
-#    hierarchical path syntax (e.g., `sys.l3.V`). Only top-level node voltages and
-#    branch currents are accessible via symbol names:
+# Observable access:
+# ------------------
+# Any system variable is accessible by name — top-level nodes, branch currents,
+# and hierarchical subcircuit nodes (which flatten into the name table, e.g.
+# `:x1_out`). A `NodeRef` from `scope(...)` also indexes an `ACSol`.
 #      - Node voltages: `ac[:vout]` (over the grid) or `freqresp(ac, :vout, ωs)`
 #      - Branch currents: `ac[:I_V1]` or `freqresp(ac, :I_V1, ωs)`
-#    Device voltages can be computed as node differences:
+#
+# The one thing that is NOT a system variable is a voltage *across* a device
+# wired between two named nodes (an inductor's `V(l3)`); that is a derived
+# quantity, taken as a node difference:
 #      `freqresp(ac, :n1, ωs) - freqresp(ac, :n2, ωs)`
 #
-# 2. Noise analysis: The `noise!()` function is not implemented. Requires:
+# Not yet implemented — Noise analysis: The `noise!()` function. Requires:
 #    - Per-device noise source modeling (thermal, shot, flicker)
 #    - Noise correlation matrix assembly
 #    - Output noise spectral density computation
+#    See doc/noise_analysis_design.md for the planned port.
 #
 # Bode plots: Use RobustAndOptimalControl to convert DescriptorStateSpace to
 # standard StateSpace: `bode(ss(subsystem(ac, :vout)), ωs)`
@@ -226,8 +230,9 @@ end
 
 Magnitude in dB (`20·log₁₀|H|`) of node/current `name` across `freqs`, which are
 given in **hertz** (as returned by [`acdec`](@ref)), matching SPICE `.ac`
-conventions. This mirrors [`magnitude_db(::ACSolution, ::Symbol)`](@ref) for the
-high-level `ac!` result, so you no longer need to convert to rad/s by hand.
+conventions, so you no longer need to convert to rad/s by hand. See also the
+two-argument [`magnitude_db(::ACSol, ::Symbol)`](@ref) which reads the grid
+stored on `ac`.
 
 ```julia
 ac = ac!(circuit)
@@ -253,8 +258,7 @@ end
     magnitude_db(ac::ACSol, name::Symbol) -> Vector{Float64}
 
 Magnitude in dB of node/current `name` over the frequency grid the analysis was
-built with (`ac!(circuit, freqs)`). Mirrors
-[`magnitude_db(::ACSolution, ::Symbol)`](@ref); errors if `ac` carries no grid.
+built with (`ac!(circuit, freqs)`); errors if `ac` carries no grid.
 """
 function MNA.magnitude_db(ac::ACSol, name::Symbol)
     return 20 .* log10.(abs.(ac[name]))
@@ -319,8 +323,12 @@ end
 
 Name-based access to an AC solution: the complex response at node voltage or
 branch current `name` over the frequency grid the analysis was built with
-(`ac!(circuit, freqs)`). This is the SPICE-native readout and matches
-[`ACSolution`](@ref)'s `sol[:name]`, so the two AC result types index alike.
+(`ac!(circuit, freqs)`). This is the SPICE-native readout and follows the same
+`sol[:name]` convention as the DC and transient solutions, so all three index
+alike.
+
+Hierarchical subcircuit nodes flatten into the name table (`:x1_out`), so they
+resolve here too; a `NodeRef` from `scope(...)` works as the index as well.
 
 For the descriptor-state-space (ControlSystems) object of an output, use
 [`subsystem`](@ref) instead. For evaluation at arbitrary angular frequencies
@@ -341,6 +349,12 @@ function Base.getindex(ac::ACSol, name::Symbol)
     end
     return freqresp(ac, name, 2π .* ac.freqs)
 end
+
+# Hierarchical access: a NodeRef (from `scope`) resolves to its flat name,
+# mirroring the DCSolution / transient-solution NodeRef indexing.
+Base.getindex(ac::ACSol, ref::MNA.NodeRef) = ac[MNA._flat_name(ref)]
+freqresp(ac::ACSol, ref::MNA.NodeRef, ωs::AbstractVector{<:Real}) =
+    freqresp(ac, MNA._flat_name(ref), ωs)
 
 """
     subsystem(ac::ACSol, name::Symbol) -> DescriptorStateSpace

--- a/src/ac.jl
+++ b/src/ac.jl
@@ -18,8 +18,8 @@
 # 1. Hierarchical device observables: Cannot observe internal device variables via
 #    hierarchical path syntax (e.g., `sys.l3.V`). Only top-level node voltages and
 #    branch currents are accessible via symbol names:
-#      - Node voltages: `freqresp(ac, :vout, ωs)` or `ac[:vout]`
-#      - Branch currents: `freqresp(ac, :I_V1, ωs)` or `ac[:I_V1]`
+#      - Node voltages: `ac[:vout]` (over the grid) or `freqresp(ac, :vout, ωs)`
+#      - Branch currents: `ac[:I_V1]` or `freqresp(ac, :I_V1, ωs)`
 #    Device voltages can be computed as node differences:
 #      `freqresp(ac, :n1, ωs) - freqresp(ac, :n2, ωs)`
 #
@@ -29,13 +29,13 @@
 #    - Output noise spectral density computation
 #
 # Bode plots: Use RobustAndOptimalControl to convert DescriptorStateSpace to
-# standard StateSpace: `bode(ss(ac[:vout]), ωs)`
+# standard StateSpace: `bode(ss(subsystem(ac, :vout)), ωs)`
 #==============================================================================#
 
 using DescriptorSystems
 using LinearAlgebra
 
-export ac!, acdec, freqresp, magnitude_db, phase_deg
+export ac!, acdec, freqresp, magnitude_db, phase_deg, subsystem
 
 abstract type FreqSol end
 
@@ -44,7 +44,8 @@ abstract type FreqSol end
 
 AC small-signal solution for MNA circuits.
 
-Contains the linearized descriptor state-space system and DC operating point.
+Contains the linearized descriptor state-space system and DC operating point,
+plus the optional Hz frequency grid the analysis was requested over.
 
 # Fields
 - `dss`: DescriptorStateSpace system (E·dx = A·x + B·u, y = C·x)
@@ -52,12 +53,19 @@ Contains the linearized descriptor state-space system and DC operating point.
 - `node_names`: Names of voltage nodes
 - `current_names`: Names of current variables
 - `n_nodes`: Number of voltage nodes
+- `freqs`: Frequency grid in **hertz** (SPICE `.ac` convention); empty when the
+  analysis was run without one
 
 # Usage
 ```julia
+# With a frequency grid: name-based access returns the SPICE-native response.
+ac_sol = ac!(circuit, acdec(20, 0.01, 10))   # freqs in Hz
+resp = ac_sol[:vout]                          # complex response over the grid
+
+# Without a grid: evaluate at chosen angular frequencies via freqresp.
 ac_sol = ac!(circuit)
-ωs = 2π .* acdec(20, 0.01, 10)  # frequencies in rad/s
-resp = freqresp(ac_sol, :vout, ωs)  # frequency response at node :vout
+ωs = 2π .* acdec(20, 0.01, 10)                # rad/s (ControlSystems contract)
+resp = freqresp(ac_sol, :vout, ωs)
 ```
 """
 struct ACSol <: FreqSol
@@ -66,10 +74,11 @@ struct ACSol <: FreqSol
     node_names::Vector{Symbol}
     current_names::Vector{Symbol}
     n_nodes::Int
+    freqs::Vector{Float64}
 end
 
 """
-    ac!(circuit::MNA.MNACircuit; gmin=1e-12) -> ACSol
+    ac!(circuit::MNA.MNACircuit, freqs=Float64[]; gmin=1e-12) -> ACSol
 
 Perform AC small-signal analysis on an MNA circuit.
 
@@ -81,20 +90,24 @@ Perform AC small-signal analysis on an MNA circuit.
 
 # Arguments
 - `circuit::MNACircuit`: Circuit with builder function and parameters
+- `freqs`: Frequency grid in **hertz** (SPICE `.ac` convention, e.g.
+  `acdec(20, 1, 1e6)`). When supplied, name-based access `ac[:name]` and the
+  two-argument `magnitude_db(ac, :name)` / `phase_deg(ac, :name)` return the
+  response over this grid. Optional — omit it and evaluate at arbitrary angular
+  frequencies via [`freqresp`](@ref) instead.
 - `gmin`: Minimum conductance for numerical stability
 
 # Returns
-`ACSol` containing the linearized DSS system and DC solution.
+`ACSol` containing the linearized DSS system, DC solution, and frequency grid.
 
 # Example
 ```julia
 circuit = MNACircuit(build_filter; R=1000.0, C=1e-6)
-ac_sol = ac!(circuit)
-ωs = 2π .* acdec(20, 0.01, 10)
-resp = freqresp(ac_sol, :vout, ωs)
+ac_sol = ac!(circuit, acdec(20, 0.01, 10))   # freqs in Hz
+resp = ac_sol[:vout]                          # response over the grid
 ```
 """
-function ac!(circuit::MNA.MNACircuit; gmin=1e-12)
+function ac!(circuit::MNA.MNACircuit, freqs::AbstractVector{<:Real}=Float64[]; gmin=1e-12)
     # Build circuit with structure discovery
     ctx = MNA.MNAContext()
     circuit.builder(circuit.params, circuit.spec, 0.0; x=MNA.ZERO_VECTOR, ctx=ctx)
@@ -144,7 +157,8 @@ function ac!(circuit::MNA.MNACircuit; gmin=1e-12)
 
     dss_sys = dss(-G, C, B, C_out, D)
 
-    return ACSol(dss_sys, dc_x, copy(ctx.node_names), copy(ctx.current_names), ctx.n_nodes)
+    return ACSol(dss_sys, dc_x, copy(ctx.node_names), copy(ctx.current_names),
+                 ctx.n_nodes, collect(Float64, freqs))
 end
 
 """
@@ -236,6 +250,27 @@ function MNA.phase_deg(ac::ACSol, name::Symbol, freqs::AbstractVector{<:Real})
 end
 
 """
+    magnitude_db(ac::ACSol, name::Symbol) -> Vector{Float64}
+
+Magnitude in dB of node/current `name` over the frequency grid the analysis was
+built with (`ac!(circuit, freqs)`). Mirrors
+[`magnitude_db(::ACSolution, ::Symbol)`](@ref); errors if `ac` carries no grid.
+"""
+function MNA.magnitude_db(ac::ACSol, name::Symbol)
+    return 20 .* log10.(abs.(ac[name]))
+end
+
+"""
+    phase_deg(ac::ACSol, name::Symbol) -> Vector{Float64}
+
+Phase in degrees of node/current `name` over the frequency grid the analysis was
+built with (`ac!(circuit, freqs)`). Errors if `ac` carries no grid.
+"""
+function MNA.phase_deg(ac::ACSol, name::Symbol)
+    return rad2deg.(angle.(ac[name]))
+end
+
+"""
     _get_node_index(ac::ACSol, node::Symbol) -> Int
 
 Get the system index for a node by name. Returns 0 for ground.
@@ -280,23 +315,50 @@ function _get_index(ac::ACSol, name::Symbol)
 end
 
 """
-    Base.getindex(ac::ACSol, name::Symbol) -> DescriptorStateSpace
+    ac[name::Symbol] -> Vector{ComplexF64}
 
-Get the descriptor state-space subsystem for observing a specific node voltage
-or branch current.
+Name-based access to an AC solution: the complex response at node voltage or
+branch current `name` over the frequency grid the analysis was built with
+(`ac!(circuit, freqs)`). This is the SPICE-native readout and matches
+[`ACSolution`](@ref)'s `sol[:name]`, so the two AC result types index alike.
 
-This returns a SISO (single-input single-output) system from AC excitation
-to the specified output.
+For the descriptor-state-space (ControlSystems) object of an output, use
+[`subsystem`](@ref) instead. For evaluation at arbitrary angular frequencies
+(without a stored grid), use [`freqresp`](@ref).
+
+# Example
+```julia
+ac = ac!(circuit, acdec(20, 1, 1e6))   # freqs in Hz
+resp = ac[:vout]                        # complex response over the grid
+iv1  = ac[:I_V1]                        # source-current response
+```
+"""
+function Base.getindex(ac::ACSol, name::Symbol)
+    if isempty(ac.freqs)
+        error("ACSol has no frequency grid: `ac[:$name]` needs one. Call " *
+              "`ac!(circuit, freqs)` with a Hz grid (e.g. `acdec(20, 1, 1e6)`), " *
+              "or use `freqresp(ac, :$name, ωs)` with angular frequencies.")
+    end
+    return freqresp(ac, name, 2π .* ac.freqs)
+end
+
+"""
+    subsystem(ac::ACSol, name::Symbol) -> DescriptorStateSpace
+
+Descriptor-state-space subsystem for observing a specific node voltage or branch
+current: a SISO (single-input single-output) system from AC excitation to the
+named output. Use it for the ControlSystems / DescriptorSystems interop —
+`ss`, `bode`, poles/zeros.
 
 # Example
 ```julia
 ac_sol = ac!(circuit)
-dss_vout = ac_sol[:vout]     # Node voltage
-dss_iv1 = ac_sol[:I_V1]      # Voltage source current
-# Can use with ControlSystemsBase for bode plots, etc.
+dss_vout = subsystem(ac_sol, :vout)     # node voltage
+dss_iv1  = subsystem(ac_sol, :I_V1)     # voltage-source current
+bode(ss(subsystem(ac_sol, :vout)), ωs)  # via ControlSystemsBase
 ```
 """
-function Base.getindex(ac::ACSol, name::Symbol)
+function subsystem(ac::ACSol, name::Symbol)
     idx = _get_index(ac, name)
     idx == 0 && error("Cannot create subsystem for ground")
 

--- a/src/mna/solve.jl
+++ b/src/mna/solve.jl
@@ -16,10 +16,11 @@ using Random
 
 # real_time is defined in precompile.jl (handles ForwardDiff.Dual for tgrad)
 
-export DCSolution, ACSolution
-export solve_dc, solve_dc!, solve_ac
+export DCSolution
+export solve_dc, solve_dc!
 export make_ode_problem, make_dae_problem  # For static MNAData
-# voltage / current accessors deleted — use sol[:name]. magnitude_db / phase_deg stay for AC.
+# voltage / current accessors deleted — use sol[:name]. magnitude_db / phase_deg
+# are the AC Bode readout; their methods live on ACSol in src/ac.jl.
 export magnitude_db, phase_deg
 
 #==============================================================================#
@@ -239,78 +240,26 @@ end
 # AC Solution
 #==============================================================================#
 
-"""
-    ACSolution
-
-Result of AC small-signal analysis.
-
-# Fields
-- `freqs::Vector{Float64}`: Frequency points (Hz)
-- `x::Vector{Vector{ComplexF64}}`: Solution at each frequency
-- `node_names::Vector{Symbol}`: Node names
-- `current_names::Vector{Symbol}`: Current variable names
-- `n_nodes::Int`: Number of voltage nodes
-"""
-struct ACSolution
-    freqs::Vector{Float64}
-    x::Vector{Vector{ComplexF64}}
-    node_names::Vector{Symbol}
-    current_names::Vector{Symbol}
-    n_nodes::Int
-end
+# AC small-signal analysis lives on the `ACSol` type in `src/ac.jl`, which is
+# DSS-backed (freqresp, ss, bode, poles/zeros) and carries a SPICE-native
+# name-based readout. `magnitude_db` / `phase_deg` are that readout's Bode
+# helpers; the generics are declared here (so MNA owns and exports them) and
+# their methods are attached to `ACSol` in `src/ac.jl`.
 
 """
-    _ac_index(sol::ACSolution, name::Symbol) -> Int
+    magnitude_db(ac, name[, freqs]) -> Vector{Float64}
 
-System index of node voltage or branch current `name`. Node names resolve first,
-then current names (offset by `n_nodes`). Errors if unknown.
+Magnitude in dB (`20·log₁₀|H|`) of node/current `name`. See the `ACSol`
+methods in `src/ac.jl`.
 """
-function _ac_index(sol::ACSolution, name::Symbol)
-    idx = findfirst(==(name), sol.node_names)
-    idx === nothing || return idx
-    idx = findfirst(==(name), sol.current_names)
-    idx === nothing && error("Unknown node or current: $name. Available nodes: " *
-                             "$(sol.node_names), currents: $(sol.current_names)")
-    return sol.n_nodes + idx
-end
+function magnitude_db end
 
 """
-    sol[name::Symbol]
+    phase_deg(ac, name[, freqs]) -> Vector{Float64}
 
-Name-based access to an AC solution — returns the complex trajectory (node
-voltage or branch current) across all frequencies. `sol[name, freq_idx]` returns
-the complex value at one frequency.
+Phase in degrees of node/current `name`. See the `ACSol` methods in `src/ac.jl`.
 """
-function Base.getindex(sol::ACSolution, name::Symbol)
-    (name === :gnd || name === Symbol("0")) && return zeros(ComplexF64, length(sol.freqs))
-    idx = _ac_index(sol, name)
-    return [x[idx] for x in sol.x]
-end
-
-function Base.getindex(sol::ACSolution, name::Symbol, freq_idx::Int)
-    (name === :gnd || name === Symbol("0")) && return 0.0 + 0.0im
-    idx = _ac_index(sol, name)
-    return sol.x[freq_idx][idx]
-end
-
-"""
-    magnitude_db(sol::ACSolution, name::Symbol) -> Vector{Float64}
-
-Get the voltage magnitude in dB at a node.
-"""
-magnitude_db(sol::ACSolution, name::Symbol) = 20 .* log10.(abs.(sol[name]))
-
-"""
-    phase_deg(sol::ACSolution, name::Symbol) -> Vector{Float64}
-
-Get the voltage phase in degrees at a node.
-"""
-phase_deg(sol::ACSolution, name::Symbol) = rad2deg.(angle.(sol[name]))
-
-function Base.show(io::IO, sol::ACSolution)
-    print(io, "ACSolution($(length(sol.freqs)) frequencies, ")
-    print(io, "$(length(sol.node_names)) nodes)")
-end
+function phase_deg end
 
 #==============================================================================#
 # DC Analysis
@@ -929,50 +878,9 @@ function solve_dc(builder::F, params::P, spec::MNASpec;
 end
 
 #==============================================================================#
-# AC Analysis
+# AC Analysis: see `ac!` / `ACSol` in src/ac.jl. AC linearizes at the DC
+# operating point and builds a DSS-backed result; there is one AC entry point.
 #==============================================================================#
-
-"""
-    solve_ac(sys::MNAData, freqs::AbstractVector{<:Real}) -> ACSolution
-
-Solve AC small-signal analysis at given frequencies.
-
-For each frequency f, solves: (G + j*2π*f*C) * x = b
-
-This linearizes around the DC operating point, so DC analysis
-should be performed first if the circuit contains nonlinear elements.
-"""
-function solve_ac(sys::MNAData, freqs::AbstractVector{<:Real})
-    n = system_size(sys)
-    nf = length(freqs)
-
-    results = Vector{Vector{ComplexF64}}(undef, nf)
-    b_complex = complex.(sys.b)
-
-    for (i, f) in enumerate(freqs)
-        omega = 2π * f
-        # Form Y = G + jωC
-        Y = sys.G + (im * omega) * sys.C
-        # Solve Y*x = b
-        results[i] = Y \ b_complex
-    end
-
-    return ACSolution(collect(Float64, freqs), results,
-                      sys.node_names, sys.current_names, sys.n_nodes)
-end
-
-"""
-    solve_ac(sys::MNAData; fstart, fstop, points_per_decade) -> ACSolution
-
-Solve AC analysis with logarithmically spaced frequencies.
-"""
-function solve_ac(sys::MNAData; fstart::Real, fstop::Real, points_per_decade::Int=10)
-    # Generate log-spaced frequencies
-    decades = log10(fstop / fstart)
-    n_points = max(2, round(Int, decades * points_per_decade) + 1)
-    freqs = 10 .^ range(log10(fstart), log10(fstop), length=n_points)
-    return solve_ac(sys, freqs)
-end
 
 #==============================================================================#
 # Transient Analysis: ODEProblem Formulation
@@ -1409,8 +1317,8 @@ _flat_name(ref::NodeRef) = isempty(ref.path) ? ref.name :
 
 # Support sol[NodeRef] on DCSolution and any SciML transient solution whose
 # f.sys supports SII. Delegates to the flat name lookup — `sol[:x1_out]`.
+# (The AC `ACSol` NodeRef method lives in src/ac.jl, next to that type.)
 Base.getindex(sol::DCSolution, ref::NodeRef) = sol[_flat_name(ref)]
-Base.getindex(sol::ACSolution, ref::NodeRef) = sol[_flat_name(ref)]
 # Transient solutions come from SciMLBase; add the NodeRef → flat lookup.
 Base.getindex(sol::SciMLBase.AbstractTimeseriesSolution, ref::NodeRef) =
     sol[_flat_name(ref)]
@@ -2202,7 +2110,8 @@ end
 # MNACircuit Analysis Methods
 #==============================================================================#
 
-# Internal solve_dc/solve_ac methods for MNACircuit (called from sweeps.jl)
+# Internal solve_dc method for MNACircuit (called from sweeps.jl). AC analysis
+# goes through `ac!` / `ACSol` (src/ac.jl), which linearizes at this DC point.
 #
 # NOTE: solve_dc(circuit) now uses Newton iteration via solve_dc(builder, params, spec)
 # which handles both linear and nonlinear circuits. For linear circuits, it converges
@@ -2236,16 +2145,6 @@ function solve_dc(circuit::MNACircuit)
     sys_final = assemble!(ctx)
 
     return DCSolution(sys_final, u)
-end
-
-function solve_ac(circuit::MNACircuit, freqs::AbstractVector{<:Real}; kwargs...)
-    # Build with detection, then rebuild with AC spec
-    ctx = build_with_detection(circuit)
-    ac_spec = MNASpec(temp=circuit.spec.temp, mode=:ac, time=0.0)
-    reset_for_restamping!(ctx)
-    circuit.builder(circuit.params, ac_spec, 0.0; x=ZERO_VECTOR, ctx=ctx)
-    sys = assemble!(ctx)
-    return solve_ac(sys, freqs; kwargs...)
 end
 
 #==============================================================================#

--- a/src/mna/solve.jl
+++ b/src/mna/solve.jl
@@ -260,22 +260,36 @@ struct ACSolution
 end
 
 """
+    _ac_index(sol::ACSolution, name::Symbol) -> Int
+
+System index of node voltage or branch current `name`. Node names resolve first,
+then current names (offset by `n_nodes`). Errors if unknown.
+"""
+function _ac_index(sol::ACSolution, name::Symbol)
+    idx = findfirst(==(name), sol.node_names)
+    idx === nothing || return idx
+    idx = findfirst(==(name), sol.current_names)
+    idx === nothing && error("Unknown node or current: $name. Available nodes: " *
+                             "$(sol.node_names), currents: $(sol.current_names)")
+    return sol.n_nodes + idx
+end
+
+"""
     sol[name::Symbol]
 
-Name-based access to an AC solution — returns the complex trajectory across
-all frequencies. `sol[name, freq_idx]` returns the complex value at one frequency.
+Name-based access to an AC solution — returns the complex trajectory (node
+voltage or branch current) across all frequencies. `sol[name, freq_idx]` returns
+the complex value at one frequency.
 """
 function Base.getindex(sol::ACSolution, name::Symbol)
     (name === :gnd || name === Symbol("0")) && return zeros(ComplexF64, length(sol.freqs))
-    idx = findfirst(==(name), sol.node_names)
-    idx === nothing && error("Unknown node: $name")
+    idx = _ac_index(sol, name)
     return [x[idx] for x in sol.x]
 end
 
 function Base.getindex(sol::ACSolution, name::Symbol, freq_idx::Int)
     (name === :gnd || name === Symbol("0")) && return 0.0 + 0.0im
-    idx = findfirst(==(name), sol.node_names)
-    idx === nothing && error("Unknown node: $name")
+    idx = _ac_index(sol, name)
     return sol.x[freq_idx][idx]
 end
 

--- a/test/ac.jl
+++ b/test/ac.jl
@@ -52,7 +52,7 @@ resp_an = ControlSystemsBase.freqrespv(H, ωs)
 @test all(Cadnip.freqresp(ac, :vin, ωs) .≈ 1.0) # check directly-observed source
 
 # SPICE-native name-based access: ac[:name] returns the complex response over the
-# stored Hz grid, matching ACSolution[:name] (return-type consistency).
+# stored Hz grid, following the same sol[:name] convention as dc!/tran!.
 @test ac[:vout] ≈ resp_sim
 @test all(ac[:vin] .≈ 1.0)
 
@@ -148,16 +148,47 @@ spectre_ac_isource_sol = ac!(MNACircuit(spectre_ac_isource_circuit))
 @test all(Cadnip.freqresp(spectre_ac_isource_sol, :vin, [1.0, 10.0]) .≈ 1.0 + 0.0im)
 
 #==============================================================================#
-# Limitations - Functionality Not Yet Implemented in MNA AC
+# Hierarchical / subcircuit node access
 #==============================================================================#
 
-# LIMITATION 1: Hierarchical device observable access
-# ---------------------------------------------------
-# Cannot observe internal device variables via hierarchical path (sys.l3.V).
-# MNA tracks flat node/current names. However, for devices connected between
-# top-level nodes, we CAN compute the voltage as node difference (shown above).
+# Subcircuit-internal nodes flatten into the flat name table (e.g. :x1_out), so
+# they are observable by name on an ACSol just like top-level nodes — and a
+# NodeRef from scope(...) resolves to the same flat name. (A voltage *across* a
+# device between two named nodes is still a node difference, e.g. V_L3 above.)
+let
+    function build_hier(params, spec, t=0.0; x=Float64[], ctx=nothing)
+        ctx === nothing ? (ctx = MNAContext()) : Cadnip.MNA.reset_for_restamping!(ctx)
+        vin    = Cadnip.MNA.get_node!(ctx, :vin)
+        x1_in  = Cadnip.MNA.get_node!(ctx, :x1_in)
+        x1_out = Cadnip.MNA.get_node!(ctx, :x1_out)
+        # 6-arg (mode-aware) stamp! is the one that registers the AC excitation
+        # (b_ac); the 4-arg form is DC-only.
+        Cadnip.MNA.stamp!(VoltageSource(0.0; ac=1.0), ctx, vin, 0, t, spec.mode)
+        Cadnip.MNA.stamp!(Resistor(1e3), ctx, vin, x1_in)
+        Cadnip.MNA.stamp!(Resistor(1e3), ctx, x1_in, x1_out)
+        Cadnip.MNA.stamp!(Capacitor(1e-6), ctx, x1_out, 0)
+        return ctx
+    end
+    hier    = MNACircuit(build_hier)
+    hfreqs  = acdec(10, 1, 1e4)          # 1 Hz … 10 kHz; RC pole ≈ 80 Hz
+    hier_ac = ac!(hier, hfreqs)
 
-# LIMITATION 2: Noise analysis
+    # The (would-be subcircuit-internal) node is observable by its flat name,
+    # and carries the expected unit-input low-pass response (not a trivial zero).
+    resp_flat = hier_ac[:x1_out]
+    @test length(resp_flat) == length(hfreqs)
+    @test abs(resp_flat[1]) > 0.9        # low freq: cap open, x1_out ≈ vin
+    @test abs(resp_flat[end]) < 0.1      # high freq: cap shorts, rolled off
+
+    # A NodeRef from scope(...) indexes the ACSol identically.
+    s = scope(Cadnip.MNA.assemble!(hier))
+    @test s.x1.out isa NodeRef
+    @test hier_ac[s.x1.out] == resp_flat
+    @test Cadnip.freqresp(hier_ac, s.x1.out, 2π .* hfreqs) ==
+          Cadnip.freqresp(hier_ac, :x1_out, 2π .* hfreqs)
+end
+
+# LIMITATION: Noise analysis
 # ----------------------------
 # noise!() is not implemented. Would require:
 # - Thermal noise (4kTR) for resistors

--- a/test/ac.jl
+++ b/test/ac.jl
@@ -32,11 +32,14 @@ ast = NyanSpectreNetlistParser.parse(IOBuffer(spice_code); start_lang=:spice, im
 circuit_code = Cadnip.make_mna_circuit(ast)
 circuit_fn = eval(circuit_code)
 
-# Create MNACircuit with parameters
+# Create MNACircuit with parameters. Passing the Hz grid to ac! makes the
+# SPICE-native name-based readout (ac[:name], 2-arg magnitude_db/phase_deg)
+# resolve over that grid.
 circ = MNACircuit(circuit_fn; res=R4_val)
-ac = ac!(circ)
+freqs_hz = acdec(20, 0.01, 10) # equivalent to spice .ac dec 10 0.01 10
+ac = ac!(circ, freqs_hz)
 
-ωs = 2π .* acdec(20, 0.01, 10) # equivalent to spice .ac dec 10 0.01 10
+ωs = 2π .* freqs_hz
 resp_sim = Cadnip.freqresp(ac, :vout, ωs) # compute frequency response
 
 # analytic
@@ -48,17 +51,30 @@ resp_an = ControlSystemsBase.freqrespv(H, ωs)
 
 @test all(Cadnip.freqresp(ac, :vin, ωs) .≈ 1.0) # check directly-observed source
 
-# Hz-based bode helpers on the high-level ACSol: magnitude_db / phase_deg take
-# frequencies in Hz (SPICE .ac convention), so no manual 2π conversion.
-freqs_hz = acdec(20, 0.01, 10)
+# SPICE-native name-based access: ac[:name] returns the complex response over the
+# stored Hz grid, matching ACSolution[:name] (return-type consistency).
+@test ac[:vout] ≈ resp_sim
+@test all(ac[:vin] .≈ 1.0)
+
+# Hz-based bode helpers on the high-level ACSol. The 2-arg forms use the stored
+# grid; the 3-arg forms take frequencies in Hz (SPICE .ac convention), so no
+# manual 2π conversion in either case.
+@test Cadnip.magnitude_db(ac, :vout) ≈ 20 .* log10.(abs.(resp_an))
+@test Cadnip.phase_deg(ac, :vout) ≈ rad2deg.(angle.(resp_an))
 @test Cadnip.magnitude_db(ac, :vout, freqs_hz) ≈ 20 .* log10.(abs.(resp_an))
 @test Cadnip.phase_deg(ac, :vout, freqs_hz) ≈ rad2deg.(angle.(resp_an))
 # equivalent to going through freqresp with rad/s by hand
 @test Cadnip.magnitude_db(ac, :vout, freqs_hz) ≈ 20 .* log10.(abs.(resp_sim))
 
-# Convert to ControlSystems state space, compute bode
-# RobustAndOptimalControl provides ss(::DescriptorStateSpace) conversion
-mag_sim, phase_sim, w_sim = bode(ss(ac[:vout]), ωs)
+# An ACSol without a frequency grid has no ac[:name] readout — use freqresp.
+ac_nogrid = ac!(circ)
+@test_throws ErrorException ac_nogrid[:vout]
+@test Cadnip.freqresp(ac_nogrid, :vout, ωs) ≈ resp_sim
+
+# The descriptor-state-space subsystem is now an explicit accessor (subsystem),
+# not ac[:name]. Convert to ControlSystems state space and compute bode.
+# RobustAndOptimalControl provides ss(::DescriptorStateSpace) conversion.
+mag_sim, phase_sim, w_sim = bode(ss(subsystem(ac, :vout)), ωs)
 mag_an, phase_an, w_an = bode(H, ωs)
 
 @test mag_sim ≈ mag_an

--- a/test/common.jl
+++ b/test/common.jl
@@ -10,7 +10,7 @@ using SciMLBase
 using Sundials
 using LinearSolve: KLUFactorization
 
-using Cadnip.MNA: MNAContext, MNASpec, assemble!, solve_dc, solve_ac
+using Cadnip.MNA: MNAContext, MNASpec, assemble!, solve_dc
 using Cadnip.MNA: MNACircuit
 using Cadnip.MNA: get_node!, stamp!
 using Cadnip.MNA: Resistor, Capacitor, Inductor, VoltageSource, CurrentSource

--- a/test/mna/core.jl
+++ b/test/mna/core.jl
@@ -26,7 +26,7 @@ using Cadnip.MNA: Resistor, Capacitor, Inductor, VoltageSource, CurrentSource
 using Cadnip.MNA: get_source_value, pwl_at_time
 using Cadnip.MNA: VCVS, VCCS, CCVS, CCCS
 using Cadnip.MNA: assemble!, assemble_G, assemble_C, get_rhs
-using Cadnip.MNA: DCSolution, ACSolution, solve_dc, solve_ac
+using Cadnip.MNA: DCSolution, solve_dc
 using Cadnip.MNA: magnitude_db, phase_deg
 using Cadnip.MNA: make_ode_problem, make_ode_function
 using Cadnip.MNA: make_dae_problem, make_dae_function
@@ -637,75 +637,46 @@ using NyanVerilogAParser
     #==========================================================================#
 
     @testset "AC: RC low-pass filter" begin
-        # R = 1k, C = 1uF
-        # fc = 1/(2*pi*R*C) ≈ 159.15 Hz
-        # At f = fc: |H| = 1/sqrt(2) ≈ 0.707 (-3dB)
-
-        ctx = MNAContext()
-        inp = get_node!(ctx, :inp)
-        out = get_node!(ctx, :out)
-
+        # R = 1k, C = 1uF; fc = 1/(2πRC) ≈ 159.15 Hz; |H(fc)| = 1/√2 (-3 dB)
         R = 1000.0
         C_val = 1e-6
         fc = 1.0 / (2π * R * C_val)
 
-        stamp!(VoltageSource(1.0), ctx, inp, 0)  # 1V AC source
-        stamp!(Resistor(R), ctx, inp, out)
-        stamp!(Capacitor(C_val), ctx, out, 0)
+        circuit = MNACircuit(sp"""
+        * RC low-pass
+        V1 inp 0 AC 1
+        R1 inp out 1k
+        C1 out 0 1u
+        """)
 
-        sys = assemble!(ctx)
-
-        # Test at various frequencies
         freqs = [fc/10, fc, fc*10]
-        ac_sol = solve_ac(sys, freqs)
+        resp = ac!(circuit, freqs)[:out]
 
-        # At low frequency: Vout ≈ Vin
-        Vout_low = abs(ac_sol[:out, 1])
-        @test Vout_low > 0.99
-
-        # At cutoff: |Vout/Vin| ≈ 0.707
-        Vout_fc = abs(ac_sol[:out, 2])
-        @test Vout_fc ≈ 1.0/sqrt(2) atol=0.01
-
-        # At high frequency: Vout << Vin
-        Vout_high = abs(ac_sol[:out, 3])
-        @test Vout_high < 0.15
+        @test abs(resp[1]) > 0.99                  # f << fc: Vout ≈ Vin
+        @test abs(resp[2]) ≈ 1.0/sqrt(2) atol=0.01 # at cutoff: -3 dB
+        @test abs(resp[3]) < 0.15                  # f >> fc: Vout ≪ Vin
     end
 
     @testset "AC: RL high-pass filter" begin
-        # For high-pass: R in series, L to ground
-        # Vout/Vin = jωL / (R + jωL)
-        # R = 1k, L = 1H
-        # fc = R/(2*pi*L) ≈ 159.15 Hz
-
-        ctx = MNAContext()
-        inp = get_node!(ctx, :inp)
-        out = get_node!(ctx, :out)
-
+        # R in series, L to ground → high-pass. Vout/Vin = jωL/(R+jωL).
+        # R = 1k, L = 1H; fc = R/(2πL) ≈ 159.15 Hz
         R = 1000.0
         L_val = 1.0
         fc = R / (2π * L_val)
 
-        stamp!(VoltageSource(1.0), ctx, inp, 0)
-        stamp!(Resistor(R), ctx, inp, out)  # R in series
-        stamp!(Inductor(L_val), ctx, out, 0)  # L to ground
-
-        sys = assemble!(ctx)
+        circuit = MNACircuit(sp"""
+        * RL high-pass
+        V1 inp 0 AC 1
+        R1 inp out 1k
+        L1 out 0 1
+        """)
 
         freqs = [fc/10, fc, fc*10]
-        ac_sol = solve_ac(sys, freqs)
+        resp = ac!(circuit, freqs)[:out]
 
-        # At low frequency: Vout << Vin (inductor is short)
-        Vout_low = abs(ac_sol[:out, 1])
-        @test Vout_low < 0.15
-
-        # At cutoff: |Vout/Vin| ≈ 0.707
-        Vout_fc = abs(ac_sol[:out, 2])
-        @test Vout_fc ≈ 1.0/sqrt(2) atol=0.01
-
-        # At high frequency: Vout ≈ Vin (inductor is open)
-        Vout_high = abs(ac_sol[:out, 3])
-        @test Vout_high > 0.99
+        @test abs(resp[1]) < 0.15                  # f << fc: L shorts → Vout ≪ Vin
+        @test abs(resp[2]) ≈ 1.0/sqrt(2) atol=0.01 # at cutoff: -3 dB
+        @test abs(resp[3]) > 0.99                  # f >> fc: L opens → Vout ≈ Vin
     end
 
     #==========================================================================#
@@ -1200,7 +1171,10 @@ using NyanVerilogAParser
             vcc = get_node!(ctx, :vcc)
             out = get_node!(ctx, :out)
 
-            stamp!(VoltageSource(params.Vcc), ctx, vcc, 0)
+            # DC Vcc for the operating point, plus a unit AC magnitude so ac!
+            # has an excitation (AC analysis uses b_ac, not the DC rhs). The
+            # 6-arg (mode-aware) stamp! is the form that registers b_ac.
+            stamp!(VoltageSource(params.Vcc; ac=1.0), ctx, vcc, 0, t, spec.mode)
             stamp!(Resistor(params.R), ctx, vcc, out)
             stamp!(Capacitor(params.C), ctx, out, 0)
 
@@ -1213,15 +1187,14 @@ using NyanVerilogAParser
         sol = solve_dc(circuit)
         @test sol[:out] ≈ 5.0  # At DC, capacitor is open
 
-        # AC sweep - cutoff fc = 1/(2πRC) ≈ 159Hz for R=1kΩ, C=1μF
-        # At 10Hz (well below cutoff), gain should be ~1
+        # AC sweep - cutoff fc = 1/(2πRC) ≈ 159Hz for R=1kΩ, C=1μF; unit input.
         freqs = [10.0, 100.0, 1000.0]
-        ac_sol = solve_ac(circuit, freqs)
+        ac_sol = ac!(circuit, freqs)
 
         # At 10Hz (f << fc), gain ≈ 1 (within 1%)
-        @test abs(ac_sol[:out][1]) > 0.99 * circuit.params.Vcc
+        @test abs(ac_sol[:out][1]) > 0.99
         # At 1000Hz (f >> fc), gain should be < 0.2 (rolloff)
-        @test abs(ac_sol[:out][3]) < 0.2 * circuit.params.Vcc
+        @test abs(ac_sol[:out][3]) < 0.2
     end
 
     @testset "DC-initialized transient (ODE)" begin


### PR DESCRIPTION
## What

Completes the AC result-type unification in `doc/ac_result_unification.md` — all four sub-tasks. Cadnip shipped **two** AC result types with divergent conventions; `ac!`/`ACSol` is now the single AC path.

## Commit 1 — `sol[:name]` return-type consistency (sub-task 2)

The two types indexed with identical `sol[:name]` syntax but returned different things (`ACSolution` → response vector; `ACSol` → DSS subsystem). Resolved so both index alike, on the SPICE-native meaning:

- `ACSol[:name]` returns the complex response vector over the analysis's Hz grid (matching the DC/transient `sol[:name]` convention). `ac!` gained an optional `freqs` arg (`ac!(circuit, acdec(...))`) to carry the grid; no-grid access errors with a pointer to `freqresp`.
- The descriptor subsystem moved to an explicit accessor `subsystem(ac, :name)` for the ControlSystems / DescriptorSystems interop (`ss`, `bode`, poles/zeros). `freqresp(ac, :name, ωs)` still evaluates at arbitrary rad/s with no stored grid.
- Two-arg `magnitude_db(ac, :name)` / `phase_deg(ac, :name)` read the stored grid.

## Commit 2 — retire `ACSolution`/`solve_ac` (sub-tasks 1, 3, 4)

- Deleted the `ACSolution` struct, all `solve_ac` methods, the duplicated accessors, and the `ACSolution` NodeRef indexing. `magnitude_db`/`phase_deg` are now bare generics in `solve.jl` whose only methods live on `ACSol`.
- `ac!` is the one AC entry point. It linearizes at the DC operating point and builds a DSS-backed result. (The old `solve_ac(circuit)` skipped the DC solve, and on `MNAData` excited with the DC rhs `b` — treating a DC source as an AC stimulus — rather than `b_ac`; `ac!` uses the correct AC excitation.)
- Ported `test/mna/core.jl`'s three `solve_ac` call sites to `ac!` (the two behavioral filter tests became netlists, per CLAUDE.md's netlist-first guidance); dropped the unused import from `test/common.jl`.
- **Hierarchical observables (sub-task 4):** subcircuit nodes already flatten into the name table, so `ac[:x1_out]` resolves via ordinary symbol lookup. Added `NodeRef` indexing + a `NodeRef` `freqresp` on `ACSol` for parity with the DC/transient solutions, and narrowed the overstated "LIMITATION 1" comment (a voltage *across* a device between two nodes is a node difference by construction, not a gap).

Net **−75 lines**. Docs updated: README AC section, `doc/ac_result_unification.md` (all sub-tasks marked done), scratchpad checkboxes.

## DSS contract

Unchanged — it lives on the `DescriptorStateSpace` reached via `ac.dss` and `subsystem(ac, :name)` (both untouched); `freqresp` is unchanged. Symbol indexing was never part of the DSS contract (DSS systems index by integer), so redefining that sugar to match `freqresp`'s vector return makes `ACSol`'s name-based surface self-consistent.

## Testing

- `test/ac.jl` — asserts `ac[:name]` responses, the no-grid error, the `subsystem` bode path, and a new hierarchical/subcircuit access test. Clean.
- `test/mna/core.jl` — 356/356 pass.
- `test/mna/laplace.jl` — 12/12 pass (other `ac!` caller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ld9iJdwTtUSMG5nTDMvNET