### PR TITLE
Noise N1: builtin diode shot noise from the junction bias

### DIFF
--- a/doc/noise_analysis_design.md
+++ b/doc/noise_analysis_design.md
@@ -133,12 +133,18 @@ high-level API.
   source; the G/C/b value path is byte-identical, so DC/transient numerics are
   unchanged (`test/mna/noise.jl`).
 
+  The builtin `Diode`/`DiodeWithCap` stamps now register shot noise (`2q·|I|`)
+  via `register_shot_noise!`, reading the junction current `I0` at the operating
+  point the channel is built at (`test/mna/noise.jl`). Same zero-cost contract:
+  no-op on `DirectStampContext`, structure-discovery side effect on `MNAContext`,
+  G/C/b value path byte-identical.
+
   Still open within the "make every source ctx-aware" scope, deferred toward N1:
-  builtin diode/BJT/MOSFET shot+flicker noise (need the branch current at the
-  device stamp) and the VA `white_noise`/`flicker_noise` builtins — those fold
-  to a literal `0.0` at codegen today (`vasim.jl`), and registering them needs
-  the LHS branch context at the contribution site rather than at the isolated
-  call expression.
+  BJT/MOSFET shot+flicker and diode flicker noise (the builtins are level-1
+  `nmos`/`pmos`/VA models rather than a Cadnip stamp with a `KF`/`AF` card), and
+  the VA `white_noise`/`flicker_noise` builtins — those fold to a literal `0.0`
+  at codegen today (`vasim.jl`), and registering them needs the LHS branch
+  context at the contribution site rather than at the isolated call expression.
 - **N1 — PSD models at the DC bias.** Evaluate per-source spectral density at the
   operating point: thermal `4kT·g`, shot `2qI`, flicker `KF·I^AF/f`, VA
   `white_noise(pwr)` → `pwr`, `flicker_noise(pwr,exp)` → `pwr/f^exp`. Bias comes

--- a/doc/scratchpad.md
+++ b/doc/scratchpad.md
@@ -66,6 +66,7 @@ The most nebulous and least important at this stage: copying features from other
 - [x] AC UX: hierarchical device-observable access in AC — subcircuit nodes flatten into the name table so `ac[:x1_out]` resolves, and a `NodeRef` from `scope(...)` indexes an `ACSol` (parity with DC/tran); genuine device-across voltages remain node differences
 - [x] Noise N0: deferred noise-source channel on `MNAContext`, no-op on `DirectStampContext` (zero transient cost); resistor Johnson–Nyquist thermal noise (`4kT·G`) is the first registered source, PSD helper covers thermal/shot/white/flicker — design: `doc/noise_analysis_design.md`. Still to wire for N1: builtin diode/BJT/MOSFET shot+flicker and the VA `white_noise`/`flicker_noise` codegen path (needs branch context at the contribution site).
 - [ ] Noise N1: per-source PSD models at the DC bias (thermal/shot/flicker + VA `white_noise`/`flicker_noise`)
+  - [x] builtin diode shot noise (`2q·|I|`) registered from the junction bias via `register_shot_noise!`
 - [ ] Noise N2: noise transfer functions via the AC linearization (adjoint solve per output/frequency)
 - [ ] Noise N3: `noise!()` + `.noise` card — output/total/input-referred, name-based access
 - [ ] Noise N4: validation against ngspice `.noise` through the high-level API

--- a/src/mna/context.jl
+++ b/src/mna/context.jl
@@ -190,7 +190,7 @@ end
 
 export NoiseKind, THERMAL, SHOT, WHITE, FLICKER
 export NoiseSource, noise_psd, noise_sources, num_noise_sources
-export stamp_noise!, register_thermal_noise!
+export stamp_noise!, register_thermal_noise!, register_shot_noise!
 
 """
     MNAContext
@@ -1003,6 +1003,21 @@ Register the Johnson–Nyquist thermal noise of a conductance `G` between nodes
 """
 @inline register_thermal_noise!(ctx::MNAContext, p, n, G; name::Symbol=:R) =
     stamp_noise!(ctx, p, n, THERMAL, G, 0.0, name)
+
+"""
+    register_shot_noise!(ctx, p, n, I; name)
+
+Register the shot noise of a junction carrying DC current `I` between nodes `p`
+and `n` (PSD `2·q·|I|`, white). The magnitude is used so a reverse-biased branch
+still registers a physically meaningful (small) source. No-op on
+[`DirectStampContext`](@ref).
+
+The current is read at the operating point the noise channel is built at (the AC
+path rebuilds at the DC solution), so registering a shot source is a
+structure-discovery-time side effect that does not perturb the G/C/b value path.
+"""
+@inline register_shot_noise!(ctx::MNAContext, p, n, I; name::Symbol=:D) =
+    stamp_noise!(ctx, p, n, SHOT, abs(I), 0.0, name)
 
 """
     num_noise_sources(ctx::MNAContext) -> Int

--- a/src/mna/devices.jl
+++ b/src/mna/devices.jl
@@ -1362,6 +1362,11 @@ function stamp!(D::Diode, ctx::AnyMNAContext, p::Int, n::Int;
         # Companion anchored at the evaluation voltage w — see
         # stamp_limited_companion! for why probe-anchoring is wrong here.
         stamp_limited_companion!(ctx, p, n, w, I0, Gd)
+
+        # Shot noise (2q·|I|) at the junction bias. No-op on the transient
+        # DirectStampContext, and a structure-discovery side effect on
+        # MNAContext, so DC/transient numerics are unchanged.
+        register_shot_noise!(ctx, p, n, I0; name=D.name)
     else
         # Classic companion model, identical to the pre-PCNR diode: raw
         # exponential (no clamp — this is the reference/unaugmented model),
@@ -1381,6 +1386,8 @@ function stamp!(D::Diode, ctx::AnyMNAContext, p::Int, n::Int;
         # So: -Ieq enters p, +Ieq enters n
         stamp_b!(ctx, p, -Ieq)
         stamp_b!(ctx, n,  Ieq)
+
+        register_shot_noise!(ctx, p, n, I0; name=D.name)
     end
 
     return nothing
@@ -1514,6 +1521,9 @@ function stamp!(D::DiodeWithCap, ctx::AnyMNAContext, p::Int, n::Int;
     # Stamp companion current
     stamp_b!(ctx, p, -Ieq)
     stamp_b!(ctx, n,  Ieq)
+
+    # Shot noise (2q·|I|) at the junction bias — see the Diode stamp.
+    register_shot_noise!(ctx, p, n, I0; name=D.name)
 
     # === Reactive Part (Junction Capacitance) ===
     Cj0, Vj, m = D.Cj0, D.Vj, D.m

--- a/src/mna/value_only.jl
+++ b/src/mna/value_only.jl
@@ -151,6 +151,7 @@ register_breakpoints!(::DirectStampContext, ::Any) = nothing
 """
     stamp_noise!(::DirectStampContext, args...)
     register_thermal_noise!(::DirectStampContext, args...; kwargs...)
+    register_shot_noise!(::DirectStampContext, args...; kwargs...)
 
 No-ops. The noise-source channel lives only on `MNAContext` (structure
 discovery); the zero-allocation restamping path carries no noise machinery, so
@@ -158,6 +159,7 @@ transient restamping is untouched (see doc/noise_analysis_design.md).
 """
 @inline stamp_noise!(::DirectStampContext, args...) = nothing
 @inline register_thermal_noise!(::DirectStampContext, args...; kwargs...) = nothing
+@inline register_shot_noise!(::DirectStampContext, args...; kwargs...) = nothing
 
 """
     get_current_idx(ctx::DirectStampContext, name::Symbol) -> CurrentIndex

--- a/test/mna/noise.jl
+++ b/test/mna/noise.jl
@@ -11,9 +11,10 @@
 using Test
 using Cadnip
 using Cadnip.MNA
-using Cadnip.MNA: MNAContext, get_node!, stamp!, Resistor, resolve_index
+using Cadnip.MNA: MNAContext, get_node!, stamp!, Resistor, Diode, VoltageSource, resolve_index
 using Cadnip.MNA: reset_for_restamping!, num_noise_sources, noise_sources, noise_psd
-using Cadnip.MNA: stamp_noise!, register_thermal_noise!
+using Cadnip.MNA: stamp_noise!, register_thermal_noise!, register_shot_noise!
+using Cadnip.MNA: solve_dc, MNASpec
 using Cadnip.MNA: THERMAL, SHOT, WHITE, FLICKER, NoiseSource
 using Cadnip.MNA: NodeIndex, GroundIndex
 using Cadnip.MNA: K_BOLTZMANN, Q_ELEMENTARY
@@ -40,6 +41,44 @@ using Cadnip.SpectreEnvironment
         expected = 4 * K_BOLTZMANN * (T + 273.15) * 1e-3
         @test noise_psd(src, T, 1e3) ≈ expected
         @test noise_psd(src, T, 1e6) ≈ expected   # white: no frequency dependence
+    end
+
+    @testset "diode shot noise registration at bias" begin
+        # A forward-biased junction registers shot noise 2q·|I| with a = |I_D|
+        # evaluated at the operating point the channel is built at. Hand-stamping
+        # at a known bias vector is a low-level stamping-mechanics test.
+        Is, Vt = 1e-14, 0.026
+        Vbias = 0.6
+        I0 = Is * (exp(Vbias / Vt) - 1.0)   # DC junction current at the bias
+
+        ctx = MNAContext()
+        a = get_node!(ctx, :a)              # index 1
+        stamp!(Diode(Is=Is, Vt=Vt, limit=false, name=:D1), ctx, a, 0; x=[Vbias])
+
+        @test num_noise_sources(ctx) == 1
+        src = noise_sources(ctx)[1]
+        @test src.kind === SHOT
+        @test src.name === :D1
+        @test src.a ≈ I0                    # a = |I_D| at the bias point
+        @test resolve_index(ctx, src.p) == a
+
+        # PSD = 2·q·|I|, white (frequency-independent)
+        expected = 2 * Q_ELEMENTARY * I0
+        @test noise_psd(src, 27.0, 1e3) ≈ expected
+        @test noise_psd(src, 27.0, 1e9) ≈ expected
+    end
+
+    @testset "diode shot noise uses current magnitude under reverse bias" begin
+        # Reverse bias: I_D saturates to -Is, so |I| = Is and the source is tiny
+        # but non-degenerate (magnitude keeps it physical).
+        Is, Vt = 1e-14, 0.026
+        ctx = MNAContext()
+        a = get_node!(ctx, :a)
+        stamp!(Diode(Is=Is, Vt=Vt, limit=false, name=:D1), ctx, a, 0; x=[-1.0])
+
+        src = noise_sources(ctx)[1]
+        @test src.a ≈ Is                    # |Is·(exp(-38)-1)| ≈ Is
+        @test noise_psd(src, 27.0, 1e3) ≈ 2 * Q_ELEMENTARY * Is
     end
 
     @testset "multiple sources accumulate; rebuild does not duplicate" begin
@@ -95,6 +134,30 @@ using Cadnip.SpectreEnvironment
         """i)
         sol = dc!(circuit)
         @test sol[:out] ≈ 2.5
+    end
+
+    @testset "numerics unchanged: builtin diode rectifier solves" begin
+        # A full Newton solve calls the Diode stamp (and its shot-noise
+        # registration) on every iteration; the operating point must be
+        # unperturbed. This is a stamping-mechanics check on the builtin Diode,
+        # so it drives the stamp directly rather than through a .model card.
+        function rect(params, spec, t::Real=0.0; x=Float64[], ctx=nothing)
+            ctx === nothing ? (ctx = MNAContext()) : reset_for_restamping!(ctx)
+            vin = get_node!(ctx, :vin)
+            out = get_node!(ctx, :out)
+            stamp!(VoltageSource(5.0; name=:V1), ctx, vin, 0)
+            stamp!(Resistor(1000.0; name=:R1), ctx, vin, out)
+            stamp!(Diode(Is=1e-14, Vt=0.026, name=:D1), ctx, out, 0; x=x)
+            return ctx
+        end
+        sol = solve_dc(rect, (;), MNASpec())
+        # 5 V through 1k into a diode clamps `out` around a forward drop.
+        @test 0.4 < sol[:out] < 0.8
+        # And the diode's shot-noise source is registered at that bias.
+        ctx = rect((;), MNASpec(); x=sol.x)
+        shot = filter(s -> s.kind === SHOT, noise_sources(ctx))
+        @test length(shot) == 1
+        @test shot[1].a > 0                # |I_D| at the clamped operating point
     end
 
     @testset "transient hot path unaffected (DirectStampContext no-op)" begin


### PR DESCRIPTION
## What

Extends the noise-source channel (N0) with the first **N1** per-source PSD model: shot noise (`2q·|I|`) on the builtin `Diode` and `DiodeWithCap` stamps.

A new `register_shot_noise!(ctx, p, n, I; name)` helper appends a `SHOT` source to the deferred noise channel, mirroring the resistor's `register_thermal_noise!` from N0. Both diode stamps call it with the junction current `I0` computed at the operating point — for the PCNR-limited path, the unlimited companion path, and `DiodeWithCap`.

## Why it's zero-cost for DC/transient

The shot-noise registration reads `I0` at the operating point the noise channel is built at (the AC path rebuilds at the DC solution), so it's a **structure-discovery-time side effect only**:

- No-op on the transient hot-path `DirectStampContext` (added alongside the existing noise no-ops), so restamping is untouched.
- The G/C/b value path is byte-identical — registration pushes to parallel COO vectors and changes no matrix entry.

This follows the contract laid out in `doc/noise_analysis_design.md` exactly as N0 did for resistor thermal noise. `|I|` (magnitude) is used so a reverse-biased junction still registers a physically meaningful (tiny) source.

## Tests

Added to `test/mna/noise.jl` (all 31 pass):

- Diode shot-noise registration at a forward bias — asserts `a = |I_D|`, `kind === SHOT`, and PSD `= 2q·|I|` (white).
- Reverse-bias case — magnitude keeps the source non-degenerate at `≈ Is`.
- A full builtin-diode Newton solve is unperturbed, and the shot source is present at the clamped operating point.

Also re-ran `test/mna/pcnr.jl` (73 pass) since the diode stamp is on that hot path.

## Scope / follow-ups

Still open toward N1 (tracked in the design doc): BJT/MOSFET shot+flicker and diode flicker (those devices are level-1/VA models rather than a Cadnip stamp with a `KF`/`AF` card), and lighting up the VA `white_noise`/`flicker_noise` builtins that currently lower to `0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAjmuX5FCudqBC5HD9eCLF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAjmuX5FCudqBC5HD9eCLF)_