### PR TITLE
Noise N1: builtin MOSFET channel thermal noise from the bias gm

### DIFF
--- a/doc/noise_analysis_design.md
+++ b/doc/noise_analysis_design.md
@@ -139,12 +139,21 @@ high-level API.
   no-op on `DirectStampContext`, structure-discovery side effect on `MNAContext`,
   G/C/b value path byte-identical.
 
+  The builtin `SimpleMOSFET` stamp now registers channel thermal noise
+  (`4kT·(2/3)·gm`, drain→source) via `register_channel_thermal_noise!`, reading
+  the operating-point transconductance `gm` the channel is built at and skipping
+  cutoff (`gm == 0`). This reuses the `THERMAL` kind with an *effective* channel
+  noise conductance `γ·gm` (`γ = 2/3` in saturation — the ngspice level-1/2/3
+  `(8/3)·k·T·gm` shape). Same zero-cost contract: no-op on `DirectStampContext`,
+  structure-discovery side effect on `MNAContext`, G/C/b value path byte-identical
+  (`test/mna/noise.jl`).
+
   Still open within the "make every source ctx-aware" scope, deferred toward N1:
-  BJT/MOSFET shot+flicker and diode flicker noise (the builtins are level-1
-  `nmos`/`pmos`/VA models rather than a Cadnip stamp with a `KF`/`AF` card), and
-  the VA `white_noise`/`flicker_noise` builtins — those fold to a literal `0.0`
-  at codegen today (`vasim.jl`), and registering them needs the LHS branch
-  context at the contribution site rather than at the isolated call expression.
+  BJT shot noise, MOSFET/diode flicker noise (the builtins carry no `KF`/`AF`
+  card yet), and the VA `white_noise`/`flicker_noise` builtins — those fold to a
+  literal `0.0` at codegen today (`vasim.jl`), and registering them needs the LHS
+  branch context at the contribution site rather than at the isolated call
+  expression.
 - **N1 — PSD models at the DC bias.** Evaluate per-source spectral density at the
   operating point: thermal `4kT·g`, shot `2qI`, flicker `KF·I^AF/f`, VA
   `white_noise(pwr)` → `pwr`, `flicker_noise(pwr,exp)` → `pwr/f^exp`. Bias comes

--- a/doc/scratchpad.md
+++ b/doc/scratchpad.md
@@ -67,6 +67,7 @@ The most nebulous and least important at this stage: copying features from other
 - [x] Noise N0: deferred noise-source channel on `MNAContext`, no-op on `DirectStampContext` (zero transient cost); resistor Johnson–Nyquist thermal noise (`4kT·G`) is the first registered source, PSD helper covers thermal/shot/white/flicker — design: `doc/noise_analysis_design.md`. Still to wire for N1: builtin diode/BJT/MOSFET shot+flicker and the VA `white_noise`/`flicker_noise` codegen path (needs branch context at the contribution site).
 - [ ] Noise N1: per-source PSD models at the DC bias (thermal/shot/flicker + VA `white_noise`/`flicker_noise`)
   - [x] builtin diode shot noise (`2q·|I|`) registered from the junction bias via `register_shot_noise!`
+  - [x] builtin MOSFET channel thermal noise (`4kT·(2/3)·gm`) registered from the bias gm via `register_channel_thermal_noise!`
 - [ ] Noise N2: noise transfer functions via the AC linearization (adjoint solve per output/frequency)
 - [ ] Noise N3: `noise!()` + `.noise` card — output/total/input-referred, name-based access
 - [ ] Noise N4: validation against ngspice `.noise` through the high-level API

--- a/src/mna/context.jl
+++ b/src/mna/context.jl
@@ -191,6 +191,7 @@ end
 export NoiseKind, THERMAL, SHOT, WHITE, FLICKER
 export NoiseSource, noise_psd, noise_sources, num_noise_sources
 export stamp_noise!, register_thermal_noise!, register_shot_noise!
+export register_channel_thermal_noise!
 
 """
     MNAContext
@@ -1018,6 +1019,20 @@ structure-discovery-time side effect that does not perturb the G/C/b value path.
 """
 @inline register_shot_noise!(ctx::MNAContext, p, n, I; name::Symbol=:D) =
     stamp_noise!(ctx, p, n, SHOT, abs(I), 0.0, name)
+
+"""
+    register_channel_thermal_noise!(ctx, p, n, gm; gamma=2/3, name)
+
+Register the channel thermal noise of a MOSFET between drain (`p`) and source
+(`n`): PSD `4·k·T·γ·gm`, white. This reuses the [`THERMAL`](@ref NoiseKind)
+shape with an *effective* channel conductance `γ·gm` — for the long-channel
+model `γ = 2/3` in saturation (the ngspice level-1/2/3 `(8/3)·k·T·gm` shape).
+The transconductance `gm` is read at the operating point the noise channel is
+built at, so registration does not perturb the G/C/b value path. No-op on
+[`DirectStampContext`](@ref).
+"""
+@inline register_channel_thermal_noise!(ctx::MNAContext, p, n, gm; gamma::Real=2/3, name::Symbol=:M) =
+    stamp_noise!(ctx, p, n, THERMAL, gamma * gm, 0.0, name)
 
 """
     num_noise_sources(ctx::MNAContext) -> Int

--- a/src/mna/devices.jl
+++ b/src/mna/devices.jl
@@ -1639,6 +1639,14 @@ function stamp!(M::SimpleMOSFET, ctx::AnyMNAContext, d::Int, g::Int, s::Int;
     stamp_b!(ctx, d, -Ieq)
     stamp_b!(ctx, s,  Ieq)
 
+    # Channel thermal noise: 4kT·(2/3)·gm between drain and source, registered at
+    # the operating-point transconductance. Skipped in cutoff (gm == 0), where the
+    # channel carries no current and injects no noise. No-op on DirectStampContext,
+    # so the transient hot path is untouched (see doc/noise_analysis_design.md).
+    if gm > 0
+        register_channel_thermal_noise!(ctx, d, s, gm; name=M.name)
+    end
+
     # === Capacitances ===
     # Simple linear caps (not voltage-dependent for this simple model)
     # Cgs between g and s

--- a/src/mna/value_only.jl
+++ b/src/mna/value_only.jl
@@ -152,6 +152,7 @@ register_breakpoints!(::DirectStampContext, ::Any) = nothing
     stamp_noise!(::DirectStampContext, args...)
     register_thermal_noise!(::DirectStampContext, args...; kwargs...)
     register_shot_noise!(::DirectStampContext, args...; kwargs...)
+    register_channel_thermal_noise!(::DirectStampContext, args...; kwargs...)
 
 No-ops. The noise-source channel lives only on `MNAContext` (structure
 discovery); the zero-allocation restamping path carries no noise machinery, so
@@ -160,6 +161,7 @@ transient restamping is untouched (see doc/noise_analysis_design.md).
 @inline stamp_noise!(::DirectStampContext, args...) = nothing
 @inline register_thermal_noise!(::DirectStampContext, args...; kwargs...) = nothing
 @inline register_shot_noise!(::DirectStampContext, args...; kwargs...) = nothing
+@inline register_channel_thermal_noise!(::DirectStampContext, args...; kwargs...) = nothing
 
 """
     get_current_idx(ctx::DirectStampContext, name::Symbol) -> CurrentIndex

--- a/test/mna/noise.jl
+++ b/test/mna/noise.jl
@@ -11,9 +11,10 @@
 using Test
 using Cadnip
 using Cadnip.MNA
-using Cadnip.MNA: MNAContext, get_node!, stamp!, Resistor, Diode, VoltageSource, resolve_index
+using Cadnip.MNA: MNAContext, get_node!, stamp!, Resistor, Diode, SimpleMOSFET, VoltageSource, resolve_index
 using Cadnip.MNA: reset_for_restamping!, num_noise_sources, noise_sources, noise_psd
 using Cadnip.MNA: stamp_noise!, register_thermal_noise!, register_shot_noise!
+using Cadnip.MNA: register_channel_thermal_noise!
 using Cadnip.MNA: solve_dc, MNASpec
 using Cadnip.MNA: THERMAL, SHOT, WHITE, FLICKER, NoiseSource
 using Cadnip.MNA: NodeIndex, GroundIndex
@@ -79,6 +80,56 @@ using Cadnip.SpectreEnvironment
         src = noise_sources(ctx)[1]
         @test src.a ≈ Is                    # |Is·(exp(-38)-1)| ≈ Is
         @test noise_psd(src, 27.0, 1e3) ≈ 2 * Q_ELEMENTARY * Is
+    end
+
+    @testset "MOSFET channel thermal noise registration in saturation" begin
+        # A MOSFET biased in saturation registers channel thermal noise
+        # 4kT·(2/3)·gm between drain and source, with a = (2/3)·gm evaluated at
+        # the operating-point transconductance. Hand-stamping at a known bias is a
+        # low-level stamping-mechanics test.
+        Vth, K = 0.5, 1e-3
+        Vg, Vd = 1.5, 2.0              # Vgs = 1.5 > Vth, Vds = 2.0 > Vgs - Vth = 1.0
+        gm = K * (Vg - Vth)           # square-law saturation gm = K·(Vgs - Vth)
+
+        ctx = MNAContext()
+        d = get_node!(ctx, :d)        # index 1
+        g = get_node!(ctx, :g)        # index 2
+        stamp!(SimpleMOSFET(Vth=Vth, K=K, lambda=0.0, name=:M1), ctx, d, g, 0; x=[Vd, Vg])
+
+        @test num_noise_sources(ctx) == 1
+        src = noise_sources(ctx)[1]
+        @test src.kind === THERMAL
+        @test src.name === :M1
+        @test src.a ≈ (2/3) * gm      # effective channel noise conductance
+        @test resolve_index(ctx, src.p) == d
+        @test resolve_index(ctx, src.n) == 0
+
+        # PSD = 4·k·T·(2/3)·gm, white
+        T = 27.0
+        expected = 4 * K_BOLTZMANN * (T + 273.15) * (2/3) * gm
+        @test noise_psd(src, T, 1e3) ≈ expected
+        @test noise_psd(src, T, 1e9) ≈ expected   # white: no frequency dependence
+    end
+
+    @testset "MOSFET in cutoff registers no channel noise" begin
+        # Vgs <= Vth: the channel carries no current (gm == 0), so there is no
+        # channel thermal noise to register.
+        ctx = MNAContext()
+        d = get_node!(ctx, :d)
+        g = get_node!(ctx, :g)
+        stamp!(SimpleMOSFET(Vth=0.5, K=1e-3, name=:M1), ctx, d, g, 0; x=[1.0, 0.2])
+        @test num_noise_sources(ctx) == 0
+    end
+
+    @testset "register_channel_thermal_noise! honors gamma" begin
+        # The effective noise conductance scales with the excess-noise factor γ.
+        ctx = MNAContext()
+        d = get_node!(ctx, :d)
+        s = get_node!(ctx, :s)
+        register_channel_thermal_noise!(ctx, d, s, 2e-3; gamma=1.0, name=:Mg)
+        src = noise_sources(ctx)[1]
+        @test src.kind === THERMAL
+        @test src.a ≈ 2e-3            # γ = 1 ⇒ a = gm
     end
 
     @testset "multiple sources accumulate; rebuild does not duplicate" begin


### PR DESCRIPTION
## Summary

Continues the noise-analysis port (`doc/noise_analysis_design.md`). After N0's resistor thermal + diode shot sources, this adds the next per-device N1 source: **MOSFET channel thermal noise**.

The `SimpleMOSFET` stamp now registers channel thermal noise `S = 4kT·(2/3)·gm` (drain→source) at the operating-point transconductance, via a new `register_channel_thermal_noise!` helper. It reuses the existing `THERMAL` `NoiseKind` with an *effective* channel noise conductance `γ·gm` — `γ = 2/3` in saturation, matching the ngspice level-1/2/3 `(8/3)·k·T·gm` shape. Cutoff (`gm == 0`) registers nothing.

## Why it's zero-cost on the hot path

Same contract as the existing noise sources:

- The helper is a **structure-discovery-time side effect** on `MNAContext` only, and a **no-op on `DirectStampContext`**, so the zero-allocation transient restamping path is untouched.
- It does **not** touch G/C/b — `gm` is read at the operating point the noise channel is built at — so DC/transient numerics are byte-identical.

## Changes

- `src/mna/context.jl` — `register_channel_thermal_noise!(ctx, p, n, gm; gamma=2/3, name)` helper + export.
- `src/mna/value_only.jl` — matching `DirectStampContext` no-op.
- `src/mna/devices.jl` — `SimpleMOSFET` stamp registers channel thermal noise when `gm > 0`.
- `test/mna/noise.jl` — first test coverage for `SimpleMOSFET`: saturation registration (`a = (2/3)·gm`, correct nodes, white PSD), cutoff no-op, and `gamma` scaling.
- `doc/noise_analysis_design.md`, `doc/scratchpad.md` — record the increment.

## Testing

- `test/mna/noise.jl` — 42/42 pass.
- `test/mna/core.jl` — 356/356 pass (no regression from the `context.jl`/`value_only.jl`/`devices.jl` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnYycPic6owZJuagBYuTZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnYycPic6owZJuagBYuTZC)_