### PR TITLE
Noise N2/N3: noise!() output-noise analysis over the MNA noise channel

### DIFF
--- a/doc/noise_analysis_design.md
+++ b/doc/noise_analysis_design.md
@@ -6,12 +6,16 @@ how it threads through the current MNA system **without slowing DC/transient**.
 
 ## Status
 
-Not implemented. The scaffolding that exists today:
+Single-operating-point linear noise analysis is implemented (`src/noise.jl`):
+`noise!(circuit, output; freqs)` computes the output-noise PSD and per-source
+contributions over the thermal sources the N0 channel registers. The remaining
+work is lighting up the other sources (device/VA shot & flicker) and the
+input-referred / `.noise`-card surface. The scaffolding this builds on:
 
-- `src/ac.jl` — `noise!()` is scoped in the header comment but unimplemented.
-  The AC path already builds a linearized descriptor state-space system
+- `src/ac.jl` — the AC path builds a linearized descriptor state-space system
   (`E·dx = A·x + B·u, y = C·x`) at the DC operating point, which is exactly the
-  linearization a noise analysis consumes.
+  linearization the noise analysis consumes; `noise!` reuses that
+  rebuild-at-op-point pattern.
 - `src/va_env.jl` / `src/vasim.jl` — the Verilog-A `white_noise` /
   `flicker_noise` builtins are parsed (NyanVerilogAParser keywords) and lowered
   to `0.0` (`vasim.jl:1297`, and named noise branches zeroed at
@@ -143,14 +147,20 @@ high-level API.
   operating point: thermal `4kT·g`, shot `2qI`, flicker `KF·I^AF/f`, VA
   `white_noise(pwr)` → `pwr`, `flicker_noise(pwr,exp)` → `pwr/f^exp`. Bias comes
   from the DC solution the AC path already computes.
-- **N2 — Transfer functions via the AC system.** Reuse `ac!`'s linearized
-  `(jωC + G)`; per output+frequency, one adjoint solve `(jωC+G)ᵀ x_adj = e_out`
-  gives the transfer from every source at O(1) each (`H_k = x_adjᵀ e_k`),
-  reusing the factorization across sources.
-- **N3 — `noise!()` analysis + output.** Output PSD `Σ_k |H_k(jω)|² S_k(ω)`, band
-  integration for total noise, input-referred via the input transfer function; a
-  `NoiseSol` mirroring `ACSol` plus a `.noise` netlist card and name-based
-  access.
+- **N2 — Transfer functions via the AC system. _(landed)_** Reuse `ac!`'s
+  linearized `(jωC + G)`; per output+frequency, one adjoint solve
+  `(jωC+G)ᵀ x_adj = e_out` gives the transfer from every source at O(1) each
+  (`H_k = x_adj[p_k] − x_adj[n_k]`), reusing the factorization across sources.
+  Implemented in `noise!` (`src/noise.jl`).
+- **N3 — `noise!()` analysis + output. _(landed, partial)_** `noise!(circuit,
+  output; freqs)` returns a `NoiseSol` (mirroring `ACSol`) with the output PSD
+  `S_out(f) = Σ_k |H_k(jω)|² S_k(f)`, per-source contributions
+  (`ns[:onoise]` / `ns[:devname]`), and band-integrated `total_noise` (the RC
+  case integrates to `kT/C`). The analysis is source-agnostic — it consumes
+  whatever sits on the noise channel, so device/VA sources light up here for
+  free once registered. **Still open:** input-referred noise (needs the input
+  source→output transfer) and the `.noise` netlist card driven through the
+  high-level API.
 - **N4 — Tests + validation.** Netlist tests (thermal noise of an RC = `4kT·R`
   shaped by the RC pole; op-amp input-referred noise) cross-checked against
   ngspice `.noise`, driven through the high-level API.

--- a/doc/scratchpad.md
+++ b/doc/scratchpad.md
@@ -65,8 +65,9 @@ The most nebulous and least important at this stage: copying features from other
 - [x] AC UX: make `sol[:name]` return-type consistent across AC types — `ACSol` now indexes to a complex response vector (matching DC/tran); the DSS subsystem moved to `subsystem(ac, :name)`; `ac!(circuit, freqs)` carries a Hz grid and 2-arg `magnitude_db`/`phase_deg`
 - [x] AC UX: hierarchical device-observable access in AC — subcircuit nodes flatten into the name table so `ac[:x1_out]` resolves, and a `NodeRef` from `scope(...)` indexes an `ACSol` (parity with DC/tran); genuine device-across voltages remain node differences
 - [x] Noise N0: deferred noise-source channel on `MNAContext`, no-op on `DirectStampContext` (zero transient cost); resistor Johnson–Nyquist thermal noise (`4kT·G`) is the first registered source, PSD helper covers thermal/shot/white/flicker — design: `doc/noise_analysis_design.md`. Still to wire for N1: builtin diode/BJT/MOSFET shot+flicker and the VA `white_noise`/`flicker_noise` codegen path (needs branch context at the contribution site).
-- [ ] Noise N1: per-source PSD models at the DC bias (thermal/shot/flicker + VA `white_noise`/`flicker_noise`)
-- [ ] Noise N2: noise transfer functions via the AC linearization (adjoint solve per output/frequency)
-- [ ] Noise N3: `noise!()` + `.noise` card — output/total/input-referred, name-based access
+- [x] Noise N2: noise transfer functions via the AC linearization — `noise!(circuit, output; freqs)` adjoint-solves `(jωC+G)ᵀ x_adj = e_out` per frequency, transfer `H_k = x_adj[p_k]-x_adj[n_k]` for every source at O(1) (`src/noise.jl`, `test/noise.jl`)
+- [x] Noise N3 (partial): `noise!()` output PSD `Σ_k |H_k|² S_k`, per-source contributions (`ns[:onoise]`/`ns[:devname]`), band-integrated `total_noise` validated against RC `4kTR`-shaped noise and `kT/C`. Source-agnostic: new sources light up for free once registered
+- [ ] Noise N1: per-source PSD at the DC bias for the *remaining* sources — builtin diode/BJT/MOSFET shot+flicker and VA `white_noise`/`flicker_noise` (thermal already flows through N2/N3)
+- [ ] Noise N3 rest: input-referred noise (input source→output transfer) + `.noise` netlist card through the high-level API
 - [ ] Noise N4: validation against ngspice `.noise` through the high-level API
 - [ ] Noise N5 (stretch): differentiable noise objectives + cyclostationary (PSS/PAC) noise

--- a/src/Cadnip.jl
+++ b/src/Cadnip.jl
@@ -97,6 +97,7 @@ include("spc/generated.jl")
 include("va_env.jl")
 include("sweeps.jl")
 include("ac.jl")
+include("noise.jl")
 include("ModelLoader.jl")
 include("circsummary.jl")
 

--- a/src/ac.jl
+++ b/src/ac.jl
@@ -26,11 +26,10 @@
 # quantity, taken as a node difference:
 #      `freqresp(ac, :n1, ωs) - freqresp(ac, :n2, ωs)`
 #
-# Not yet implemented — Noise analysis: The `noise!()` function. Requires:
-#    - Per-device noise source modeling (thermal, shot, flicker)
-#    - Noise correlation matrix assembly
-#    - Output noise spectral density computation
-#    See doc/noise_analysis_design.md for the planned port.
+# Noise analysis: `noise!()` (see src/noise.jl) reuses this same
+# rebuild-at-DC-operating-point linearization, adjoint-solving `(jωC+G)` per
+# frequency to accumulate the output-noise PSD from the sources on the context's
+# noise channel. See doc/noise_analysis_design.md.
 #
 # Bode plots: Use RobustAndOptimalControl to convert DescriptorStateSpace to
 # standard StateSpace: `bode(ss(subsystem(ac, :vout)), ωs)`

--- a/src/noise.jl
+++ b/src/noise.jl
@@ -1,0 +1,204 @@
+#==============================================================================#
+# Small-signal noise analysis
+#
+# Noise analysis reuses the AC linearization at the DC operating point (see
+# `src/ac.jl` and `doc/noise_analysis_design.md`). Each registered noise source
+# (the deferred channel on `MNAContext` populated during structure discovery) is
+# a small-signal current source injected between two branch nodes, with a
+# one-sided power spectral density `S_k(f)` set by its `NoiseKind`.
+#
+# For an output `y` (a node voltage or branch current) the transfer function
+# from source `k` to `y` is `H_k(jω)`. Since the sources are uncorrelated, the
+# output noise PSD is the incoherent sum
+#
+#     S_y(f) = Σ_k |H_k(jω)|² · S_k(f),   ω = 2πf.
+#
+# The transfer functions all share one factorization per frequency: solving the
+# adjoint system `(jωC + G)ᵀ x_adj = e_y` once yields `H_k = x_adjᵀ b_k` for
+# *every* source `k` at O(1) each, where `b_k = e_{p_k} − e_{n_k}` is the unit
+# current injection of source `k`. This is the classic SPICE `.noise` inner loop
+# (design doc §"The dual approach, reconciled").
+#
+# The analysis is source-agnostic: it consumes whatever sits on the noise
+# channel, so every future source (diode/BJT shot, VA `white_noise`/
+# `flicker_noise`) flows through unchanged once registered.
+#==============================================================================#
+
+using LinearAlgebra
+
+export noise!, NoiseSol, onoise, total_noise
+
+"""
+    NoiseSol
+
+Output of [`noise!`](@ref): the output-referred noise of a circuit over a Hz
+frequency grid, decomposed into per-source contributions.
+
+# Fields
+- `freqs`: frequency grid in **hertz** (SPICE `.noise` convention)
+- `output`: the observed output (node voltage or branch current) name
+- `onoise`: total output noise PSD over the grid, in V²/Hz (voltage output) or
+  A²/Hz (current output)
+- `contributions`: per-source output-noise PSD, keyed by the originating device
+  name; the values sum to `onoise` (incoherently)
+- `temp`: temperature (Celsius) the PSDs were evaluated at
+
+Index it like the other solutions: `ns[:onoise]` is the total PSD and `ns[name]`
+is a single device's contribution. [`total_noise`](@ref) integrates the band to
+an RMS value.
+"""
+struct NoiseSol
+    freqs::Vector{Float64}
+    output::Symbol
+    onoise::Vector{Float64}
+    contributions::Dict{Symbol,Vector{Float64}}
+    temp::Float64
+end
+
+"""
+    noise!(circuit::MNA.MNACircuit, output; freqs, gmin=1e-12) -> NoiseSol
+
+Small-signal noise analysis of `circuit`, computing the output-referred noise
+spectral density at `output` (a node-voltage or branch-current name) over the Hz
+grid `freqs`.
+
+# Algorithm
+1. Solve the DC operating point (Newton), then rebuild the linearized `G`/`C` at
+   that point — exactly as [`ac!`](@ref) does.
+2. Collect the noise sources registered on the context during that rebuild
+   (resistor thermal `4kT·G`, and any device/VA source that registers itself).
+3. Per frequency, one adjoint solve `(jωC + G)ᵀ x_adj = e_output` gives the
+   transfer `H_k` from every source at O(1) each; accumulate the incoherent sum
+   `S_out(f) = Σ_k |H_k|² S_k(f)` and keep each source's contribution.
+
+# Arguments
+- `output`: node or current name to observe (e.g. `:vout`, `:I_V1`).
+- `freqs`: frequency grid in **hertz**, e.g. `acdec(20, 1, 1e6)` (required).
+- `gmin`: shunt conductance added to `G` for numerical stability.
+
+# Returns
+[`NoiseSol`](@ref) — index `ns[:onoise]` for the total output PSD, `ns[:r1]` for
+one source's contribution (device names are normalized to lower case), and
+[`total_noise`](@ref)`(ns)` for the band-integrated RMS.
+
+# Example
+```julia
+circuit = MNACircuit(sp\"\"\"
+V1 in 0 DC 0
+R1 in out 1k
+C1 out 0 1u
+\"\"\"i)
+ns = noise!(circuit, :out; freqs=acdec(10, 1, 1e6))
+ns[:onoise]          # output voltage noise PSD (V²/Hz) over the grid
+total_noise(ns)      # integrated RMS noise voltage
+```
+"""
+function noise!(circuit::MNA.MNACircuit, output::Symbol;
+                freqs::AbstractVector{<:Real}, gmin=1e-12)
+    isempty(freqs) && throw(ArgumentError(
+        "noise!(circuit, output; freqs=...) needs a non-empty Hz grid " *
+        "(e.g. acdec(20, 1, 1e6))"))
+
+    # Structure discovery, then DC operating point.
+    ctx = MNA.MNAContext()
+    circuit.builder(circuit.params, circuit.spec, 0.0; x=MNA.ZERO_VECTOR, ctx=ctx)
+    dc_sol = MNA.solve_dc(circuit)
+
+    # Rebuild the linearization (and noise channel) at the operating point.
+    MNA.reset_for_restamping!(ctx)
+    circuit.builder(circuit.params, circuit.spec, 0.0; x=dc_sol.x, ctx=ctx)
+
+    G = Matrix(MNA.assemble_G(ctx; gshunt=gmin))
+    C = Matrix(MNA.assemble_C(ctx))
+    n = MNA.system_size(ctx)
+
+    out_idx = _noise_output_index(ctx, output)
+
+    srcs = MNA.noise_sources(ctx)
+    isempty(srcs) && @warn "noise!: circuit has no registered noise sources; \
+                            output noise is zero"
+
+    temp_c = circuit.spec.temp
+    e_out = zeros(ComplexF64, n)
+    e_out[out_idx] = 1.0
+
+    fs = collect(Float64, freqs)
+    onoise = zeros(Float64, length(fs))
+    contributions = Dict{Symbol,Vector{Float64}}(
+        s.name => zeros(Float64, length(fs)) for s in srcs)
+
+    for (fi, f) in enumerate(fs)
+        ω = 2π * f
+        # Adjoint solve: (jωC + G)ᵀ x_adj = e_out.
+        x_adj = (transpose(im * ω .* C .+ G)) \ e_out
+        for s in srcs
+            p = MNA.resolve_index(ctx, s.p)
+            q = MNA.resolve_index(ctx, s.n)
+            # H_k = x_adjᵀ (e_p − e_n); ground (index 0) contributes nothing.
+            Hk = (p == 0 ? zero(ComplexF64) : x_adj[p]) -
+                 (q == 0 ? zero(ComplexF64) : x_adj[q])
+            Sk = MNA.noise_psd(s, temp_c, f)
+            contrib = abs2(Hk) * Sk
+            onoise[fi] += contrib
+            contributions[s.name][fi] += contrib
+        end
+    end
+
+    return NoiseSol(fs, output, onoise, contributions, temp_c)
+end
+
+"""
+    _noise_output_index(ctx, name::Symbol) -> Int
+
+System index of node-voltage or branch-current `name` in `ctx`. Errors for
+ground or unknown names.
+"""
+function _noise_output_index(ctx::MNA.MNAContext, name::Symbol)
+    (name === :gnd || name === Symbol("0")) &&
+        error("noise!: output cannot be ground (node 0)")
+    ni = findfirst(==(name), ctx.node_names)
+    ni === nothing || return ni
+    ci = findfirst(==(name), ctx.current_names)
+    ci === nothing || return ctx.n_nodes + ci
+    error("noise!: unknown output $name. Available nodes: $(ctx.node_names), " *
+          "currents: $(ctx.current_names)")
+end
+
+"""
+    onoise(ns::NoiseSol) -> Vector{Float64}
+
+Total output-noise PSD over the frequency grid (alias for `ns[:onoise]`).
+"""
+onoise(ns::NoiseSol) = ns.onoise
+
+"""
+    ns[name::Symbol] -> Vector{Float64}
+
+Name-based access to a noise solution, mirroring `sol[:name]` for DC/AC/tran.
+`ns[:onoise]` is the total output-noise PSD; any other symbol is looked up as a
+noise-source (device) name and returns that source's contribution to the output
+PSD.
+"""
+function Base.getindex(ns::NoiseSol, name::Symbol)
+    name === :onoise && return ns.onoise
+    haskey(ns.contributions, name) && return ns.contributions[name]
+    error("NoiseSol: unknown key :$name. Use :onoise for the total, or a source \
+           name from $(sort(collect(keys(ns.contributions)))).")
+end
+
+"""
+    total_noise(ns::NoiseSol) -> Float64
+
+Band-integrated RMS output noise: `sqrt(∫ S_out(f) df)` over the analysis grid,
+by trapezoidal integration. Units are V (voltage output) or A (current output).
+For a meaningful integral supply a dense grid spanning the band of interest.
+"""
+function total_noise(ns::NoiseSol)
+    fs = ns.freqs
+    length(fs) < 2 && return sqrt(length(fs) == 1 ? ns.onoise[1] : 0.0)
+    acc = 0.0
+    for i in 1:length(fs)-1
+        acc += 0.5 * (ns.onoise[i] + ns.onoise[i+1]) * (fs[i+1] - fs[i])
+    end
+    return sqrt(acc)
+end

--- a/test/noise.jl
+++ b/test/noise.jl
@@ -1,0 +1,96 @@
+#==============================================================================#
+# Small-signal noise analysis (noise!) — behavioral tests.
+#
+# These drive the high-level API on SPICE netlists and check the output-noise
+# PSD against textbook analytical results:
+#   - a resistor divider: white output noise 4kT·(R1‖R2);
+#   - an RC low-pass: resistor thermal noise 4kTR shaped by the RC pole,
+#     S_vout(f) = 4kTR / (1 + (2πfRC)²), whose band integral is the famous kT/C.
+#==============================================================================#
+
+using Test
+using Cadnip
+using Cadnip.MNA
+using Cadnip.SpectreEnvironment
+using Cadnip.MNA: K_BOLTZMANN
+
+# Boltzmann·T at the default 27 °C operating temperature.
+const _kT = K_BOLTZMANN * (27.0 + 273.15)
+
+@testset "noise! analysis" begin
+
+    @testset "resistor divider: white output noise 4kT·(R1‖R2)" begin
+        # V1 is DC-only, so for noise it is an AC short: node `in` sits at AC
+        # ground. Output node `out` then sees R1 to ground and R2 to ground,
+        # i.e. the two thermal current sources both see Z = R1‖R2.
+        circuit = MNACircuit(sp"""
+        V1 in 0 DC 0
+        R1 in out 1k
+        R2 out 0 1k
+        """i)
+
+        ns = noise!(circuit, :out; freqs=[1.0, 1e3, 1e6])
+
+        Rpar = 500.0                       # 1k ‖ 1k
+        expected = 4 * _kT * Rpar          # V²/Hz, white
+        @test all(≈(expected; rtol=1e-6), ns[:onoise])
+
+        # Two equal sources → each contributes half, and they sum to the total.
+        # (SPICE device names are normalized to lower case.)
+        @test ns[:r1] ≈ ns[:r2]
+        @test ns[:r1] .+ ns[:r2] ≈ ns[:onoise]
+    end
+
+    @testset "RC low-pass: thermal noise shaped by the RC pole" begin
+        R = 1e3
+        C = 1e-6
+        circuit = MNACircuit(sp"""
+        V1 in 0 DC 0
+        R1 in out 1k
+        C1 out 0 1u
+        """i)
+
+        freqs = acdec(10, 1.0, 1e7)
+        ns = noise!(circuit, :out; freqs=freqs)
+
+        # S_vout(f) = 4kTR / (1 + (2πfRC)²)
+        expected = [4 * _kT * R / (1 + (2π * f * R * C)^2) for f in freqs]
+        @test ns[:onoise] ≈ expected rtol=1e-6
+
+        # Low-frequency plateau is the bare resistor thermal noise 4kTR.
+        @test ns[:onoise][1] ≈ 4 * _kT * R rtol=1e-3
+
+        # Single source: its contribution is the whole output noise.
+        @test ns[:r1] ≈ ns[:onoise]
+    end
+
+    @testset "kT/C: band-integrated RC noise" begin
+        # Integrating S_vout over all frequency gives the classic kT/C result.
+        # Use a dense linear grid well past the pole (f_c ≈ 159 kHz) so the
+        # trapezoidal integral captures the tail.
+        C = 1e-6
+        circuit = MNACircuit(sp"""
+        V1 in 0 DC 0
+        R1 in out 1k
+        C1 out 0 1u
+        """i)
+
+        freqs = collect(range(0.0, 5e6; length=200_001))
+        ns = noise!(circuit, :out; freqs=freqs)
+        vrms2 = total_noise(ns)^2
+        @test vrms2 ≈ _kT / C rtol=2e-2
+    end
+
+    @testset "errors and edge cases" begin
+        circuit = MNACircuit(sp"""
+        V1 in 0 DC 0
+        R1 in out 1k
+        R2 out 0 1k
+        """i)
+
+        @test_throws ArgumentError noise!(circuit, :out; freqs=Float64[])
+        ns = noise!(circuit, :out; freqs=[1e3])
+        @test_throws ErrorException ns[:nonexistent_source]
+        @test onoise(ns) === ns[:onoise]
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,6 +106,7 @@ elseif RUN_CORE
     # AC small-signal analysis
     @testset "AC Analysis" begin
         @testset "ac.jl" include("ac.jl")
+        @testset "noise.jl" include("noise.jl")
     end
 
     # PDK Precompilation tests


### PR DESCRIPTION
## What

Adds `noise!(circuit, output; freqs)` — a single-operating-point linear noise analysis, the N2/N3 slice of the noise roadmap in `doc/noise_analysis_design.md`. It builds directly on the N0 groundwork (the deferred noise-source channel on `MNAContext`) that landed earlier.

## How

It reuses the AC path's rebuild-at-DC-operating-point linearization. Per frequency it does **one adjoint solve** `(jωC + G)ᵀ x_adj = e_out`, which yields the transimpedance from *every* registered noise source at O(1) each:

```
H_k(jω) = x_adj[p_k] − x_adj[n_k]
```

and accumulates the incoherent output PSD

```
S_out(f) = Σ_k |H_k(jω)|² · S_k(f),   ω = 2πf
```

where `S_k` comes from the existing `noise_psd` helper (thermal/shot/white/flicker shapes).

The analysis is **source-agnostic**: it consumes whatever sits on the noise channel, so future device/VA sources (diode/BJT shot, Verilog-A `white_noise`/`flicker_noise`) light up here for free once they register themselves. Today that means the resistor Johnson–Nyquist thermal sources registered in N0.

## API

`NoiseSol` mirrors `ACSol` with the same `sol[:name]` convention:

- `ns[:onoise]` — total output-noise PSD (V²/Hz or A²/Hz) over the grid
- `ns[:devname]` — a single device's contribution (device names normalized to lower case)
- `total_noise(ns)` — band-integrated RMS

```julia
circuit = MNACircuit(sp"""
V1 in 0 DC 0
R1 in out 1k
C1 out 0 1u
"""i)
ns = noise!(circuit, :out; freqs=acdec(10, 1, 1e6))
ns[:onoise]        # output voltage-noise PSD over the grid
total_noise(ns)    # integrated RMS noise voltage
```

## Tests

`test/noise.jl` drives the high-level API on SPICE netlists and checks against textbook analytical results:

- **Resistor divider** — white output noise `4kT·(R1‖R2)`, and per-source contributions summing to the total
- **RC low-pass** — resistor thermal noise `4kTR` shaped by the RC pole, `S_out(f) = 4kTR / (1 + (2πfRC)²)`, matched point-by-point
- **kT/C** — the band-integrated RC noise recovers the famous `kT/C`
- error/edge cases (empty grid, unknown key, `onoise` accessor)

All 10 pass; the existing `test/ac.jl` and `test/mna/noise.jl` (N0 channel) still pass.

## Docs

Updated `doc/noise_analysis_design.md` (N2 / partial-N3 marked landed), `doc/scratchpad.md` progress list, and the stale "not yet implemented" comment in `src/ac.jl`.

## Still open (follow-ups)

- **N1 for the remaining sources**: builtin diode/BJT/MOSFET shot+flicker and VA `white_noise`/`flicker_noise` registration (thermal already flows through end-to-end).
- **Rest of N3**: input-referred noise (needs the input source→output transfer) and a `.noise` netlist card through the high-level API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YW8ipDndVCMm3zhWCE8P54

---
_Generated by [Claude Code](https://claude.ai/code/session_01YW8ipDndVCMm3zhWCE8P54)_